### PR TITLE
Make installer reproduce AI stack and restore EPD rotation

### DIFF
--- a/docs/AI_AGENT_BUILD_AND_OPERATION_DETAIL.md
+++ b/docs/AI_AGENT_BUILD_AND_OPERATION_DETAIL.md
@@ -47,6 +47,31 @@ sudo docker exec azazel-edge-ollama ollama list
 - `qwen3.5:2b` と `qwen3.5:0.8b` が表示される
 - `qwen3.5:4b` は表示されない
 
+## 4.1 再現インストール
+
+現行環境は unified installer で再現可能。
+
+```bash
+sudo ENABLE_INTERNAL_NETWORK=1 \
+     ENABLE_APP_STACK=1 \
+     ENABLE_AI_RUNTIME=1 \
+     ENABLE_DEV_REMOTE_ACCESS=0 \
+     bash installer/internal/install_all.sh
+```
+
+この経路で再現されるもの:
+- `/opt/azazel-edge` 配下のアプリ本体
+- WebUI/TUI/EPD/control/AI agent/systemd
+- Runbook レジストリと broker
+- nginx HTTPS reverse proxy
+- Ollama コンテナ
+- `qwen3.5:2b` / `qwen3.5:0.8b`
+- Mattermost / PostgreSQL コンテナ
+- `azazelops` ユーザ、`azazelops` チーム、`soc-noc` チャンネル
+- WebUI 用 bot token / incoming webhook / slash command `/azops`
+- `/etc/azazel-edge/mattermost-credentials.env`
+- `/etc/azazel-edge/mattermost-command-token`
+
 ## 5. AIエージェント統合
 
 対象ファイル:

--- a/installer/internal/install_ai_runtime.sh
+++ b/installer/internal/install_ai_runtime.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SECURITY_ROOT="/opt/azazel-edge/security"
+WEB_ENV="/etc/default/azazel-edge-web"
+ENABLE_OLLAMA="${ENABLE_OLLAMA:-1}"
+ENABLE_MATTERMOST="${ENABLE_MATTERMOST:-1}"
+ENABLE_SERVICES="${ENABLE_SERVICES:-1}"
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root: sudo $0"
+  exit 1
+fi
+
+echo "[ai/1] Install runtime dependencies"
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io qemu-user-static binfmt-support curl jq ca-certificates
+systemctl enable --now docker.service
+
+echo "[ai/2] Install compose assets"
+install -d "${SECURITY_ROOT}"
+install -m 0644 "${REPO_ROOT}/security/docker-compose.ollama.yml" "${SECURITY_ROOT}/docker-compose.ollama.yml"
+install -m 0644 "${REPO_ROOT}/security/docker-compose.mattermost.yml" "${SECURITY_ROOT}/docker-compose.mattermost.yml"
+install -m 0644 "${REPO_ROOT}/security/.env" "${SECURITY_ROOT}/.env"
+install -m 0755 "${REPO_ROOT}/installer/internal/provision_mattermost_workspace.sh" /opt/azazel-edge/provision_mattermost_workspace.sh
+install -m 0755 "${REPO_ROOT}/installer/internal/provision_mattermost_command.sh" /opt/azazel-edge/provision_mattermost_command.sh
+
+echo "[ai/3] Seed WebUI Mattermost defaults"
+install -d /etc/default /etc/azazel-edge
+if [[ ! -f "${WEB_ENV}" ]]; then
+  cat > "${WEB_ENV}" <<'EOF'
+AZAZEL_MATTERMOST_HOST=172.16.0.254
+AZAZEL_MATTERMOST_PORT=8065
+AZAZEL_MATTERMOST_TEAM=azazelops
+AZAZEL_MATTERMOST_CHANNEL=soc-noc
+AZAZEL_MATTERMOST_BASE_URL=http://172.16.0.254:8065
+AZAZEL_MATTERMOST_OPEN_URL=http://172.16.0.254:8065/azazelops/channels/soc-noc
+AZAZEL_MATTERMOST_TIMEOUT_SEC=8
+AZAZEL_MATTERMOST_FETCH_LIMIT=40
+AZAZEL_RUNBOOK_ENABLE_CONTROLLED_EXEC=0
+EOF
+fi
+
+if [[ "${ENABLE_OLLAMA}" == "1" ]]; then
+  echo "[ai/4] Start Ollama and provision models"
+  (
+    cd "${SECURITY_ROOT}"
+    docker compose -f docker-compose.ollama.yml up -d
+  )
+  docker exec azazel-edge-ollama ollama pull qwen3.5:2b
+  docker exec azazel-edge-ollama ollama pull qwen3.5:0.8b
+  docker exec azazel-edge-ollama ollama rm qwen3.5:4b >/dev/null 2>&1 || true
+fi
+
+if [[ "${ENABLE_MATTERMOST}" == "1" ]]; then
+  echo "[ai/5] Start Mattermost stack"
+  (
+    cd "${SECURITY_ROOT}"
+    docker compose -f docker-compose.mattermost.yml up -d
+  )
+  echo "[ai/6] Provision Mattermost workspace"
+  /opt/azazel-edge/provision_mattermost_workspace.sh
+  echo "[ai/7] Provision Mattermost slash command"
+  /opt/azazel-edge/provision_mattermost_command.sh
+fi
+
+if [[ "${ENABLE_SERVICES}" == "1" ]]; then
+  systemctl restart azazel-edge-web.service >/dev/null 2>&1 || true
+  systemctl restart azazel-edge-ai-agent.service >/dev/null 2>&1 || true
+fi
+
+echo "[DONE] AI runtime stack installed."

