### PR TITLE
Harden demo review readiness

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -3098,6 +3098,47 @@ def api_demo_overlay():
     return jsonify({"ok": True, "overlay": payload, "active": bool(payload.get("active"))}), 200
 
 
+@app.route("/api/demo/capabilities", methods=["GET"])
+def api_demo_capabilities():
+    if not verify_token():
+        return jsonify({"ok": False, "error": "Unauthorized"}), 403
+    try:
+        from azazel_edge.demo import DemoScenarioRunner
+    except Exception as exc:
+        return jsonify({"ok": False, "error": f"demo_capabilities_unavailable:{exc}"}), 500
+    return jsonify(
+        {
+            "ok": True,
+            "execution_mode": "deterministic_replay",
+            "ai_used_in_core_path": False,
+            "live_telemetry_required": False,
+            "local_only_in_core_path": True,
+            "boundary": DemoScenarioRunner.capability_boundary(),
+        }
+    ), 200
+
+
+@app.route("/api/demo/explanation/latest", methods=["GET"])
+def api_demo_explanation_latest():
+    if not verify_token():
+        return jsonify({"ok": False, "error": "Unauthorized"}), 403
+    payload = read_demo_overlay()
+    if not payload.get("active"):
+        return jsonify({"ok": False, "error": "no_active_demo_overlay"}), 404
+    raw = payload.get("raw_result") if isinstance(payload.get("raw_result"), dict) else {}
+    explanation = raw.get("explanation") if isinstance(raw.get("explanation"), dict) else {}
+    if not explanation:
+        return jsonify({"ok": False, "error": "no_explanation_available"}), 404
+    return jsonify(
+        {
+            "ok": True,
+            "scenario_id": payload.get("scenario_id"),
+            "action": payload.get("action"),
+            "explanation": explanation,
+        }
+    ), 200
+
+
 @app.route("/api/demo/overlay/clear", methods=["POST"])
 def api_demo_overlay_clear():
     if not verify_token():

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -61,10 +61,24 @@ function resetDemoOverlayPresentation() {
     updateElement('demoStatusBadge', tr('dashboard.demo_ready', 'READY'));
     const badge = document.getElementById('demoStatusBadge');
     if (badge) badge.className = 'assistant-status status-neutral';
+    updateElement('demoScenarioId', '-');
+    updateElement('demoEventCount', '-');
+    updateElement('demoExecutionMode', 'deterministic_replay');
+    updateElement('demoAiCore', 'not-used');
     updateElement('demoNocStatus', '-');
     updateElement('demoSocStatus', '-');
     updateElement('demoAction', '-');
     updateElement('demoReason', '-');
+    updateElement('demoSafetyReversible', '-');
+    updateElement('demoSafetyApproval', '-');
+    updateElement('demoSafetyAudited', '-');
+    updateElement('demoSafetyEffect', '-');
+    updateElement('demoTraceNocFragile', '-');
+    updateElement('demoTraceStrongSoc', '-');
+    updateElement('demoTraceBlastConfidence', '-');
+    updateElement('demoTraceClientImpact', '-');
+    updateElement('demoBoundaryMode', 'DETERMINISTIC REPLAY');
+    updateElement('demoBoundarySummary', 'Synthetic replay path. AI is not used in the core decision loop.');
     updateElement('demoOperatorWording', tr('dashboard.no_demo', 'No demo overlay is active.'));
     updateElement('demoResponse', tr('dashboard.no_demo_response', 'Run a scenario to preview the deterministic pipeline.'));
     renderList('demoNextChecks', [tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.')], (item) => item);
@@ -310,6 +324,12 @@ function bindStaticHandlers() {
         await runDemoScenario();
     });
     document.getElementById('demoClearOverlayBtn')?.addEventListener('click', clearDemoOverlay);
+    document.getElementById('reviewOpenCapabilitiesBtn')?.addEventListener('click', () => {
+        void openAuthenticatedJson('/api/demo/capabilities', 'Azazel-Edge Capability Boundary');
+    });
+    document.getElementById('reviewOpenExplanationBtn')?.addEventListener('click', () => {
+        void openAuthenticatedJson('/api/demo/explanation/latest', 'Azazel-Edge Latest Explanation');
+    });
 
     loadDemoScenarios();
 }
@@ -491,6 +511,7 @@ async function refreshDashboard() {
         ['state', '/api/state', true],
         ['mattermost', '/api/mattermost/status', false],
         ['capabilities', '/api/ai/capabilities', false],
+        ['demoCapabilities', '/api/demo/capabilities', false],
         ['demoOverlay', '/api/demo/overlay', false],
     ];
 
@@ -526,6 +547,7 @@ async function refreshDashboard() {
     const state = resultMap.state?.data || {};
     const mattermost = resultMap.mattermost?.data || { reachable: false, command_triggers: [] };
     const capabilities = resultMap.capabilities?.data || { mattermost_triggers: [] };
+    const demoCapabilities = resultMap.demoCapabilities?.data || { boundary: {}, execution_mode: 'deterministic_replay' };
     const demoOverlay = resultMap.demoOverlay?.data?.overlay || {};
 
     latestState = state || {};
@@ -546,6 +568,7 @@ async function refreshDashboard() {
         updateTemporaryMission(actions);
         updateEvidenceBoard(evidence, health);
         updateAssistant(actions, mattermost, capabilities);
+        updateReviewReadiness(resultMap.health, resultMap.demoCapabilities, demoOverlayResult);
         updateControlButtons(summary, state);
         if (demoOverlayResult) {
             applyDemoOverlay(demoOverlayResult);
@@ -613,6 +636,8 @@ async function runDemoScenario() {
     if (submit) submit.disabled = true;
     updateElement('demoResponse', tr('dashboard.demo_running', 'Running demo scenario...'));
     updateElement('demoOperatorWording', tr('dashboard.demo_preparing', 'Preparing scenario replay...'));
+    updateElement('demoBoundaryMode', 'DETERMINISTIC REPLAY');
+    updateElement('demoBoundarySummary', 'Synthetic replay path. AI is not used in the core decision loop.');
     updateElement('demoNocStatus', '-');
     updateElement('demoSocStatus', '-');
     updateElement('demoAction', '-');
@@ -627,6 +652,7 @@ async function runDemoScenario() {
         const payload = await fetchJson(`/api/demo/run/${encodeURIComponent(scenarioId)}`, { method: 'POST' });
         const result = payload.result || {};
         const overlay = payload.overlay || {};
+        applyDemoDerivedFields(result);
         updateElement('demoNocStatus', result.noc?.summary?.status || '-');
         updateElement('demoSocStatus', result.soc?.summary?.status || '-');
         updateElement('demoAction', result.arbiter?.action || '-');
@@ -712,6 +738,14 @@ function applyDemoOverlay(result) {
         ? result.rejected_alternatives
         : (Array.isArray(raw.explanation?.why_not_others) ? raw.explanation.why_not_others : []);
     const operatorWording = String(result.operator_wording || raw.explanation?.operator_wording || '').trim();
+    applyDemoDerivedFields({
+        scenario_id: scenarioId,
+        event_count: Number(result.event_count || raw.event_count || 0),
+        execution: result.execution || raw.execution || {},
+        action_profile: result.action_profile || raw.arbiter?.action_profile || {},
+        decision_trace: result.decision_trace || raw.arbiter?.decision_trace || {},
+        capability_boundary: result.capability_boundary || raw.capability_boundary || {},
+    });
     updateElement('demoNocStatus', nocStatus || '-');
     updateElement('demoSocStatus', socStatus || '-');
     updateElement('demoAction', action || '-');
@@ -1241,6 +1275,161 @@ function buildDemoMioQuestion(result) {
     const action = result?.arbiter?.action || '-';
     const reason = result?.arbiter?.reason || '-';
     return `Demo scenario ${scenarioId}: NOC status ${nocStatus}, SOC status ${socStatus}, selected action ${action}, reason ${reason}. Explain this choice for an operator and give the next checks.`;
+}
+
+async function openAuthenticatedJson(path, title) {
+    const popup = window.open('', '_blank', 'noopener,noreferrer');
+    if (popup) {
+        popup.document.title = title;
+        popup.document.body.innerHTML = '<pre>Loading...</pre>';
+    }
+    try {
+        const payload = await fetchJson(path);
+        const content = JSON.stringify(payload, null, 2);
+        if (popup) {
+            popup.document.title = title;
+            popup.document.body.innerHTML = `<pre>${escapeHtml(content)}</pre>`;
+        }
+    } catch (error) {
+        if (popup) {
+            popup.document.title = `${title} (error)`;
+            popup.document.body.innerHTML = `<pre>${escapeHtml(String(error.message || error))}</pre>`;
+        }
+        showToast(`${title}: ${error.message || error}`, 'error');
+    }
+}
+
+function formatDemoBoolean(value) {
+    return value ? 'yes' : 'no';
+}
+
+function formatCapabilityBoundarySummary(boundary) {
+    if (!boundary || typeof boundary !== 'object') {
+        return 'Synthetic replay path. AI is not used in the core decision loop.';
+    }
+    const implemented = Array.isArray(boundary.implemented_now) ? boundary.implemented_now.length : 0;
+    const demoOnly = Array.isArray(boundary.demo_only) ? boundary.demo_only.length : 0;
+    const experimental = Array.isArray(boundary.experimental) ? boundary.experimental.length : 0;
+    return `Synthetic replay path. implemented=${implemented}, demo_only=${demoOnly}, experimental=${experimental}. AI is not used in the core decision loop.`;
+}
+
+function applyDemoDerivedFields(source) {
+    const raw = source && typeof source === 'object' ? source : {};
+    const execution = raw.execution && typeof raw.execution === 'object' ? raw.execution : {};
+    const actionProfile = raw.action_profile && typeof raw.action_profile === 'object'
+        ? raw.action_profile
+        : (raw.arbiter?.action_profile && typeof raw.arbiter.action_profile === 'object' ? raw.arbiter.action_profile : {});
+    const decisionTrace = raw.decision_trace && typeof raw.decision_trace === 'object'
+        ? raw.decision_trace
+        : (raw.arbiter?.decision_trace && typeof raw.arbiter.decision_trace === 'object' ? raw.arbiter.decision_trace : {});
+    const capabilityBoundary = raw.capability_boundary && typeof raw.capability_boundary === 'object' ? raw.capability_boundary : {};
+    const scenarioId = String(raw.scenario_id || '-').trim();
+    const eventCount = Number(raw.event_count || 0);
+
+    updateElement('demoScenarioId', scenarioId || '-');
+    updateElement('demoEventCount', Number.isFinite(eventCount) ? String(eventCount) : '-');
+    updateElement('demoExecutionMode', String(execution.mode || 'deterministic_replay'));
+    updateElement('demoAiCore', execution.ai_used ? 'used' : 'not-used');
+    updateElement('demoSafetyReversible', formatDemoBoolean(Boolean(actionProfile.reversible)));
+    updateElement('demoSafetyApproval', actionProfile.approval_required ? 'required' : 'not-required');
+    updateElement('demoSafetyAudited', formatDemoBoolean(Boolean(actionProfile.audited)));
+    updateElement('demoSafetyEffect', String(actionProfile.effect || '-'));
+    updateElement('demoTraceNocFragile', formatDemoBoolean(Boolean(decisionTrace.noc_fragile)));
+    updateElement('demoTraceStrongSoc', formatDemoBoolean(Boolean(decisionTrace.strong_soc)));
+    updateElement(
+        'demoTraceBlastConfidence',
+        `${Number(decisionTrace.blast_score || 0)}/${Number(decisionTrace.confidence_score || 0)}`,
+    );
+    updateElement(
+        'demoTraceClientImpact',
+        `${Number(decisionTrace.client_impact_score || 0)} / critical=${Number(decisionTrace.critical_client_count || 0)}`,
+    );
+    updateElement('demoBoundaryMode', execution.live_telemetry ? 'LIVE TELEMETRY' : 'DETERMINISTIC REPLAY');
+    updateElement('demoBoundarySummary', formatCapabilityBoundarySummary(capabilityBoundary));
+}
+
+function updateReviewReadiness(healthEntry, demoCapabilitiesEntry, demoOverlay) {
+    const healthOk = Boolean(healthEntry?.ok);
+    const demoCapabilitiesOk = Boolean(demoCapabilitiesEntry?.ok);
+    const health = healthEntry?.data || {};
+    const demoCapabilities = demoCapabilitiesEntry?.data || {};
+    const boundary = demoOverlay?.capability_boundary || demoCapabilities?.boundary || {};
+    const execution = demoOverlay?.execution || {
+        mode: demoCapabilities?.execution_mode || 'deterministic_replay',
+        ai_used: Boolean(demoCapabilities?.ai_used_in_core_path),
+        live_telemetry: Boolean(demoCapabilities?.live_telemetry_required),
+        local_only: Boolean(demoCapabilities?.local_only_in_core_path),
+    };
+    const implemented = Array.isArray(boundary.implemented_now) ? boundary.implemented_now : [];
+    const demoOnly = Array.isArray(boundary.demo_only) ? boundary.demo_only : [];
+    const experimental = Array.isArray(boundary.experimental) ? boundary.experimental : [];
+    const nonGoals = Array.isArray(boundary.non_goals) ? boundary.non_goals : [];
+    const staleFlags = health?.stale_flags || {};
+    const queue = health?.queue || {};
+    const llm = health?.llm || {};
+    const badge = document.getElementById('reviewStatusBadge');
+    const capabilityBtn = document.getElementById('reviewOpenCapabilitiesBtn');
+    const explanationBtn = document.getElementById('reviewOpenExplanationBtn');
+    const hasBoundaryData = Boolean(demoOverlay?.capability_boundary) || demoCapabilitiesOk;
+    const hasHealthData = healthOk;
+    const overlayActive = Boolean(demoOverlay);
+    const healthy = hasBoundaryData
+        && hasHealthData
+        && !staleFlags.snapshot
+        && !staleFlags.ai_metrics
+        && Number(queue.capacity ?? 0) > 0
+        && Number(queue.depth ?? 0) <= Number(queue.capacity ?? 0);
+    const status = (!hasBoundaryData || !hasHealthData) ? 'UNKNOWN' : (healthy ? 'BOUNDED' : 'CHECK');
+
+    updateElement('reviewExecutionMode', hasBoundaryData ? String(execution.mode || 'deterministic_replay') : 'unknown');
+    updateElement('reviewAiCore', hasBoundaryData ? (execution.ai_used ? 'used' : 'not-used') : 'unknown');
+    updateElement('reviewLocalOnly', hasBoundaryData ? (execution.local_only ? 'yes' : 'no') : 'unknown');
+    updateElement('reviewLiveTelemetry', hasBoundaryData ? (execution.live_telemetry ? 'required' : 'not-required') : 'unknown');
+    updateElement('reviewDemoState', overlayActive ? 'overlay-active' : 'overlay-inactive');
+    updateElement('reviewBoundaryCounts', hasBoundaryData ? `${implemented.length} / ${experimental.length}` : 'unknown');
+    renderList('reviewImplementedList', hasBoundaryData && implemented.length ? implemented : ['No data'], (item) => item);
+    renderList(
+        'reviewExperimentalList',
+        hasBoundaryData
+            ? [
+                ...experimental.map((item) => `experimental: ${item}`),
+                ...demoOnly.map((item) => `demo-only: ${item}`),
+            ]
+            : ['No data'],
+        (item) => item,
+    );
+    renderList(
+        'reviewNonGoalsList',
+        hasBoundaryData && nonGoals.length ? nonGoals.map((item) => `non-goal: ${item}`) : ['No data'],
+        (item) => item,
+    );
+
+    updateElement('reviewQueueDepth', hasHealthData ? `${queue.depth ?? 0} / ${queue.capacity ?? 0} (max ${queue.max_seen ?? 0})` : 'unknown');
+    updateElement('reviewDeferredCount', hasHealthData ? String(queue.deferred_count ?? 0) : 'unknown');
+    updateElement('reviewFallbackRate', hasHealthData ? String(llm.fallback_rate ?? 0) : 'unknown');
+    updateElement('reviewPolicyMode', hasHealthData ? String(health?.policy_mode || '-') : 'unknown');
+    updateElement('reviewLatency', hasHealthData ? `${llm.latency_ms_last ?? 0} ms / ema ${llm.latency_ms_ema ?? 0}` : 'unknown');
+    updateElement(
+        'reviewStaleFlags',
+        hasHealthData
+            ? `snapshot=${staleFlags.snapshot ? 'yes' : 'no'} ai=${staleFlags.ai_metrics ? 'yes' : 'no'} events=${staleFlags.ai_activity ? 'yes' : 'no'}`
+            : 'unknown',
+    );
+    updateElement('reviewStatusBadge', status);
+    if (badge) {
+        badge.className = `assistant-status ${
+            status === 'BOUNDED' ? 'status-safe' : (status === 'CHECK' ? 'status-caution' : 'status-neutral')
+        }`;
+    }
+    if (capabilityBtn) capabilityBtn.disabled = !hasBoundaryData;
+    if (explanationBtn) explanationBtn.disabled = !overlayActive;
+    updateElement('reviewSummary', 'Deterministic edge pipeline, bounded controls, local-first operation, auditable outputs.');
+    updateElement(
+        'reviewSummaryDetail',
+        !hasBoundaryData || !hasHealthData
+            ? 'Reviewer-proof summary is incomplete because capability or health data is unavailable.'
+            : `Execution=${execution.mode || 'deterministic_replay'} | local_only=${execution.local_only ? 'yes' : 'no'} | demo_state=${overlayActive ? 'overlay-active' : 'overlay-inactive'} | bounded=${healthy ? 'yes' : 'check'}`,
+    );
 }
 
 function renderList(id, items, formatter) {

--- a/azazel_edge_web/static/style.css
+++ b/azazel_edge_web/static/style.css
@@ -268,6 +268,31 @@ body[data-audience="professional"] .temp-only {
     line-height: 1.45;
 }
 
+.demo-boundary-banner {
+    display: grid;
+    gap: 8px;
+    margin-top: 16px;
+    padding: 14px 16px;
+    border-radius: 16px;
+    border: 1px solid rgba(116, 212, 255, 0.28);
+    background: linear-gradient(145deg, rgba(30, 66, 92, 0.38), rgba(17, 30, 46, 0.7));
+}
+
+.demo-boundary-banner strong {
+    color: #cceeff;
+    font-family: var(--font-mono);
+    letter-spacing: 0.04em;
+}
+
+.demo-boundary-banner span {
+    color: var(--text-main);
+    line-height: 1.5;
+}
+
+.review-panel .action-list {
+    margin-top: 10px;
+}
+
 .demo-raw-panel {
     margin-top: 16px;
     border-top: 1px solid rgba(255,255,255,0.06);

--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -517,13 +517,39 @@
                             <button type="button" id="demoClearOverlayBtn" class="shortcut-btn">{{ tr('dashboard.clear_demo', 'Clear Demo Overlay') }}</button>
                         </div>
                     </form>
+                    <div class="demo-boundary-banner" id="demoBoundaryBanner">
+                        <strong id="demoBoundaryMode">DETERMINISTIC REPLAY</strong>
+                        <span id="demoBoundarySummary">Synthetic replay path. AI is not used in the core decision loop.</span>
+                    </div>
                     <div class="assistant-block">
                         <div class="assistant-label">Scenario Result</div>
                         <div class="fact-list compact-list">
+                            <div class="fact-item"><span>Scenario</span><strong id="demoScenarioId">-</strong></div>
+                            <div class="fact-item"><span>Events</span><strong id="demoEventCount">-</strong></div>
+                            <div class="fact-item"><span>Execution</span><strong id="demoExecutionMode">-</strong></div>
+                            <div class="fact-item"><span>AI Core</span><strong id="demoAiCore">-</strong></div>
                             <div class="fact-item"><span>NOC</span><strong id="demoNocStatus">-</strong></div>
                             <div class="fact-item"><span>SOC</span><strong id="demoSocStatus">-</strong></div>
                             <div class="fact-item"><span>Action</span><strong id="demoAction">-</strong></div>
                             <div class="fact-item"><span>Reason</span><strong id="demoReason">-</strong></div>
+                        </div>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Action Safety</div>
+                        <div class="fact-list compact-list">
+                            <div class="fact-item"><span>Reversible</span><strong id="demoSafetyReversible">-</strong></div>
+                            <div class="fact-item"><span>Approval</span><strong id="demoSafetyApproval">-</strong></div>
+                            <div class="fact-item"><span>Audited</span><strong id="demoSafetyAudited">-</strong></div>
+                            <div class="fact-item"><span>Effect</span><strong id="demoSafetyEffect">-</strong></div>
+                        </div>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Arbiter Trace</div>
+                        <div class="fact-list compact-list">
+                            <div class="fact-item"><span>NOC Fragile</span><strong id="demoTraceNocFragile">-</strong></div>
+                            <div class="fact-item"><span>Strong SOC</span><strong id="demoTraceStrongSoc">-</strong></div>
+                            <div class="fact-item"><span>Blast / Confidence</span><strong id="demoTraceBlastConfidence">-</strong></div>
+                            <div class="fact-item"><span>Client Impact</span><strong id="demoTraceClientImpact">-</strong></div>
                         </div>
                     </div>
                     <div class="assistant-block">
@@ -552,6 +578,62 @@
                         <summary>Raw JSON</summary>
                         <pre class="assistant-response demo-raw-response" id="demoResponse">{{ tr('dashboard.no_demo_response', 'Run a scenario to preview the deterministic pipeline.') }}</pre>
                     </details>
+                </section>
+
+                <section class="panel assistant-panel review-panel" id="reviewPanel">
+                    <div class="panel-heading assistant-heading">
+                        <div>
+                            <div class="panel-kicker">Review Readiness</div>
+                            <h2>Capability Boundary and Resource Guard</h2>
+                        </div>
+                        <span class="assistant-status status-neutral" id="reviewStatusBadge">READY</span>
+                    </div>
+                    <p class="assistant-intro">Compact proof that the deterministic path is bounded, local-first, and running within visible resource limits.</p>
+                    <div class="demo-boundary-banner">
+                        <strong id="reviewSummary">Deterministic edge pipeline, bounded controls, local-first operation, auditable outputs.</strong>
+                        <span id="reviewSummaryDetail">Waiting for capability and health data.</span>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Capability Boundary</div>
+                        <div class="fact-list compact-list">
+                            <div class="fact-item"><span>Execution</span><strong id="reviewExecutionMode">-</strong></div>
+                            <div class="fact-item"><span>AI Core</span><strong id="reviewAiCore">-</strong></div>
+                            <div class="fact-item"><span>Local Only</span><strong id="reviewLocalOnly">-</strong></div>
+                            <div class="fact-item"><span>Live Telemetry</span><strong id="reviewLiveTelemetry">-</strong></div>
+                            <div class="fact-item"><span>Demo State</span><strong id="reviewDemoState">-</strong></div>
+                            <div class="fact-item"><span>Implemented / Experimental</span><strong id="reviewBoundaryCounts">-</strong></div>
+                        </div>
+                        <div class="assistant-shortcuts">
+                            <button type="button" class="shortcut-btn" id="reviewOpenCapabilitiesBtn">Open Capability JSON</button>
+                            <button type="button" class="shortcut-btn" id="reviewOpenExplanationBtn">Open Latest Explanation</button>
+                        </div>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Implemented Now</div>
+                        <ul class="action-list" id="reviewImplementedList">
+                            <li>No data</li>
+                        </ul>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Experimental / Non-goals</div>
+                        <ul class="action-list" id="reviewExperimentalList">
+                            <li>No data</li>
+                        </ul>
+                        <ul class="action-list" id="reviewNonGoalsList">
+                            <li>No data</li>
+                        </ul>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Resource Guard</div>
+                        <div class="fact-list compact-list">
+                            <div class="fact-item"><span>Queue</span><strong id="reviewQueueDepth">-</strong></div>
+                            <div class="fact-item"><span>Deferred</span><strong id="reviewDeferredCount">-</strong></div>
+                            <div class="fact-item"><span>Fallback</span><strong id="reviewFallbackRate">-</strong></div>
+                            <div class="fact-item"><span>Policy</span><strong id="reviewPolicyMode">-</strong></div>
+                            <div class="fact-item"><span>Latency</span><strong id="reviewLatency">-</strong></div>
+                            <div class="fact-item"><span>Stale</span><strong id="reviewStaleFlags">-</strong></div>
+                        </div>
+                    </div>
                 </section>
             </aside>
         </div>

--- a/py/azazel_edge/arbiter/action.py
+++ b/py/azazel_edge/arbiter/action.py
@@ -6,6 +6,43 @@ from typing import Any, Dict, List
 class ActionArbiter:
     REQUIRED_NOC_KEYS = {'availability', 'path_health', 'device_health', 'client_health', 'summary', 'evidence_ids'}
     REQUIRED_SOC_KEYS = {'suspicion', 'confidence', 'technique_likelihood', 'blast_radius', 'summary', 'evidence_ids'}
+    ACTION_PROFILES = {
+        'observe': {
+            'reversible': True,
+            'approval_required': False,
+            'audited': True,
+            'effect': 'visibility_only',
+            'mode': 'passive',
+        },
+        'notify': {
+            'reversible': True,
+            'approval_required': False,
+            'audited': True,
+            'effect': 'operator_notification',
+            'mode': 'human_loop',
+        },
+        'throttle': {
+            'reversible': True,
+            'approval_required': True,
+            'audited': True,
+            'effect': 'traffic_shaping',
+            'mode': 'bounded_control',
+        },
+        'redirect': {
+            'reversible': True,
+            'approval_required': True,
+            'audited': True,
+            'effect': 'controlled_redirect',
+            'mode': 'bounded_control',
+        },
+        'isolate': {
+            'reversible': True,
+            'approval_required': True,
+            'audited': True,
+            'effect': 'segment_isolation',
+            'mode': 'high_risk_control',
+        },
+    }
 
     def decide(self, noc: Dict[str, Any], soc: Dict[str, Any], client_impact: Dict[str, Any] | None = None) -> Dict[str, Any]:
         self._validate_schema(noc, self.REQUIRED_NOC_KEYS, 'noc')
@@ -55,6 +92,18 @@ class ActionArbiter:
 
         rejected = self._rejected_alternatives(action, noc_fragile=noc_fragile, strong_soc=strong_soc, blast_score=blast_score)
         chosen_evidence_ids = self._chosen_evidence_ids(action, noc, soc)
+        action_profile = self.action_profile(action)
+        decision_trace = self._decision_trace(
+            noc=noc,
+            soc=soc,
+            action=action,
+            reason=reason,
+            noc_fragile=noc_fragile,
+            strong_soc=strong_soc,
+            blast_score=blast_score,
+            confidence_score=confidence_score,
+            client_impact=client_impact or {},
+        )
 
         return {
             'action': action,
@@ -63,6 +112,8 @@ class ActionArbiter:
             'chosen_evidence_ids': chosen_evidence_ids,
             'rejected_alternatives': rejected,
             'client_impact': client_impact or {},
+            'action_profile': action_profile,
+            'decision_trace': decision_trace,
         }
 
     @staticmethod
@@ -125,3 +176,38 @@ class ActionArbiter:
             else:
                 candidates.append({'action': 'isolate', 'reason': 'isolate_gate_not_satisfied'})
         return candidates
+
+    @classmethod
+    def action_profile(cls, action: str) -> Dict[str, Any]:
+        profile = cls.ACTION_PROFILES.get(str(action or 'observe'), cls.ACTION_PROFILES['observe'])
+        return dict(profile)
+
+    @classmethod
+    def _decision_trace(
+        cls,
+        noc: Dict[str, Any],
+        soc: Dict[str, Any],
+        action: str,
+        reason: str,
+        noc_fragile: bool,
+        strong_soc: bool,
+        blast_score: int,
+        confidence_score: int,
+        client_impact: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        return {
+            'selected_action': action,
+            'selected_reason': reason,
+            'noc_fragile': bool(noc_fragile),
+            'strong_soc': bool(strong_soc),
+            'availability_label': str(noc.get('availability', {}).get('label') or 'unknown'),
+            'path_label': str(noc.get('path_health', {}).get('label') or 'unknown'),
+            'device_label': str(noc.get('device_health', {}).get('label') or 'unknown'),
+            'suspicion_label': str(soc.get('suspicion', {}).get('label') or 'unknown'),
+            'suspicion_score': int(soc.get('suspicion', {}).get('score') or 0),
+            'confidence_score': int(confidence_score or 0),
+            'blast_score': int(blast_score or 0),
+            'client_impact_score': int(client_impact.get('score') or 0),
+            'critical_client_count': int(client_impact.get('critical_client_count') or 0),
+            'safety_profile': cls.action_profile(action),
+        }

--- a/py/azazel_edge/demo/scenarios.py
+++ b/py/azazel_edge/demo/scenarios.py
@@ -38,6 +38,27 @@ class DemoScenarioPack:
 
 
 class DemoScenarioRunner:
+    CAPABILITY_BOUNDARY = {
+        'implemented_now': [
+            'deterministic_evidence_to_evaluation_pipeline',
+            'deterministic_action_arbiter',
+            'decision_explanation',
+            'dashboard_demo_replay',
+        ],
+        'demo_only': [
+            'synthetic_scenario_replay_overlay',
+        ],
+        'experimental': [
+            'local_ai_operator_assist',
+            'ti_sigma_yara_helpers',
+        ],
+        'non_goals': [
+            'enterprise_siem_replacement',
+            'fully_autonomous_response',
+            'high_throughput_datacenter_edge',
+        ],
+    }
+
     def __init__(self):
         self.pack = DemoScenarioPack()
         self.noc = NocEvaluator()
@@ -68,8 +89,20 @@ class DemoScenarioRunner:
             'scenario_id': scenario_id,
             'description': scenario.get('description', ''),
             'event_count': len(events),
+            'execution': {
+                'mode': 'deterministic_replay',
+                'ai_used': False,
+                'live_telemetry': False,
+                'local_only': True,
+                'source': 'demo_scenario_pack',
+            },
+            'capability_boundary': self.capability_boundary(),
             'noc': noc_eval,
             'soc': soc_eval,
             'arbiter': arbiter,
             'explanation': explanation,
         }
+
+    @classmethod
+    def capability_boundary(cls) -> Dict[str, List[str]]:
+        return {key: list(value) for key, value in cls.CAPABILITY_BOUNDARY.items()}

--- a/py/azazel_edge/demo_overlay.py
+++ b/py/azazel_edge/demo_overlay.py
@@ -85,6 +85,8 @@ def build_demo_overlay(result: Dict[str, Any]) -> Dict[str, Any]:
     arbiter = result.get("arbiter") if isinstance(result.get("arbiter"), dict) else {}
     noc = result.get("noc") if isinstance(result.get("noc"), dict) else {}
     soc = result.get("soc") if isinstance(result.get("soc"), dict) else {}
+    execution = result.get("execution") if isinstance(result.get("execution"), dict) else {}
+    capability_boundary = result.get("capability_boundary") if isinstance(result.get("capability_boundary"), dict) else {}
     return {
         "active": True,
         "ts": time.time(),
@@ -92,9 +94,13 @@ def build_demo_overlay(result: Dict[str, Any]) -> Dict[str, Any]:
         "scenario_id": str(result.get("scenario_id") or "demo"),
         "description": str(result.get("description") or ""),
         "event_count": int(result.get("event_count") or 0),
+        "execution": execution,
+        "capability_boundary": capability_boundary,
         "action": str(arbiter.get("action") or "observe"),
         "reason": str(arbiter.get("reason") or "demo_overlay"),
         "control_mode": str(arbiter.get("control_mode") or "none"),
+        "action_profile": arbiter.get("action_profile") if isinstance(arbiter.get("action_profile"), dict) else {},
+        "decision_trace": arbiter.get("decision_trace") if isinstance(arbiter.get("decision_trace"), dict) else {},
         "chosen_evidence_ids": list(explanation.get("evidence_ids") or arbiter.get("chosen_evidence_ids") or []),
         "rejected_alternatives": list(explanation.get("why_not_others") or arbiter.get("rejected_alternatives") or []),
         "next_checks": list(explanation.get("next_checks") or []),

--- a/tests/test_demo_api_v1.py
+++ b/tests/test_demo_api_v1.py
@@ -148,6 +148,35 @@ class DemoApiV1Tests(unittest.TestCase):
         self.assertEqual(loaded, {})
         self.assertFalse(overlay_path.exists())
 
+    def test_demo_capabilities_endpoint(self) -> None:
+        response = self.client.get("/api/demo/capabilities")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["execution_mode"], "deterministic_replay")
+        self.assertFalse(payload["ai_used_in_core_path"])
+        self.assertTrue(payload["local_only_in_core_path"])
+        self.assertIn("implemented_now", payload["boundary"])
+
+    def test_latest_explanation_endpoint_reads_active_overlay(self) -> None:
+        overlay = build_demo_overlay(
+            {
+                "scenario_id": "mixed_correlation_demo",
+                "event_count": 3,
+                "execution": {"mode": "deterministic_replay", "ai_used": False},
+                "arbiter": {"action": "throttle", "reason": "correlated_signal"},
+                "explanation": {"operator_wording": "demo wording", "evidence_ids": ["soc-1"]},
+            }
+        )
+        write_demo_overlay(overlay, self.overlay_path)
+        response = self.client.get("/api/demo/explanation/latest")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["scenario_id"], "mixed_correlation_demo")
+        self.assertEqual(payload["action"], "throttle")
+        self.assertEqual(payload["explanation"]["operator_wording"], "demo wording")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_demo_runner_v1.py
+++ b/tests/test_demo_runner_v1.py
@@ -22,8 +22,14 @@ class DemoRunnerV1Tests(unittest.TestCase):
         result = subprocess.run([str(RUNNER), 'run', 'mixed_correlation_demo'], capture_output=True, text=True, cwd=str(ROOT), check=True)
         payload = json.loads(result.stdout)
         self.assertTrue(payload['ok'])
-        self.assertEqual(payload['result']['scenario_id'], 'mixed_correlation_demo')
-        self.assertIn('arbiter', payload['result'])
+        scenario = payload['result']
+        self.assertEqual(scenario['scenario_id'], 'mixed_correlation_demo')
+        self.assertIn('arbiter', scenario)
+        self.assertEqual(scenario['execution']['mode'], 'deterministic_replay')
+        self.assertFalse(scenario['execution']['ai_used'])
+        self.assertIn('implemented_now', scenario['capability_boundary'])
+        self.assertTrue(scenario['arbiter']['action_profile']['audited'])
+        self.assertIn('selected_action', scenario['arbiter']['decision_trace'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add deterministic replay, action safety, arbiter trace, and capability boundary metadata to the demo path
- add review-readiness UI for capability boundary and resource guard, with fail-closed status handling
- add authenticated export helpers and update demo API/runner tests for the new review metadata

## Verification
- ./.venv/bin/pytest -q tests/test_demo_runner_v1.py
- python3 -m py_compile py/azazel_edge/arbiter/action.py py/azazel_edge/demo/scenarios.py py/azazel_edge/demo_overlay.py azazel_edge_web/app.py

## Notes
- tests/test_demo_api_v1.py was not run in this environment because Flask is not installed