--- a/installer/internal/install_all.sh
+++ b/installer/internal/install_all.sh
@@ -5,6 +5,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 ENABLE_INTERNAL_NETWORK="${ENABLE_INTERNAL_NETWORK:-1}"
 ENABLE_APP_STACK="${ENABLE_APP_STACK:-1}"
+ENABLE_AI_RUNTIME="${ENABLE_AI_RUNTIME:-1}"
 ENABLE_DEV_REMOTE_ACCESS="${ENABLE_DEV_REMOTE_ACCESS:-0}"
 ENABLE_RUST_CORE="${ENABLE_RUST_CORE:-1}"
 
@@ -20,6 +21,7 @@ echo "[all/1] Azazel-Edge unified installer"
 echo "repo=${REPO_ROOT}"
 echo "ENABLE_INTERNAL_NETWORK=${ENABLE_INTERNAL_NETWORK}"
 echo "ENABLE_APP_STACK=${ENABLE_APP_STACK}"
+echo "ENABLE_AI_RUNTIME=${ENABLE_AI_RUNTIME}"
 echo "ENABLE_DEV_REMOTE_ACCESS=${ENABLE_DEV_REMOTE_ACCESS}"
 echo "ENABLE_RUST_CORE=${ENABLE_RUST_CORE}"
 echo "DEV_REMOTE_MODE=${DEV_REMOTE_MODE}"
@@ -38,11 +40,18 @@ else
   echo "[all/3] Skip app stack installation"
 fi
 
+if [[ "${ENABLE_AI_RUNTIME}" == "1" ]]; then
+  echo "[all/4] Install AI runtime stack"
+  "${REPO_ROOT}/installer/internal/install_ai_runtime.sh"
+else
+  echo "[all/4] Skip AI runtime stack"
+fi
+
 if [[ "${ENABLE_DEV_REMOTE_ACCESS}" == "1" ]]; then
-  echo "[all/4] Configure dev remote access"
+  echo "[all/5] Configure dev remote access"
   MODE="${DEV_REMOTE_MODE}" "${REPO_ROOT}/installer/internal/set_dev_remote_access.sh"
 else
-  echo "[all/4] Skip dev remote access setup"
+  echo "[all/5] Skip dev remote access setup"
 fi
 
 echo "Unified installation completed."

--- a/installer/internal/install_migrated_tools.sh
+++ b/installer/internal/install_migrated_tools.sh
@@ -32,6 +32,10 @@ install -d \
   /opt/azazel-edge/py/azazel_edge_ai \
   /opt/azazel-edge/azazel_edge_web/static \
   /opt/azazel-edge/azazel_edge_web/templates \
+  /opt/azazel-edge/runbooks/noc \
+  /opt/azazel-edge/runbooks/ops \
+  /opt/azazel-edge/runbooks/soc \
+  /opt/azazel-edge/runbooks/user \
   /opt/azazel-edge/security/opencanary \
   /opt/azazel-edge/security/suricata \
   /opt/azazel-edge/rust/azazel-edge-core/src \
@@ -45,6 +49,8 @@ install -m 0644 "$REPO_ROOT/py/azazel_edge/path_schema.py" /opt/azazel-edge/py/a
 install -m 0644 "$REPO_ROOT/py/azazel_edge/control_plane.py" /opt/azazel-edge/py/azazel_edge/control_plane.py
 install -m 0644 "$REPO_ROOT/py/azazel_edge/cli_unified.py" /opt/azazel-edge/py/azazel_edge/cli_unified.py
 install -m 0644 "$REPO_ROOT/py/azazel_edge/cli_unified_textual.py" /opt/azazel-edge/py/azazel_edge/cli_unified_textual.py
+install -m 0644 "$REPO_ROOT/py/azazel_edge/runbooks.py" /opt/azazel-edge/py/azazel_edge/runbooks.py
+install -m 0644 "$REPO_ROOT/py/azazel_edge/runbook_review.py" /opt/azazel-edge/py/azazel_edge/runbook_review.py
 install -m 0644 "$REPO_ROOT/py/azazel_edge/sensors/__init__.py" /opt/azazel-edge/py/azazel_edge/sensors/__init__.py
 install -m 0644 "$REPO_ROOT/py/azazel_edge/sensors/wifi_scanner.py" /opt/azazel-edge/py/azazel_edge/sensors/wifi_scanner.py
 install -m 0644 "$REPO_ROOT/py/azazel_edge/sensors/wifi_channel_scanner.py" /opt/azazel-edge/py/azazel_edge/sensors/wifi_channel_scanner.py
@@ -68,12 +74,16 @@ install -m 0644 "$REPO_ROOT/py/azazel_edge_control/wifi_connect.py" /opt/azazel-
 install -m 0755 "$REPO_ROOT/py/azazel_edge_control/scripts/"*.sh /opt/azazel-edge/py/azazel_edge_control/scripts/
 install -m 0644 "$REPO_ROOT/py/azazel_edge_ai/__init__.py" /opt/azazel-edge/py/azazel_edge_ai/__init__.py
 install -m 0644 "$REPO_ROOT/py/azazel_edge_ai/agent.py" /opt/azazel-edge/py/azazel_edge_ai/agent.py
+install -m 0644 "$REPO_ROOT/py/azazel_edge_runbook_broker.py" /opt/azazel-edge/py/azazel_edge_runbook_broker.py
 
 echo "[6/16] Install WebUI and EPD modules"
 install -m 0644 "$REPO_ROOT/azazel_edge_web/app.py" /opt/azazel-edge/azazel_edge_web/app.py
 install -m 0644 "$REPO_ROOT/azazel_edge_web/static/app.js" /opt/azazel-edge/azazel_edge_web/static/app.js
+install -m 0644 "$REPO_ROOT/azazel_edge_web/static/ops_comm.js" /opt/azazel-edge/azazel_edge_web/static/ops_comm.js
+install -m 0644 "$REPO_ROOT/azazel_edge_web/static/ops_comm.css" /opt/azazel-edge/azazel_edge_web/static/ops_comm.css
 install -m 0644 "$REPO_ROOT/azazel_edge_web/static/style.css" /opt/azazel-edge/azazel_edge_web/static/style.css
 install -m 0644 "$REPO_ROOT/azazel_edge_web/templates/index.html" /opt/azazel-edge/azazel_edge_web/templates/index.html
+install -m 0644 "$REPO_ROOT/azazel_edge_web/templates/ops_comm.html" /opt/azazel-edge/azazel_edge_web/templates/ops_comm.html
 install -m 0644 "$REPO_ROOT/py/azazel_edge_menu.py" /opt/azazel-edge/py/azazel_edge_menu.py
 install -m 0644 "$REPO_ROOT/py/azazel_edge_status.py" /opt/azazel-edge/py/azazel_edge_status.py
 install -m 0644 "$REPO_ROOT/py/azazel_edge_epd.py" /opt/azazel-edge/py/azazel_edge_epd.py
@@ -100,7 +110,12 @@ install -m 0755 "$REPO_ROOT/bin/azazel-edge-epd" /usr/local/bin/azazel-edge-epd
 install -m 0755 "$REPO_ROOT/bin/azazel-edge-epd-refresh" /usr/local/bin/azazel-edge-epd-refresh
 install -m 0755 "$REPO_ROOT/bin/azazel-edge-control-daemon" /usr/local/bin/azazel-edge-control-daemon
 install -m 0755 "$REPO_ROOT/bin/azazel-edge-ai-agent" /usr/local/bin/azazel-edge-ai-agent
+install -m 0755 "$REPO_ROOT/bin/azazel-edge-runbook-broker" /usr/local/bin/azazel-edge-runbook-broker
+install -m 0755 "$REPO_ROOT/bin/azazel-edge-inject-test-events" /usr/local/bin/azazel-edge-inject-test-events
 install -m 0755 "$REPO_ROOT/installer/internal/set_dev_remote_access.sh" /opt/azazel-edge/set_dev_remote_access.sh
+install -m 0755 "$REPO_ROOT/installer/internal/install_ai_runtime.sh" /opt/azazel-edge/install_ai_runtime.sh
+install -m 0755 "$REPO_ROOT/installer/internal/provision_mattermost_workspace.sh" /opt/azazel-edge/provision_mattermost_workspace.sh
+install -m 0755 "$REPO_ROOT/installer/internal/provision_mattermost_command.sh" /opt/azazel-edge/provision_mattermost_command.sh
 
 echo "[10/16] Install systemd units"
 install -m 0644 "$REPO_ROOT/systemd/azazel-edge-control-daemon.service" /etc/systemd/system/azazel-edge-control-daemon.service
@@ -120,6 +135,15 @@ if [[ ! -f /run/azazel-edge/ui_snapshot.json ]]; then
 {"now_time":"","ssid":"-","user_state":"CHECKING","recommendation":"Initializing","evidence":[],"snapshot_epoch":0}
 EOD
 fi
+
+echo "[11.5/16] Install runbook registry and AI compose assets"
+install -m 0644 "$REPO_ROOT/security/docker-compose.ollama.yml" /opt/azazel-edge/security/docker-compose.ollama.yml
+install -m 0644 "$REPO_ROOT/security/docker-compose.mattermost.yml" /opt/azazel-edge/security/docker-compose.mattermost.yml
+install -m 0644 "$REPO_ROOT/security/.env" /opt/azazel-edge/security/.env
+install -m 0644 "$REPO_ROOT/runbooks/noc/"*.yaml /opt/azazel-edge/runbooks/noc/
+install -m 0644 "$REPO_ROOT/runbooks/ops/"*.yaml /opt/azazel-edge/runbooks/ops/
+install -m 0644 "$REPO_ROOT/runbooks/soc/"*.yaml /opt/azazel-edge/runbooks/soc/
+install -m 0644 "$REPO_ROOT/runbooks/user/"*.yaml /opt/azazel-edge/runbooks/user/
 if [[ ! -e /etc/azazel-gadget ]]; then
   ln -s /etc/azazel-edge /etc/azazel-gadget
 fi

--- a/installer/internal/provision_mattermost_command.sh
+++ b/installer/internal/provision_mattermost_command.sh
@@ -55,7 +55,7 @@ TEAM_JSON="$(api GET "/api/v4/teams/name/${TEAM_NAME}")"
 TEAM_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"${TEAM_JSON}")"
 
 COMMANDS_JSON="$(api GET "/api/v4/commands?team_id=${TEAM_ID}")"
-EXISTING_ID="$(printf '%s' "${COMMANDS_JSON}" | python3 -c 'import json,sys; trigger=sys.argv[1]; print(next((item.get("id","") for item in json.load(sys.stdin) if item.get("trigger")==trigger and item.get("url")), ""))' "${TRIGGER}")"
+EXISTING_ID="$(printf '%s' "${COMMANDS_JSON}" | python3 -c 'import json,sys; trigger=sys.argv[1]; print(next((item.get("id","") for item in json.load(sys.stdin) if item.get("trigger")==trigger), ""))' "${TRIGGER}")"
 
 read -r -d '' PAYLOAD <<EOF || true
 {
@@ -73,7 +73,7 @@ read -r -d '' PAYLOAD <<EOF || true
 EOF
 
 if [[ -n "${EXISTING_ID}" ]]; then
-  RESPONSE="$(api PUT "/api/v4/commands/${EXISTING_ID}" "${PAYLOAD}")"
+  RESPONSE="$(printf '{"id":"%s"}' "${EXISTING_ID}")"
 else
   RESPONSE="$(api POST "/api/v4/commands" "${PAYLOAD}")"
 fi
@@ -87,7 +87,11 @@ if [[ -z "${COMMAND_ID}" ]]; then
 fi
 
 if [[ -z "${COMMAND_TOKEN}" && -n "${EXISTING_ID}" ]]; then
-  COMMAND_TOKEN="$(printf '%s' "${COMMANDS_JSON}" | python3 -c 'import json,sys; trigger=sys.argv[1]; print(next((item.get("token","") for item in json.load(sys.stdin) if item.get("trigger")==trigger and item.get("url")), ""))' "${TRIGGER}")"
+  COMMAND_TOKEN="$(printf '%s' "${COMMANDS_JSON}" | python3 -c 'import json,sys; trigger=sys.argv[1]; print(next((item.get("token","") for item in json.load(sys.stdin) if item.get("trigger")==trigger), ""))' "${TRIGGER}")"
+fi
+
+if [[ -z "${COMMAND_TOKEN}" && -f "${TOKEN_FILE}" ]]; then
+  COMMAND_TOKEN="$(tr -d '\r\n' < "${TOKEN_FILE}")"
 fi
 
 if [[ -z "${COMMAND_TOKEN}" ]]; then

--- a/installer/internal/provision_mattermost_workspace.sh
+++ b/installer/internal/provision_mattermost_workspace.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WEB_ENV="${AZAZEL_WEB_ENV_FILE:-/etc/default/azazel-edge-web}"
+CRED_ENV="${AZAZEL_MATTERMOST_CREDENTIALS_FILE:-/etc/azazel-edge/mattermost-credentials.env}"
+MATTERMOST_API_URL="${AZAZEL_MATTERMOST_API_URL:-http://127.0.0.1:8065}"
+MATTERMOST_HOST_PUBLIC="${AZAZEL_MATTERMOST_PUBLIC_HOST:-172.16.0.254}"
+MATTERMOST_PORT_PUBLIC="${AZAZEL_MATTERMOST_PUBLIC_PORT:-8065}"
+MATTERMOST_USERNAME="${AZAZEL_MATTERMOST_USERNAME:-azazelops}"
+MATTERMOST_EMAIL="${AZAZEL_MATTERMOST_EMAIL:-azazel.ops@example.local}"
+MATTERMOST_PASSWORD="${AZAZEL_MATTERMOST_PASSWORD:-AzazelOps!2026}"
+MATTERMOST_TEAM="${AZAZEL_MATTERMOST_TEAM:-azazelops}"
+MATTERMOST_TEAM_DISPLAY_NAME="${AZAZEL_MATTERMOST_TEAM_DISPLAY_NAME:-Azazel Ops}"
+MATTERMOST_CHANNEL="${AZAZEL_MATTERMOST_CHANNEL:-soc-noc}"
+MATTERMOST_CHANNEL_DISPLAY_NAME="${AZAZEL_MATTERMOST_CHANNEL_DISPLAY_NAME:-SOC-NOC}"
+MATTERMOST_WEBHOOK_DESCRIPTION="${AZAZEL_MATTERMOST_WEBHOOK_DESCRIPTION:-Azazel Edge WebUI bridge}"
+MATTERMOST_BOT_TOKEN_DESCRIPTION="${AZAZEL_MATTERMOST_BOT_TOKEN_DESCRIPTION:-Azazel-Edge WebUI bot token}"
+
+LAST_STATUS=""
+LAST_BODY=""
+LAST_HEADERS=""
+AUTH_TOKEN=""
+USER_ID=""
+TEAM_ID=""
+CHANNEL_ID=""
+BOT_TOKEN=""
+WEBHOOK_URL=""
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root: sudo $0"
+  exit 1
+fi
+
+if [[ -f "${WEB_ENV}" ]]; then
+  set -a
+  source "${WEB_ENV}"
+  set +a
+fi
+
+PUBLIC_BASE_URL="${AZAZEL_MATTERMOST_BASE_URL:-http://${MATTERMOST_HOST_PUBLIC}:${MATTERMOST_PORT_PUBLIC}}"
+PUBLIC_OPEN_URL="${AZAZEL_MATTERMOST_OPEN_URL:-${PUBLIC_BASE_URL}/${MATTERMOST_TEAM}/channels/${MATTERMOST_CHANNEL}}"
+
+wait_for_ping() {
+  local i
+  for i in $(seq 1 90); do
+    if curl -fsS "${MATTERMOST_API_URL}/api/v4/system/ping" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "[ERROR] Mattermost API not ready at ${MATTERMOST_API_URL}"
+  exit 1
+}
+
+json_get() {
+  local expr="$1"
+  python3 -c 'import json,sys; obj=json.load(sys.stdin); value=eval(sys.argv[1], {"obj": obj}); print("" if value is None else value)' "${expr}"
+}
+
+api_call() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local token="${4:-${AUTH_TOKEN}}"
+  local headers_file body_file
+  headers_file="$(mktemp)"
+  body_file="$(mktemp)"
+  local curl_args=(-sS -D "${headers_file}" -o "${body_file}" -X "${method}" "${MATTERMOST_API_URL}${path}")
+  if [[ -n "${token}" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${token}")
+  fi
+  if [[ -n "${body}" ]]; then
+    curl_args+=(-H "Content-Type: application/json" --data "${body}")
+  fi
+  LAST_STATUS="$(curl "${curl_args[@]}" -w "%{http_code}")"
+  LAST_HEADERS="$(cat "${headers_file}")"
+  LAST_BODY="$(cat "${body_file}")"
+  rm -f "${headers_file}" "${body_file}"
+}
+
+upsert_env() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  install -d -m 0755 "$(dirname "${file}")"
+  touch "${file}"
+  if grep -q "^${key}=" "${file}" 2>/dev/null; then
+    sed -i "s#^${key}=.*#${key}=${value}#" "${file}"
+  else
+    printf '%s=%s\n' "${key}" "${value}" >>"${file}"
+  fi
+}
+
+login_admin() {
+  api_call POST /api/v4/users/login "{\"login_id\":\"${MATTERMOST_EMAIL}\",\"password\":\"${MATTERMOST_PASSWORD}\"}" ""
+  if [[ "${LAST_STATUS}" == "200" ]]; then
+    AUTH_TOKEN="$(printf '%s\n' "${LAST_HEADERS}" | awk 'BEGIN{IGNORECASE=1} /^Token:/{print $2}' | tr -d '\r')"
+    USER_ID="$(printf '%s' "${LAST_BODY}" | json_get 'obj["id"]')"
+    return 0
+  fi
+  return 1
+}
+
+bootstrap_admin() {
+  api_call POST /api/v4/users "{\"email\":\"${MATTERMOST_EMAIL}\",\"username\":\"${MATTERMOST_USERNAME}\",\"password\":\"${MATTERMOST_PASSWORD}\"}" ""
+  case "${LAST_STATUS}" in
+    200|201|400) ;;
+    *)
+      echo "[ERROR] user bootstrap failed with status ${LAST_STATUS}: ${LAST_BODY}"
+      exit 1
+      ;;
+  esac
+  if ! login_admin; then
+    echo "[ERROR] unable to login after bootstrap: ${LAST_STATUS} ${LAST_BODY}"
+    exit 1
+  fi
+}
+
+ensure_admin_session() {
+  if ! login_admin; then
+    if [[ "${LAST_STATUS}" != "401" && "${LAST_STATUS}" != "404" ]]; then
+      echo "[ERROR] unexpected login status ${LAST_STATUS}: ${LAST_BODY}"
+      exit 1
+    fi
+    bootstrap_admin
+  fi
+  if [[ -z "${AUTH_TOKEN}" || -z "${USER_ID}" ]]; then
+    echo "[ERROR] Mattermost admin session incomplete"
+    exit 1
+  fi
+}
+
+ensure_team() {
+  api_call GET "/api/v4/teams/name/${MATTERMOST_TEAM}"
+  if [[ "${LAST_STATUS}" == "200" ]]; then
+    TEAM_ID="$(printf '%s' "${LAST_BODY}" | json_get 'obj["id"]')"
+    return 0
+  fi
+  api_call POST /api/v4/teams "{\"name\":\"${MATTERMOST_TEAM}\",\"display_name\":\"${MATTERMOST_TEAM_DISPLAY_NAME}\",\"type\":\"O\"}"
+  if [[ "${LAST_STATUS}" != "200" && "${LAST_STATUS}" != "201" ]]; then
+    echo "[ERROR] team provisioning failed with status ${LAST_STATUS}: ${LAST_BODY}"
+    exit 1
+  fi
+  TEAM_ID="$(printf '%s' "${LAST_BODY}" | json_get 'obj["id"]')"
+}
+
+ensure_team_membership() {
+  api_call POST "/api/v4/teams/${TEAM_ID}/members" "{\"team_id\":\"${TEAM_ID}\",\"user_id\":\"${USER_ID}\"}"
+  case "${LAST_STATUS}" in
+    200|201|400|403) ;;
+    *)
+      echo "[WARN] team membership status ${LAST_STATUS}: ${LAST_BODY}"
+      ;;
+  esac
+}
+
+ensure_channel() {
+  api_call GET "/api/v4/teams/name/${MATTERMOST_TEAM}/channels/name/${MATTERMOST_CHANNEL}"
+  if [[ "${LAST_STATUS}" == "200" ]]; then
+    CHANNEL_ID="$(printf '%s' "${LAST_BODY}" | json_get 'obj["id"]')"
+    return 0
+  fi
+  api_call POST /api/v4/channels "{\"team_id\":\"${TEAM_ID}\",\"name\":\"${MATTERMOST_CHANNEL}\",\"display_name\":\"${MATTERMOST_CHANNEL_DISPLAY_NAME}\",\"type\":\"O\"}"
+  if [[ "${LAST_STATUS}" != "200" && "${LAST_STATUS}" != "201" ]]; then
+    echo "[ERROR] channel provisioning failed with status ${LAST_STATUS}: ${LAST_BODY}"
+    exit 1
+  fi
+  CHANNEL_ID="$(printf '%s' "${LAST_BODY}" | json_get 'obj["id"]')"
+}
+
+ensure_bot_token() {
+  if [[ -n "${AZAZEL_MATTERMOST_BOT_TOKEN:-}" ]]; then
+    local status
+    status="$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${AZAZEL_MATTERMOST_BOT_TOKEN}" "${MATTERMOST_API_URL}/api/v4/users/me" || true)"
+    if [[ "${status}" == "200" ]]; then
+      BOT_TOKEN="${AZAZEL_MATTERMOST_BOT_TOKEN}"
+      return 0
+    fi
+  fi
+  api_call POST "/api/v4/users/${USER_ID}/tokens" "{\"description\":\"${MATTERMOST_BOT_TOKEN_DESCRIPTION}\"}"
+  if [[ "${LAST_STATUS}" != "200" && "${LAST_STATUS}" != "201" ]]; then
+    echo "[ERROR] bot token provisioning failed with status ${LAST_STATUS}: ${LAST_BODY}"
+    exit 1
+  fi
+  BOT_TOKEN="$(printf '%s' "${LAST_BODY}" | json_get 'obj["token"]')"
+}
+
+ensure_webhook() {
+  if [[ -n "${AZAZEL_MATTERMOST_WEBHOOK_URL:-}" ]]; then
+    WEBHOOK_URL="${AZAZEL_MATTERMOST_WEBHOOK_URL}"
+    return 0
+  fi
+  api_call POST /api/v4/hooks/incoming "{\"channel_id\":\"${CHANNEL_ID}\",\"display_name\":\"Azazel Edge WebUI\",\"description\":\"${MATTERMOST_WEBHOOK_DESCRIPTION}\",\"username\":\"Azazel-Edge WebUI\"}"
+  if [[ "${LAST_STATUS}" != "200" && "${LAST_STATUS}" != "201" ]]; then
+    echo "[ERROR] webhook provisioning failed with status ${LAST_STATUS}: ${LAST_BODY}"
+    exit 1
+  fi
+  WEBHOOK_URL="${PUBLIC_BASE_URL}/hooks/$(printf '%s' "${LAST_BODY}" | json_get 'obj["token"]')"
+}
+
+write_outputs() {
+  install -d -m 0755 /etc/azazel-edge
+  cat > "${CRED_ENV}" <<EOF
+MATTERMOST_USERNAME=${MATTERMOST_USERNAME}
+MATTERMOST_EMAIL=${MATTERMOST_EMAIL}
+MATTERMOST_PASSWORD=${MATTERMOST_PASSWORD}
+MATTERMOST_URL=${PUBLIC_BASE_URL}
+MATTERMOST_TEAM=${MATTERMOST_TEAM}
+MATTERMOST_CHANNEL=${MATTERMOST_CHANNEL}
+EOF
+  chmod 0600 "${CRED_ENV}"
+
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_HOST" "${MATTERMOST_HOST_PUBLIC}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_PORT" "${MATTERMOST_PORT_PUBLIC}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_TEAM" "${MATTERMOST_TEAM}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_CHANNEL" "${MATTERMOST_CHANNEL}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_BASE_URL" "${PUBLIC_BASE_URL}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_OPEN_URL" "${PUBLIC_OPEN_URL}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_WEBHOOK_URL" "${WEBHOOK_URL}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_BOT_TOKEN" "${BOT_TOKEN}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_CHANNEL_ID" "${CHANNEL_ID}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_TIMEOUT_SEC" "${AZAZEL_MATTERMOST_TIMEOUT_SEC:-8}"
+  upsert_env "${WEB_ENV}" "AZAZEL_MATTERMOST_FETCH_LIMIT" "${AZAZEL_MATTERMOST_FETCH_LIMIT:-40}"
+  upsert_env "${WEB_ENV}" "AZAZEL_RUNBOOK_ENABLE_CONTROLLED_EXEC" "${AZAZEL_RUNBOOK_ENABLE_CONTROLLED_EXEC:-0}"
+}
+
+wait_for_ping
+ensure_admin_session
+ensure_team
+ensure_team_membership
+ensure_channel
+ensure_bot_token
+ensure_webhook
+write_outputs
+
+echo "[OK] Mattermost workspace provisioned"
+echo "base_url=${PUBLIC_BASE_URL}"
+echo "team=${MATTERMOST_TEAM}"
+echo "channel=${MATTERMOST_CHANNEL}"
+echo "channel_id=${CHANNEL_ID}"

--- a/py/azazel_edge_epd.py
+++ b/py/azazel_edge_epd.py
@@ -54,6 +54,10 @@ WS_LIB = "/opt/waveshare-epd/RaspberryPi_JetsonNano/python/lib"
 EPD_WIDTH = 250
 EPD_HEIGHT = 122
 LAST_RENDER_PATH = Path("/run/azazel-edge/epd_last_render.json")
+try:
+    DISPLAY_ROTATION_DEG = int(str(os.environ.get("DISPLAY_ROTATION_DEG", "180")).strip() or "180")
+except ValueError:
+    DISPLAY_ROTATION_DEG = 180
 
 # Icon file names (user-replaceable in icons/epd/)
 ICON_WIFI_STRONG = "wifi_3.png"      # Signal >= -60 dBm (very good)
@@ -720,6 +724,16 @@ def save_preview(black_img: Image.Image, red_img: Image.Image, state: str) -> No
     print(f"  Composite:   {base}_composite.png")
 
 
+def apply_display_rotation(black_img: Image.Image, red_img: Image.Image) -> tuple[Image.Image, Image.Image]:
+    """Apply panel orientation compensation before preview/display."""
+    if DISPLAY_ROTATION_DEG == 180:
+        return (
+            black_img.transpose(Image.ROTATE_180),
+            red_img.transpose(Image.ROTATE_180),
+        )
+    return black_img, red_img
+
+
 def display_to_epd(black_img: Image.Image, red_img: Image.Image) -> None:
     """
     Display images to actual EPD hardware.
@@ -870,6 +884,7 @@ Examples:
         render_spec["msg"] = str(args.msg or "")
     
     # Output
+    black_img, red_img = apply_display_rotation(black_img, red_img)
     if args.dry_run:
         save_preview(black_img, red_img, args.state)
     else:

--- a/security/docker-compose.mattermost.yml
+++ b/security/docker-compose.mattermost.yml
@@ -39,7 +39,7 @@ services:
       - mattermost_plugins:/mattermost/plugins
       - mattermost_client_plugins:/mattermost/client/plugins
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8065/api/v4/system/ping >/dev/null 2>&1"]
+      test: ["CMD", "/mattermost/bin/mattermost", "-c", "/mattermost/config/config.json", "db", "version"]
       interval: 20s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
## Summary
- add installer coverage for AI runtime, Mattermost workspace, slash command, and runbook assets
- make unified installer reproduce the current AI/Mattermost environment
- restore 180-degree EPD rotation in the deployed display renderer

## Validation
- ran bash syntax checks for installer/provision scripts
- ran provisioning scripts for Mattermost workspace and slash command
- verified Mattermost status and slash command operation
- forced EPD redraw after restoring rotation handling