### PR TITLE
Implement NOC capacity and assurance baseline

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -924,6 +924,8 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
     mode = mode_runtime.get("mode") if isinstance(mode_runtime.get("mode"), dict) else {}
     connection = state.get("connection") if isinstance(state.get("connection"), dict) else {}
     network_health = state.get("network_health") if isinstance(state.get("network_health"), dict) else {}
+    noc_capacity = state.get("noc_capacity") if isinstance(state.get("noc_capacity"), dict) else {}
+    noc_client_inventory = state.get("noc_client_inventory") if isinstance(state.get("noc_client_inventory"), dict) else {}
     internal = state.get("internal") if isinstance(state.get("internal"), dict) else {}
     attack = state.get("attack") if isinstance(state.get("attack"), dict) else {}
     now_epoch = time.time()
@@ -973,6 +975,12 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
     path_scope = ("全 uplink 利用者" if lang == "ja" else "all uplink clients") if str(connection.get("internet_check") or "").upper() == "FAIL" else (
         ("DNS 影響利用者" if lang == "ja" else "dns-affected clients") if _as_int(network_health.get("dns_mismatch"), 0) > 0 else ("広域影響なし" if lang == "ja" else "no broad impact indicated")
     )
+    top_sources = noc_capacity.get("top_sources") if isinstance(noc_capacity.get("top_sources"), list) else []
+    top_talker = "-"
+    if top_sources and isinstance(top_sources[0], dict):
+        top_talker = str(top_sources[0].get("src_ip") or top_sources[0].get("id") or "-")
+    noc_service_assurance = state.get("noc_service_assurance") if isinstance(state.get("noc_service_assurance"), dict) else {}
+    noc_resolution_assurance = state.get("noc_resolution_assurance") if isinstance(state.get("noc_resolution_assurance"), dict) else {}
     return {
         "ok": True,
         "risk": {
@@ -1062,6 +1070,29 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
                 "signals": signals[:4],
             },
             "service_health": service_summary,
+            "service_assurance": {
+                "status": str(noc_service_assurance.get("status") or "unknown"),
+                "degraded_targets": noc_service_assurance.get("degraded_targets") if isinstance(noc_service_assurance.get("degraded_targets"), list) else [],
+            },
+            "resolution_health": {
+                "status": str(noc_resolution_assurance.get("status") or "unknown"),
+                "failed_targets": noc_resolution_assurance.get("failed_targets") if isinstance(noc_resolution_assurance.get("failed_targets"), list) else [],
+            },
+            "capacity": {
+                "state": str(noc_capacity.get("state") or "unknown"),
+                "mode": str(noc_capacity.get("mode") or "unknown"),
+                "utilization_pct": _as_float(noc_capacity.get("utilization_pct"), 0.0) if "utilization_pct" in noc_capacity else None,
+                "top_talker": top_talker,
+                "signals": noc_capacity.get("signals") if isinstance(noc_capacity.get("signals"), list) else [],
+            },
+            "client_inventory": {
+                "current_client_count": _as_int(noc_client_inventory.get("current_client_count"), 0),
+                "new_client_count": _as_int(noc_client_inventory.get("new_client_count"), 0),
+                "unknown_client_count": _as_int(noc_client_inventory.get("unknown_client_count"), 0),
+                "unauthorized_client_count": _as_int(noc_client_inventory.get("unauthorized_client_count"), 0),
+                "inventory_mismatch_count": _as_int(noc_client_inventory.get("inventory_mismatch_count"), 0),
+                "stale_session_count": _as_int(noc_client_inventory.get("stale_session_count"), 0),
+            },
             "client_impact": {
                 "scope": path_scope,
                 "segment_scope": str(state.get("up_if") or "unknown"),

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -74,6 +74,14 @@ function resetDemoOverlayPresentation() {
     updateElement('demoSafetyAudited', '-');
     updateElement('demoSafetyEffect', '-');
     updateElement('demoTraceNocFragile', '-');
+    updateElement('nocCapacityState', '-');
+    updateElement('nocCapacityUtilization', '-');
+    updateElement('nocCapacityMode', '-');
+    updateElement('nocCapacityTopTalker', '-');
+    updateElement('nocClientCurrent', '0');
+    updateElement('nocClientUnknown', '0');
+    updateElement('nocClientUnauthorized', '0');
+    updateElement('nocClientMismatch', '0');
     updateElement('demoTraceStrongSoc', '-');
     updateElement('demoTraceBlastConfidence', '-');
     updateElement('demoTraceClientImpact', '-');
@@ -826,10 +834,14 @@ function applyDemoOverlay(result) {
         tr('dashboard.demo_service_simulated', 'demo-services: simulated'),
         tr('dashboard.demo_control_mode', 'control-mode: {mode}', { mode: result.arbiter?.control_mode || 'none' }),
     ], (item) => item);
-    updateElement('nocClientScope', 'demo impact');
-    updateElement('nocClientSegment', scenarioId);
-    updateElement('nocClientPortal', 'N/A');
-    updateElement('nocClientDnsMismatch', '0');
+    updateElement('nocCapacityState', String(result.noc?.capacity_health?.label || 'unknown').toUpperCase());
+    updateElement('nocCapacityUtilization', '-');
+    updateElement('nocCapacityMode', 'demo');
+    updateElement('nocCapacityTopTalker', '-');
+    updateElement('nocClientCurrent', String(result.noc?.client_inventory_health?.score != null ? 1 : 0));
+    updateElement('nocClientUnknown', '0');
+    updateElement('nocClientUnauthorized', '0');
+    updateElement('nocClientMismatch', '0');
     renderList(
         'rejectedStrongerActionsList',
         rejected.length ? rejected : [tr('dashboard.no_active_rejections', 'No rejected stronger actions')],
@@ -994,6 +1006,10 @@ function updateSplitBoard(summary, actions) {
     const correlation = soc.correlation || {};
     const path = noc.path_health || {};
     const services = noc.service_health || {};
+    const serviceAssurance = noc.service_assurance || {};
+    const resolutionHealth = noc.resolution_health || {};
+    const capacity = noc.capacity || {};
+    const clientInventory = noc.client_inventory || {};
     const clientImpact = noc.client_impact || {};
     const attackType = soc.attack_type || tr('dashboard.no_attack_type', 'No current attack type');
 
@@ -1028,10 +1044,19 @@ function updateSplitBoard(summary, actions) {
         Object.entries(services).map(([name, value]) => `${name}: ${value}`),
         (item) => item,
     );
-    updateElement('nocClientScope', clientImpact.scope || '-');
-    updateElement('nocClientSegment', clientImpact.segment_scope || '-');
-    updateElement('nocClientPortal', clientImpact.captive_portal || '-');
-    updateElement('nocClientDnsMismatch', String(clientImpact.dns_mismatch ?? 0));
+    updateElement('nocServiceAssurance', String(serviceAssurance.status || 'unknown').toUpperCase());
+    updateElement('nocResolutionHealth', String(resolutionHealth.status || 'unknown').toUpperCase());
+    const utilization = capacity.utilization_pct == null || capacity.utilization_pct === ''
+        ? '-'
+        : `${capacity.utilization_pct}%`;
+    updateElement('nocCapacityState', String(capacity.state || 'unknown').toUpperCase());
+    updateElement('nocCapacityUtilization', utilization);
+    updateElement('nocCapacityMode', capacity.mode || '-');
+    updateElement('nocCapacityTopTalker', capacity.top_talker || '-');
+    updateElement('nocClientCurrent', String(clientInventory.current_client_count ?? 0));
+    updateElement('nocClientUnknown', String(clientInventory.unknown_client_count ?? 0));
+    updateElement('nocClientUnauthorized', String(clientInventory.unauthorized_client_count ?? 0));
+    updateElement('nocClientMismatch', String(clientInventory.inventory_mismatch_count ?? 0));
 
     renderList(
         'rejectedStrongerActionsList',

--- a/azazel_edge_web/static/style.css
+++ b/azazel_edge_web/static/style.css
@@ -414,7 +414,7 @@ body.demo-overlay-active #healthSummaryLine {
 
 .noc-lower-grid {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 12px;
 }
 

--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -297,17 +297,30 @@
                                 <div class="noc-lower-grid">
                                     <div class="split-subcard">
                                         <div class="assistant-label">Service Health</div>
+                                        <div class="fact-list compact-list">
+                                            <div class="fact-item"><span>Assurance</span><strong id="nocServiceAssurance">-</strong></div>
+                                            <div class="fact-item"><span>Resolution</span><strong id="nocResolutionHealth">-</strong></div>
+                                        </div>
                                         <ul class="action-list" id="nocServiceList">
                                             <li>{{ tr('dashboard.no_service_summary', 'No service summary.') }}</li>
                                         </ul>
                                     </div>
                                     <div class="split-subcard">
-                                        <div class="assistant-label">Client Impact</div>
+                                        <div class="assistant-label">Capacity</div>
                                         <div class="fact-list compact-list">
-                                            <div class="fact-item"><span>Scope</span><strong id="nocClientScope">-</strong></div>
-                                            <div class="fact-item"><span>Segment</span><strong id="nocClientSegment">-</strong></div>
-                                            <div class="fact-item"><span>Captive Portal</span><strong id="nocClientPortal">-</strong></div>
-                                            <div class="fact-item"><span>DNS Mismatch</span><strong id="nocClientDnsMismatch">0</strong></div>
+                                            <div class="fact-item"><span>State</span><strong id="nocCapacityState">-</strong></div>
+                                            <div class="fact-item"><span>Utilization</span><strong id="nocCapacityUtilization">-</strong></div>
+                                            <div class="fact-item"><span>Mode</span><strong id="nocCapacityMode">-</strong></div>
+                                            <div class="fact-item"><span>Top Talker</span><strong id="nocCapacityTopTalker">-</strong></div>
+                                        </div>
+                                    </div>
+                                    <div class="split-subcard">
+                                        <div class="assistant-label">Client Inventory</div>
+                                        <div class="fact-list compact-list">
+                                            <div class="fact-item"><span>Current</span><strong id="nocClientCurrent">0</strong></div>
+                                            <div class="fact-item"><span>Unknown</span><strong id="nocClientUnknown">0</strong></div>
+                                            <div class="fact-item"><span>Unauthorized</span><strong id="nocClientUnauthorized">0</strong></div>
+                                            <div class="fact-item"><span>Mismatch</span><strong id="nocClientMismatch">0</strong></div>
                                         </div>
                                     </div>
                                 </div>

--- a/py/azazel_edge/arbiter/action.py
+++ b/py/azazel_edge/arbiter/action.py
@@ -131,7 +131,7 @@ class ActionArbiter:
             chosen.extend(noc.get('evidence_ids', []))
             chosen.extend(soc.get('evidence_ids', []))
         elif action == 'notify':
-            for key in ('availability', 'path_health', 'device_health'):
+            for key in ('availability', 'path_health', 'device_health', 'capacity_health', 'client_inventory_health'):
                 chosen.extend(noc.get(key, {}).get('evidence_ids', []))
             chosen.extend(soc.get('suspicion', {}).get('evidence_ids', []))
         else:
@@ -139,6 +139,8 @@ class ActionArbiter:
             chosen.extend(soc.get('blast_radius', {}).get('evidence_ids', []))
             chosen.extend(noc.get('availability', {}).get('evidence_ids', []))
             chosen.extend(noc.get('path_health', {}).get('evidence_ids', []))
+            chosen.extend(noc.get('capacity_health', {}).get('evidence_ids', []))
+            chosen.extend(noc.get('client_inventory_health', {}).get('evidence_ids', []))
         return sorted(dict.fromkeys(str(x) for x in chosen if str(x)))
 
     @staticmethod
@@ -203,6 +205,8 @@ class ActionArbiter:
             'availability_label': str(noc.get('availability', {}).get('label') or 'unknown'),
             'path_label': str(noc.get('path_health', {}).get('label') or 'unknown'),
             'device_label': str(noc.get('device_health', {}).get('label') or 'unknown'),
+            'capacity_label': str(noc.get('capacity_health', {}).get('label') or 'unknown'),
+            'client_inventory_label': str(noc.get('client_inventory_health', {}).get('label') or 'unknown'),
             'suspicion_label': str(soc.get('suspicion', {}).get('label') or 'unknown'),
             'suspicion_score': int(soc.get('suspicion', {}).get('score') or 0),
             'confidence_score': int(confidence_score or 0),

--- a/py/azazel_edge/evaluators/noc.py
+++ b/py/azazel_edge/evaluators/noc.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Iterable, List
 import ipaddress
 import re
 
+from azazel_edge.evidence_plane.noc_inventory import build_client_inventory
+
 
 DEFAULT_CONFIG: Dict[str, Dict[str, int]] = {
     'availability': {
@@ -41,6 +43,36 @@ DEFAULT_CONFIG: Dict[str, Dict[str, int]] = {
         'unknown_client_penalty_per_client': 5,
         'unknown_client_penalty_cap': 20,
     },
+    'capacity_health': {
+        'elevated_penalty': 15,
+        'congested_penalty': 35,
+        'unknown_penalty': 10,
+        'high_concentration_penalty': 10,
+    },
+    'client_inventory_health': {
+        'unknown_client_penalty_per_client': 8,
+        'unknown_client_penalty_cap': 24,
+        'unauthorized_client_penalty_per_client': 12,
+        'unauthorized_client_penalty_cap': 36,
+        'inventory_mismatch_penalty_per_client': 10,
+        'inventory_mismatch_penalty_cap': 30,
+        'stale_session_penalty_per_client': 5,
+        'stale_session_penalty_cap': 20,
+        'authorized_missing_penalty_per_client': 4,
+        'authorized_missing_penalty_cap': 16,
+    },
+    'service_health': {
+        'probe_failed_penalty': 20,
+        'window_degraded_penalty': 10,
+        'window_down_penalty': 25,
+        'collector_failure_penalty': 10,
+    },
+    'resolution_health': {
+        'probe_failed_penalty': 25,
+        'window_degraded_penalty': 10,
+        'window_failed_penalty': 30,
+        'collector_failure_penalty': 10,
+    },
 }
 
 
@@ -54,6 +86,14 @@ def _merge_config(config: Dict[str, Any] | None) -> Dict[str, Dict[str, int]]:
         for key, value in values.items():
             if isinstance(value, (int, float)):
                 merged[section][key] = int(value)
+    if merged['capacity_health']['elevated_penalty'] < 0 or merged['capacity_health']['congested_penalty'] < merged['capacity_health']['elevated_penalty']:
+        raise ValueError('invalid_capacity_health_config')
+    if merged['client_inventory_health']['unauthorized_client_penalty_per_client'] < merged['client_inventory_health']['unknown_client_penalty_per_client']:
+        raise ValueError('invalid_client_inventory_health_config')
+    if merged['service_health']['window_down_penalty'] < merged['service_health']['window_degraded_penalty']:
+        raise ValueError('invalid_service_health_config')
+    if merged['resolution_health']['window_failed_penalty'] < merged['resolution_health']['window_degraded_penalty']:
+        raise ValueError('invalid_resolution_health_config')
     return merged
 
 
@@ -140,6 +180,10 @@ class NocEvaluator:
         path_health = self._evaluate_path_health(by_kind)
         device_health = self._evaluate_device_health(by_kind)
         client_health = self._evaluate_client_health(by_kind, sot=sot, sot_diff=sot_diff)
+        capacity_health = self._evaluate_capacity_health(by_kind)
+        client_inventory_health = self._evaluate_client_inventory_health(payloads, by_kind, sot=sot, sot_diff=sot_diff)
+        service_health = self._evaluate_service_health(by_kind)
+        resolution_health = self._evaluate_resolution_health(by_kind)
         if sot_diff:
             path_health = self._apply_sot_diff_to_path_health(path_health, sot_diff)
 
@@ -151,7 +195,16 @@ class NocEvaluator:
             if 'sot_missing' not in client_health['reasons']:
                 client_health['reasons'].append('sot_missing')
 
-        dimensions = [availability, path_health, device_health, client_health]
+        dimensions = [
+            availability,
+            path_health,
+            device_health,
+            client_health,
+            capacity_health,
+            client_inventory_health,
+            service_health,
+            resolution_health,
+        ]
         worst_score = min(int(dim['score']) for dim in dimensions) if dimensions else 100
         if worst_score < 90:
             summary_reasons.extend(
@@ -161,6 +214,10 @@ class NocEvaluator:
                     ('path_health', path_health),
                     ('device_health', device_health),
                     ('client_health', client_health),
+                    ('capacity_health', capacity_health),
+                    ('client_inventory_health', client_inventory_health),
+                    ('service_health', service_health),
+                    ('resolution_health', resolution_health),
                 )
                 if dim['label'] != 'good'
             )
@@ -179,6 +236,10 @@ class NocEvaluator:
             'path_health': path_health,
             'device_health': device_health,
             'client_health': client_health,
+            'capacity_health': capacity_health,
+            'client_inventory_health': client_inventory_health,
+            'service_health': service_health,
+            'resolution_health': resolution_health,
             'summary': summary,
             'evidence_ids': sorted(dict.fromkeys(all_evidence_ids)),
         }
@@ -193,6 +254,10 @@ class NocEvaluator:
             'path_health': evaluation.get('path_health', {}),
             'device_health': evaluation.get('device_health', {}),
             'client_health': evaluation.get('client_health', {}),
+            'capacity_health': evaluation.get('capacity_health', {}),
+            'client_inventory_health': evaluation.get('client_inventory_health', {}),
+            'service_health': evaluation.get('service_health', {}),
+            'resolution_health': evaluation.get('resolution_health', {}),
             'evidence_ids': evaluation.get('evidence_ids', []),
         }
 
@@ -335,6 +400,36 @@ class NocEvaluator:
 
         return _make_dimension(score, reasons, evidence_ids)
 
+    def _evaluate_capacity_health(self, by_kind: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+        cfg = self.config['capacity_health']
+        score = 100
+        reasons: List[str] = []
+        evidence_ids: List[str] = []
+
+        for event in by_kind.get('capacity_pressure', []):
+            evidence_ids.append(str(event.get('event_id') or ''))
+            attrs = event.get('attrs', {})
+            state = str(attrs.get('state') or 'unknown')
+            mode = str(attrs.get('mode') or 'unknown')
+            if state == 'congested':
+                score -= cfg['congested_penalty']
+                reasons.append(f'capacity_congested:{mode}')
+            elif state == 'elevated':
+                score -= cfg['elevated_penalty']
+                reasons.append(f'capacity_elevated:{mode}')
+            elif state == 'unknown':
+                score -= cfg['unknown_penalty']
+                reasons.append(f'capacity_unknown:{mode}')
+
+        for event in by_kind.get('traffic_concentration', []):
+            evidence_ids.append(str(event.get('event_id') or ''))
+            attrs = event.get('attrs', {})
+            if bool(attrs.get('high_concentration')):
+                score -= cfg['high_concentration_penalty']
+                reasons.append('traffic_concentration_high')
+
+        return _make_dimension(score, reasons, evidence_ids)
+
     def _evaluate_client_health(self, by_kind: Dict[str, List[Dict[str, Any]]], sot: Dict[str, Any] | None, sot_diff: Dict[str, Any] | None = None) -> Dict[str, Any]:
         cfg = self.config['client_health']
         score = 100
@@ -397,6 +492,126 @@ class NocEvaluator:
                 score -= min(cfg['unknown_client_penalty_cap'], cfg['unknown_client_penalty_per_client'] * len(unauthorized_devices))
                 reasons.append('unauthorized_devices_present')
                 evidence_ids.extend(str(x) for x in sot_diff.get('evidence_ids', []) if str(x))
+
+        return _make_dimension(score, reasons, evidence_ids)
+
+    def _evaluate_client_inventory_health(
+        self,
+        payloads: List[Dict[str, Any]],
+        by_kind: Dict[str, List[Dict[str, Any]]],
+        sot: Dict[str, Any] | None,
+        sot_diff: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        cfg = self.config['client_inventory_health']
+        score = 100
+        reasons: List[str] = []
+        evidence_ids: List[str] = []
+
+        summary_attrs: Dict[str, Any] = {}
+        summaries = by_kind.get('client_inventory_summary', [])
+        if summaries:
+            summary_attrs = summaries[-1].get('attrs', {}) if isinstance(summaries[-1].get('attrs'), dict) else {}
+            evidence_ids.extend(str(item.get('event_id') or '') for item in summaries)
+        else:
+            inventory = build_client_inventory(payloads, sot=sot)
+            summary_attrs = inventory.get('summary', {})
+            evidence_ids.extend(str(x) for x in inventory.get('evidence_ids', []) if str(x))
+
+        unknown_count = int(summary_attrs.get('unknown_client_count') or 0)
+        unauthorized_count = int(summary_attrs.get('unauthorized_client_count') or 0)
+        mismatch_count = int(summary_attrs.get('inventory_mismatch_count') or 0)
+        stale_count = int(summary_attrs.get('stale_session_count') or 0)
+        missing_count = int(summary_attrs.get('authorized_missing_count') or 0)
+
+        if unknown_count:
+            score -= min(cfg['unknown_client_penalty_cap'], cfg['unknown_client_penalty_per_client'] * unknown_count)
+            reasons.append('client_inventory_unknown_present')
+        if unauthorized_count:
+            score -= min(cfg['unauthorized_client_penalty_cap'], cfg['unauthorized_client_penalty_per_client'] * unauthorized_count)
+            reasons.append('client_inventory_unauthorized_present')
+        if mismatch_count:
+            score -= min(cfg['inventory_mismatch_penalty_cap'], cfg['inventory_mismatch_penalty_per_client'] * mismatch_count)
+            reasons.append('client_inventory_mismatch')
+        if stale_count:
+            score -= min(cfg['stale_session_penalty_cap'], cfg['stale_session_penalty_per_client'] * stale_count)
+            reasons.append('client_inventory_stale_sessions')
+        if missing_count:
+            score -= min(cfg['authorized_missing_penalty_cap'], cfg['authorized_missing_penalty_per_client'] * missing_count)
+            reasons.append('client_inventory_authorized_missing')
+        if sot_diff:
+            unauthorized_devices = sot_diff.get('unauthorized_devices', []) if isinstance(sot_diff.get('unauthorized_devices'), list) else []
+            if unauthorized_devices and 'client_inventory_unauthorized_present' not in reasons:
+                reasons.append('client_inventory_unauthorized_present')
+
+        return _make_dimension(score, reasons, evidence_ids)
+
+    def _evaluate_service_health(self, by_kind: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+        cfg = self.config['service_health']
+        score = 100
+        reasons: List[str] = []
+        evidence_ids: List[str] = []
+
+        for event in by_kind.get('service_probe', []):
+            evidence_ids.append(str(event.get('event_id') or ''))
+            attrs = event.get('attrs', {})
+            name = str(attrs.get('name') or attrs.get('target') or event.get('subject') or 'unknown')
+            if not bool(attrs.get('reachable')):
+                score -= cfg['probe_failed_penalty']
+                reasons.append(f'service_probe_failed:{name}')
+
+        for event in by_kind.get('service_probe_window', []):
+            evidence_ids.append(str(event.get('event_id') or ''))
+            attrs = event.get('attrs', {})
+            name = str(attrs.get('name') or attrs.get('target') or event.get('subject') or 'unknown')
+            state = str(attrs.get('state') or 'unknown')
+            if state == 'degraded':
+                score -= cfg['window_degraded_penalty']
+                reasons.append(f'service_window_degraded:{name}')
+            elif state == 'down':
+                score -= cfg['window_down_penalty']
+                reasons.append(f'service_window_down:{name}')
+
+        for event in by_kind.get('collector_failure', []):
+            collector = str(event.get('attrs', {}).get('collector') or '')
+            if collector == 'service_probes':
+                evidence_ids.append(str(event.get('event_id') or ''))
+                score -= cfg['collector_failure_penalty']
+                reasons.append('collector_failure:service_probes')
+
+        return _make_dimension(score, reasons, evidence_ids)
+
+    def _evaluate_resolution_health(self, by_kind: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+        cfg = self.config['resolution_health']
+        score = 100
+        reasons: List[str] = []
+        evidence_ids: List[str] = []
+
+        for event in by_kind.get('resolution_probe', []):
+            evidence_ids.append(str(event.get('event_id') or ''))
+            attrs = event.get('attrs', {})
+            name = str(attrs.get('name') or event.get('subject') or 'unknown')
+            if not bool(attrs.get('resolved')):
+                score -= cfg['probe_failed_penalty']
+                reasons.append(f'resolution_failed:{name}')
+
+        for event in by_kind.get('resolution_probe_window', []):
+            evidence_ids.append(str(event.get('event_id') or ''))
+            attrs = event.get('attrs', {})
+            name = str(attrs.get('name') or event.get('subject') or 'unknown')
+            state = str(attrs.get('state') or 'unknown')
+            if state == 'degraded':
+                score -= cfg['window_degraded_penalty']
+                reasons.append(f'resolution_window_degraded:{name}')
+            elif state == 'failed':
+                score -= cfg['window_failed_penalty']
+                reasons.append(f'resolution_window_failed:{name}')
+
+        for event in by_kind.get('collector_failure', []):
+            collector = str(event.get('attrs', {}).get('collector') or '')
+            if collector == 'resolution_probes':
+                evidence_ids.append(str(event.get('event_id') or ''))
+                score -= cfg['collector_failure_penalty']
+                reasons.append('collector_failure:resolution_probes')
 
         return _make_dimension(score, reasons, evidence_ids)
 

--- a/py/azazel_edge/evidence_plane/__init__.py
+++ b/py/azazel_edge/evidence_plane/__init__.py
@@ -1,6 +1,7 @@
 from .schema import EvidenceEvent, REQUIRED_FIELDS, iso_utc_now, make_event_id
 from .bus import EvidenceBus
-from .flow_min import adapt_flow_record, iter_flow_jsonl, read_flow_jsonl
+from .flow_min import adapt_flow_record, iter_flow_jsonl, read_flow_jsonl, summarize_flow_events
+from .noc_inventory import build_client_inventory, build_client_inventory_events
 from .suricata import adapt_suricata_record, iter_suricata_jsonl, read_suricata_jsonl
 from .noc_probe import NocProbeAdapter
 from .syslog_min import adapt_syslog_line
@@ -15,6 +16,9 @@ __all__ = [
     'adapt_flow_record',
     'iter_flow_jsonl',
     'read_flow_jsonl',
+    'summarize_flow_events',
+    'build_client_inventory',
+    'build_client_inventory_events',
     'adapt_suricata_record',
     'iter_suricata_jsonl',
     'read_suricata_jsonl',

--- a/py/azazel_edge/evidence_plane/flow_min.py
+++ b/py/azazel_edge/evidence_plane/flow_min.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
-from .schema import EvidenceEvent
+from .schema import EvidenceEvent, iso_utc_now
 
 
 def adapt_flow_record(record: Dict[str, object]) -> EvidenceEvent:
@@ -55,6 +55,83 @@ def adapt_flow_record(record: Dict[str, object]) -> EvidenceEvent:
     )
 
 
+def summarize_flow_events(events: Iterable[EvidenceEvent | Dict[str, object]]) -> Optional[EvidenceEvent]:
+    flow_rows: List[Dict[str, object]] = []
+    for event in events:
+        payload = event.to_dict() if hasattr(event, 'to_dict') else (dict(event) if isinstance(event, dict) else {})
+        if str(payload.get('kind') or '') != 'flow_summary':
+            continue
+        attrs = payload.get('attrs', {})
+        if not isinstance(attrs, dict):
+            continue
+        flow_rows.append(attrs)
+    if not flow_rows:
+        return None
+
+    total_bytes = 0
+    total_packets = 0
+    by_source: Dict[str, Dict[str, int]] = {}
+    by_service: Dict[str, Dict[str, int]] = {}
+    latest_ts = ''
+    for row in flow_rows:
+        src_ip = str(row.get('src_ip') or '-')
+        proto = str(row.get('proto') or row.get('app_proto') or 'unknown').upper()
+        service = f"{row.get('app_proto') or proto}:{int(row.get('dst_port') or 0)}/{proto}"
+        bytes_total = int(row.get('bytes_toserver') or 0) + int(row.get('bytes_toclient') or 0)
+        packets_total = int(row.get('pkts_toserver') or 0) + int(row.get('pkts_toclient') or 0)
+        total_bytes += bytes_total
+        total_packets += packets_total
+        by_source.setdefault(src_ip, {'bytes': 0, 'packets': 0, 'flows': 0})
+        by_source[src_ip]['bytes'] += bytes_total
+        by_source[src_ip]['packets'] += packets_total
+        by_source[src_ip]['flows'] += 1
+        by_service.setdefault(service, {'bytes': 0, 'packets': 0, 'flows': 0})
+        by_service[service]['bytes'] += bytes_total
+        by_service[service]['packets'] += packets_total
+        by_service[service]['flows'] += 1
+
+    top_sources = [
+        {'src_ip': key, **stats}
+        for key, stats in sorted(by_source.items(), key=lambda item: (-item[1]['bytes'], item[0]))[:3]
+    ]
+    top_services = [
+        {'service': key, **stats}
+        for key, stats in sorted(by_service.items(), key=lambda item: (-item[1]['bytes'], item[0]))[:3]
+    ]
+    top_source_bytes = int(top_sources[0]['bytes']) if top_sources else 0
+    top_service_bytes = int(top_services[0]['bytes']) if top_services else 0
+    max_ratio = max(
+        (top_source_bytes / total_bytes) if total_bytes > 0 else 0.0,
+        (top_service_bytes / total_bytes) if total_bytes > 0 else 0.0,
+    )
+    severity = 0
+    if max_ratio >= 0.8:
+        severity = 55
+    elif max_ratio >= 0.6:
+        severity = 35
+    attrs = {
+        'total_flows': len(flow_rows),
+        'total_bytes': total_bytes,
+        'total_packets': total_packets,
+        'top_sources': top_sources,
+        'top_services': top_services,
+        'source_concentration_ratio': round((top_source_bytes / total_bytes), 4) if total_bytes > 0 else 0.0,
+        'service_concentration_ratio': round((top_service_bytes / total_bytes), 4) if total_bytes > 0 else 0.0,
+        'max_concentration_ratio': round(max_ratio, 4),
+        'high_concentration': max_ratio >= 0.6,
+    }
+    return EvidenceEvent.build(
+        ts=latest_ts or iso_utc_now(),
+        source='flow_min',
+        kind='traffic_concentration',
+        subject='flow-window',
+        severity=severity,
+        confidence=0.8,
+        attrs=attrs,
+        status='warn' if severity > 0 else 'info',
+    )
+
+
 def iter_flow_jsonl(path: Path) -> Iterable[EvidenceEvent]:
     if not path.exists():
         return []
@@ -78,4 +155,8 @@ def iter_flow_jsonl(path: Path) -> Iterable[EvidenceEvent]:
 
 def read_flow_jsonl(path: Path, limit: Optional[int] = None) -> List[EvidenceEvent]:
     items = list(iter_flow_jsonl(path))
-    return items[-limit:] if isinstance(limit, int) and limit > 0 else items
+    items = items[-limit:] if isinstance(limit, int) and limit > 0 else items
+    summary = summarize_flow_events(items)
+    if summary is not None:
+        items.append(summary)
+    return items

--- a/py/azazel_edge/evidence_plane/noc_inventory.py
+++ b/py/azazel_edge/evidence_plane/noc_inventory.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import ipaddress
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from .schema import EvidenceEvent, iso_utc_now
+
+
+def _event_payloads(events: Iterable[Any]) -> List[Dict[str, Any]]:
+    payloads: List[Dict[str, Any]] = []
+    for event in events:
+        if hasattr(event, 'to_dict'):
+            payload = event.to_dict()
+        elif isinstance(event, dict):
+            payload = dict(event)
+        else:
+            continue
+        if isinstance(payload.get('attrs'), dict):
+            payloads.append(payload)
+    return payloads
+
+
+def _parse_ts(value: str) -> Optional[datetime]:
+    raw = str(value or '').strip()
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+
+def _epoch(value: str) -> Optional[float]:
+    parsed = _parse_ts(value)
+    if parsed is None:
+        return None
+    return parsed.timestamp()
+
+
+def _network_id(networks: List[Dict[str, Any]], ip: str) -> str:
+    try:
+        addr = ipaddress.ip_address(str(ip or ''))
+    except ValueError:
+        return ''
+    for item in networks:
+        try:
+            cidr = ipaddress.ip_network(str(item.get('cidr') or ''), strict=False)
+        except ValueError:
+            continue
+        if addr in cidr:
+            return str(item.get('id') or '')
+    return ''
+
+
+@dataclass
+class _SessionRecord:
+    key: str
+    mac: str = ''
+    ip: str = ''
+    hostname: str = ''
+    interface_or_segment: str = ''
+    first_seen: str = ''
+    last_seen: str = ''
+    sources_present: set[str] = field(default_factory=set)
+    service_hints: set[str] = field(default_factory=set)
+    evidence_ids: set[str] = field(default_factory=set)
+    source_states: Dict[str, str] = field(default_factory=dict)
+    arp_state: str = ''
+
+    def merge_ts(self, ts: str) -> None:
+        if not ts:
+            return
+        if not self.first_seen:
+            self.first_seen = ts
+        else:
+            current = _epoch(self.first_seen)
+            candidate = _epoch(ts)
+            if current is None or (candidate is not None and candidate < current):
+                self.first_seen = ts
+        if not self.last_seen:
+            self.last_seen = ts
+        else:
+            current = _epoch(self.last_seen)
+            candidate = _epoch(ts)
+            if current is None or (candidate is not None and candidate > current):
+                self.last_seen = ts
+
+
+def _device_lookup(sot: Dict[str, Any] | None) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]], List[Dict[str, Any]]]:
+    if not isinstance(sot, dict):
+        return {}, {}, []
+    by_ip: Dict[str, Dict[str, Any]] = {}
+    by_mac: Dict[str, Dict[str, Any]] = {}
+    devices = sot.get('devices', []) if isinstance(sot.get('devices'), list) else []
+    for item in devices:
+        if not isinstance(item, dict):
+            continue
+        ip = str(item.get('ip') or '')
+        mac = str(item.get('mac') or '').lower()
+        if ip:
+            by_ip[ip] = item
+        if mac:
+            by_mac[mac] = item
+    networks = sot.get('networks', []) if isinstance(sot.get('networks'), list) else []
+    return by_ip, by_mac, [item for item in networks if isinstance(item, dict)]
+
+
+def build_client_inventory(
+    events: Iterable[Any],
+    sot: Dict[str, Any] | None = None,
+    stale_after_sec: int = 900,
+    new_after_sec: int = 300,
+    now_ts: str | None = None,
+) -> Dict[str, Any]:
+    payloads = _event_payloads(events)
+    by_ip, by_mac, networks = _device_lookup(sot)
+    sessions: Dict[str, _SessionRecord] = {}
+    now_norm = str(now_ts or iso_utc_now())
+    now_epoch = _epoch(now_norm) or datetime.now(timezone.utc).timestamp()
+    seen_sot_keys: set[str] = set()
+
+    def ensure_session(key: str) -> _SessionRecord:
+        if key not in sessions:
+            sessions[key] = _SessionRecord(key=key)
+        return sessions[key]
+
+    def find_session(ip: str, mac: str = '') -> Optional[_SessionRecord]:
+        for item in sessions.values():
+            if mac and item.mac and item.mac == mac:
+                return item
+            if ip and item.ip and item.ip == ip:
+                return item
+        return None
+
+    for payload in payloads:
+        kind = str(payload.get('kind') or '')
+        attrs = payload.get('attrs', {})
+        ts = str(payload.get('ts') or '')
+        evidence_id = str(payload.get('event_id') or '')
+        ip = ''
+        mac = ''
+        source_name = ''
+        iface = ''
+        hostname = ''
+        if kind == 'dhcp_lease':
+            ip = str(attrs.get('ip') or '')
+            mac = str(attrs.get('mac') or '').lower()
+            iface = str(attrs.get('interface') or '')
+            hostname = str(attrs.get('hostname') or '')
+            source_name = 'dhcp'
+        elif kind == 'arp_entry':
+            ip = str(attrs.get('ip') or '')
+            mac = str(attrs.get('mac') or '').lower()
+            iface = str(attrs.get('dev') or attrs.get('interface') or '')
+            source_name = 'arp'
+        elif kind == 'flow_summary':
+            ip = str(attrs.get('src_ip') or '')
+            if not ip:
+                continue
+            service_hint = f"{attrs.get('app_proto') or attrs.get('proto') or 'unknown'}:{int(attrs.get('dst_port') or 0)}"
+            source_name = 'flow'
+            session = find_session(ip) or ensure_session(f'{ip}|flow')
+            if not session.ip:
+                session.ip = ip
+            if service_hint:
+                session.service_hints.add(service_hint)
+            if not session.interface_or_segment:
+                session.interface_or_segment = _network_id(networks, ip) or 'unknown'
+            session.sources_present.add(source_name)
+            if evidence_id:
+                session.evidence_ids.add(evidence_id)
+            session.merge_ts(ts)
+            continue
+        else:
+            continue
+
+        session = find_session(ip, mac=mac) or ensure_session(mac or f'{ip}|{iface or "unknown"}')
+        session.ip = session.ip or ip
+        session.mac = session.mac or mac
+        session.hostname = session.hostname or hostname
+        session.interface_or_segment = session.interface_or_segment or iface or _network_id(networks, ip) or 'unknown'
+        if kind == 'arp_entry':
+            session.arp_state = str(attrs.get('state') or '')
+        session.sources_present.add(source_name)
+        session.source_states[source_name] = str(attrs.get('state') or '')
+        if evidence_id:
+            session.evidence_ids.add(evidence_id)
+        session.merge_ts(ts)
+
+    rows: List[Dict[str, Any]] = []
+    counts = {
+        'current_client_count': 0,
+        'new_client_count': 0,
+        'unknown_client_count': 0,
+        'unauthorized_client_count': 0,
+        'inventory_mismatch_count': 0,
+        'stale_session_count': 0,
+        'authorized_missing_count': 0,
+    }
+
+    for session in sessions.values():
+        device = by_mac.get(session.mac) or by_ip.get(session.ip) or {}
+        device_key = str(device.get('id') or device.get('ip') or device.get('mac') or '')
+        if device_key:
+            seen_sot_keys.add(device_key)
+        session_state = 'unknown_present'
+        if device:
+            if bool(device.get('authorized', True)):
+                session_state = 'authorized_present'
+            else:
+                session_state = 'unauthorized_present'
+        mismatch = 'dhcp' in session.sources_present and 'arp' not in session.sources_present
+        if mismatch:
+            session_state = 'inventory_mismatch'
+        last_seen_epoch = _epoch(session.last_seen) or now_epoch
+        if now_epoch - last_seen_epoch > max(60, stale_after_sec):
+            session_state = 'stale_session'
+        if session_state == 'authorized_present':
+            counts['current_client_count'] += 1
+        elif session_state == 'unknown_present':
+            counts['current_client_count'] += 1
+            counts['unknown_client_count'] += 1
+        elif session_state == 'unauthorized_present':
+            counts['current_client_count'] += 1
+            counts['unauthorized_client_count'] += 1
+        elif session_state == 'inventory_mismatch':
+            counts['current_client_count'] += 1
+            counts['inventory_mismatch_count'] += 1
+        elif session_state == 'stale_session':
+            counts['stale_session_count'] += 1
+        first_seen_epoch = _epoch(session.first_seen) or now_epoch
+        if now_epoch - first_seen_epoch <= max(60, new_after_sec):
+            counts['new_client_count'] += 1
+        rows.append({
+            'session_key': session.key,
+            'mac': session.mac,
+            'ip': session.ip,
+            'hostname': session.hostname,
+            'interface_or_segment': session.interface_or_segment or 'unknown',
+            'first_seen': session.first_seen or now_norm,
+            'last_seen': session.last_seen or now_norm,
+            'sources_present': sorted(session.sources_present),
+            'service_hints': sorted(session.service_hints),
+            'sot_status': 'known' if device else 'unknown',
+            'session_state': session_state,
+            'arp_state': session.arp_state,
+            'evidence_ids': sorted(session.evidence_ids),
+        })
+
+    if isinstance(sot, dict) and isinstance(sot.get('devices'), list):
+        for item in sot.get('devices', []):
+            if not isinstance(item, dict):
+                continue
+            key = str(item.get('id') or item.get('ip') or item.get('mac') or '')
+            if not key or key in seen_sot_keys:
+                continue
+            counts['authorized_missing_count'] += 1
+            rows.append({
+                'session_key': f'sot:{key}',
+                'mac': str(item.get('mac') or '').lower(),
+                'ip': str(item.get('ip') or ''),
+                'hostname': str(item.get('hostname') or ''),
+                'interface_or_segment': _network_id(networks, str(item.get('ip') or '')) or 'expected',
+                'first_seen': '',
+                'last_seen': '',
+                'sources_present': [],
+                'service_hints': [],
+                'sot_status': 'known',
+                'session_state': 'authorized_missing',
+                'arp_state': '',
+                'evidence_ids': [],
+            })
+
+    rows.sort(key=lambda item: (str(item.get('session_state') or ''), str(item.get('ip') or ''), str(item.get('mac') or '')))
+    evidence_ids = sorted({
+        evidence_id
+        for row in rows
+        for evidence_id in row.get('evidence_ids', [])
+        if str(evidence_id)
+    })
+    return {
+        'summary': counts,
+        'sessions': rows,
+        'evidence_ids': evidence_ids,
+    }
+
+
+def build_client_inventory_events(
+    events: Iterable[Any],
+    sot: Dict[str, Any] | None = None,
+    stale_after_sec: int = 900,
+    new_after_sec: int = 300,
+    now_ts: str | None = None,
+) -> List[EvidenceEvent]:
+    inventory = build_client_inventory(
+        events,
+        sot=sot,
+        stale_after_sec=stale_after_sec,
+        new_after_sec=new_after_sec,
+        now_ts=now_ts,
+    )
+    ts = str(now_ts or iso_utc_now())
+    output: List[EvidenceEvent] = []
+    for row in inventory['sessions']:
+        state = str(row.get('session_state') or 'unknown_present')
+        severity = 0
+        if state in {'unauthorized_present', 'inventory_mismatch'}:
+            severity = 60
+        elif state in {'unknown_present', 'stale_session', 'authorized_missing'}:
+            severity = 35
+        output.append(EvidenceEvent.build(
+            ts=ts,
+            source='noc_probe',
+            kind='client_session',
+            subject=str(row.get('ip') or row.get('mac') or row.get('session_key') or 'client'),
+            severity=severity,
+            confidence=0.85,
+            attrs=row,
+            status='warn' if severity > 0 else 'info',
+            evidence_refs=list(row.get('evidence_ids') or []),
+        ))
+    summary = dict(inventory['summary'])
+    summary['sessions'] = inventory['sessions'][:10]
+    output.append(EvidenceEvent.build(
+        ts=ts,
+        source='noc_probe',
+        kind='client_inventory_summary',
+        subject='client_inventory',
+        severity=60 if summary.get('unauthorized_client_count', 0) or summary.get('inventory_mismatch_count', 0) else (35 if summary.get('unknown_client_count', 0) or summary.get('stale_session_count', 0) else 0),
+        confidence=0.9,
+        attrs=summary,
+        status='warn' if summary.get('unauthorized_client_count', 0) or summary.get('inventory_mismatch_count', 0) or summary.get('unknown_client_count', 0) else 'info',
+        evidence_refs=inventory['evidence_ids'],
+    ))
+    return output

--- a/py/azazel_edge/evidence_plane/noc_probe.py
+++ b/py/azazel_edge/evidence_plane/noc_probe.py
@@ -49,6 +49,25 @@ def _cpu_mem_temp_severity(metrics: Dict[str, Any]) -> int:
     return severity
 
 
+def _resolution_severity(result: Dict[str, Any]) -> int:
+    return 0 if bool(result.get('resolved')) else 60
+
+
+def _service_probe_severity(result: Dict[str, Any]) -> int:
+    return 0 if bool(result.get('reachable')) else 60
+
+
+def _window_severity(state: str) -> int:
+    normalized = str(state or 'unknown').lower()
+    if normalized in {'normal', 'healthy', 'resolved'}:
+        return 0
+    if normalized in {'degraded'}:
+        return 30
+    if normalized in {'down', 'failed'}:
+        return 65
+    return 15
+
+
 class NocProbeAdapter:
     def __init__(self, up_interface: str = 'eth1', down_interface: str = 'usb0', gateway_ip: str = ''):
         self.up_interface = up_interface
@@ -98,6 +117,22 @@ class NocProbeAdapter:
                 status='ok' if sev == 0 else 'fail',
             ))
 
+        path_probe_window = snapshot.get('path_probe_window') if isinstance(snapshot.get('path_probe_window'), list) else []
+        for row in path_probe_window:
+            if not isinstance(row, dict):
+                continue
+            sev = _window_severity(str(row.get('state') or 'unknown'))
+            events.append(EvidenceEvent.build(
+                ts=ts,
+                source='noc_probe',
+                kind='path_probe_window',
+                subject=str(row.get('target') or host),
+                severity=sev,
+                confidence=0.9,
+                attrs=row,
+                status='ok' if sev == 0 else 'warn',
+            ))
+
         iface_stats = snapshot.get('iface_stats') if isinstance(snapshot.get('iface_stats'), list) else []
         for row in iface_stats:
             if not isinstance(row, dict):
@@ -108,6 +143,110 @@ class NocProbeAdapter:
                 source='noc_probe',
                 kind='iface_stats',
                 subject=str(row.get('interface') or host),
+                severity=sev,
+                confidence=0.9,
+                attrs=row,
+                status='ok' if sev == 0 else 'warn',
+            ))
+
+        capacity_samples = snapshot.get('capacity_samples') if isinstance(snapshot.get('capacity_samples'), list) else []
+        for row in capacity_samples:
+            if not isinstance(row, dict):
+                continue
+            sample_state = str(row.get('sample_state') or 'unknown')
+            sev = 0 if sample_state == 'sampled' else 10
+            events.append(EvidenceEvent.build(
+                ts=ts,
+                source='noc_probe',
+                kind='capacity_sample',
+                subject=str(row.get('interface') or host),
+                severity=sev,
+                confidence=0.85,
+                attrs=row,
+                status='info' if sev == 0 else 'warn',
+            ))
+
+        capacity_pressure = snapshot.get('capacity_pressure') if isinstance(snapshot.get('capacity_pressure'), list) else []
+        for row in capacity_pressure:
+            if not isinstance(row, dict):
+                continue
+            state = str(row.get('state') or 'unknown')
+            sev = 0
+            if state == 'elevated':
+                sev = 35
+            elif state == 'congested':
+                sev = 65
+            elif state == 'unknown':
+                sev = 20
+            events.append(EvidenceEvent.build(
+                ts=ts,
+                source='noc_probe',
+                kind='capacity_pressure',
+                subject=str(row.get('interface') or host),
+                severity=sev,
+                confidence=0.9,
+                attrs=row,
+                status='warn' if sev > 0 else 'info',
+            ))
+
+        resolution_probes = snapshot.get('resolution_probes') if isinstance(snapshot.get('resolution_probes'), list) else []
+        for row in resolution_probes:
+            if not isinstance(row, dict):
+                continue
+            sev = _resolution_severity(row)
+            events.append(EvidenceEvent.build(
+                ts=ts,
+                source='noc_probe',
+                kind='resolution_probe',
+                subject=str(row.get('name') or host),
+                severity=sev,
+                confidence=0.9,
+                attrs=row,
+                status='ok' if sev == 0 else 'fail',
+            ))
+
+        resolution_probe_window = snapshot.get('resolution_probe_window') if isinstance(snapshot.get('resolution_probe_window'), list) else []
+        for row in resolution_probe_window:
+            if not isinstance(row, dict):
+                continue
+            sev = _window_severity(str(row.get('state') or 'unknown'))
+            events.append(EvidenceEvent.build(
+                ts=ts,
+                source='noc_probe',
+                kind='resolution_probe_window',
+                subject=str(row.get('name') or host),
+                severity=sev,
+                confidence=0.9,
+                attrs=row,
+                status='ok' if sev == 0 else 'warn',
+            ))
+
+        service_probes = snapshot.get('service_probes') if isinstance(snapshot.get('service_probes'), list) else []
+        for row in service_probes:
+            if not isinstance(row, dict):
+                continue
+            sev = _service_probe_severity(row)
+            events.append(EvidenceEvent.build(
+                ts=ts,
+                source='noc_probe',
+                kind='service_probe',
+                subject=str(row.get('name') or row.get('target') or host),
+                severity=sev,
+                confidence=0.9,
+                attrs=row,
+                status='ok' if sev == 0 else 'fail',
+            ))
+
+        service_probe_window = snapshot.get('service_probe_window') if isinstance(snapshot.get('service_probe_window'), list) else []
+        for row in service_probe_window:
+            if not isinstance(row, dict):
+                continue
+            sev = _window_severity(str(row.get('state') or 'unknown'))
+            events.append(EvidenceEvent.build(
+                ts=ts,
+                source='noc_probe',
+                kind='service_probe_window',
+                subject=str(row.get('name') or row.get('target') or host),
                 severity=sev,
                 confidence=0.9,
                 attrs=row,

--- a/py/azazel_edge/evidence_plane/service.py
+++ b/py/azazel_edge/evidence_plane/service.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional
 
 from .bus import EvidenceBus
 from .flow_min import read_flow_jsonl
+from .noc_inventory import build_client_inventory_events
 from .noc_probe import NocProbeAdapter
 from .schema import EvidenceEvent
 from .suricata import read_suricata_jsonl
@@ -26,7 +27,9 @@ class EvidencePlaneService:
 
     def dispatch_noc_probe(self, adapter: Optional[NocProbeAdapter] = None, snapshot: Optional[Dict[str, object]] = None) -> List[Dict[str, object]]:
         probe = adapter or NocProbeAdapter()
-        return self.dispatch_events(probe.collect(snapshot=snapshot if isinstance(snapshot, dict) else None))
+        events = probe.collect(snapshot=snapshot if isinstance(snapshot, dict) else None)
+        events.extend(build_client_inventory_events(events))
+        return self.dispatch_events(events)
 
     def dispatch_syslog_line(self, line: str) -> Dict[str, object]:
         return self.bus.publish(adapt_syslog_line(line))

--- a/py/azazel_edge/explanations/decision.py
+++ b/py/azazel_edge/explanations/decision.py
@@ -51,6 +51,16 @@ class DecisionExplainer:
             'noc_status': noc_summary.get('status', 'unknown'),
             'soc_status': soc_summary.get('status', 'unknown'),
             'target': target,
+            'noc_dimensions': {
+                'availability': (noc.get('availability') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
+                'path_health': (noc.get('path_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
+                'device_health': (noc.get('device_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
+                'client_health': (noc.get('client_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
+                'capacity_health': (noc.get('capacity_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
+                'client_inventory_health': (noc.get('client_inventory_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
+                'service_health': (noc.get('service_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
+                'resolution_health': (noc.get('resolution_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
+            },
             'ti_matches': soc_summary.get('ti_matches', []),
             'attack_candidates': attack_candidates,
             'sigma_hits': sigma_hits,
@@ -172,6 +182,10 @@ class DecisionExplainer:
             checks.append('review_soc_evidence_and_attack_candidates')
         if str(noc_summary.get('status') or '') in {'poor', 'critical'}:
             checks.append('confirm_noc_stability_before_escalation')
+        if any(str(noc_summary.get('reasons') or '').find(token) >= 0 for token in ('capacity_health', 'client_inventory_health')):
+            checks.append('review_capacity_and_client_inventory_summary')
+        if any(str(noc_summary.get('reasons') or '').find(token) >= 0 for token in ('service_health', 'resolution_health')):
+            checks.append('review_path_and_service_assurance')
         if int(client_impact.get('critical_client_count') or 0) > 0:
             checks.append('confirm_critical_client_owner_before_control')
         return checks

--- a/py/azazel_edge/sensors/noc_monitor.py
+++ b/py/azazel_edge/sensors/noc_monitor.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import re
 import socket
+import statistics
 import subprocess
 import time
+from collections import deque
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 from .system_metrics import (
     get_cpu_temperature,
     get_cpu_usage,
+    get_link_speed_mbps,
     get_memory_usage,
     get_network_stats,
 )
@@ -27,6 +32,11 @@ SERVICE_TARGETS = {
     'opencanary': 'opencanary',
 }
 EXTERNAL_PATH_TARGETS = ('1.1.1.1', '8.8.8.8')
+DEFAULT_RESOLUTION_TARGETS = ('example.com', 'openai.com')
+DEFAULT_SERVICE_PROBE_TARGETS = (
+    {'name': 'resolver-tcp', 'probe': 'tcp', 'host': '1.1.1.1', 'port': 53, 'timeout_sec': 2.0},
+    {'name': 'https-head', 'probe': 'http', 'url': 'https://example.com', 'method': 'HEAD', 'timeout_sec': 3.0},
+)
 
 
 def _run(cmd: List[str], timeout: float = 3.0) -> str:
@@ -115,6 +125,7 @@ def collect_iface_stats(interfaces: Iterable[str]) -> List[Dict[str, Any]]:
             'carrier': int((base / 'carrier').read_text(encoding='utf-8').strip()) if (base / 'carrier').exists() else 0,
             'mtu': int((base / 'mtu').read_text(encoding='utf-8').strip()) if (base / 'mtu').exists() else 0,
             'mac': (base / 'address').read_text(encoding='utf-8').strip().lower() if (base / 'address').exists() else '',
+            'speed_mbps': int(get_link_speed_mbps(iface) or 0),
         }
         row.update(get_network_stats(iface))
         rows.append(row)
@@ -192,6 +203,118 @@ def collect_service_health(targets: Dict[str, str] = SERVICE_TARGETS) -> Dict[st
     return result
 
 
+def collect_dns_resolution(name: str, timeout_sec: float = 2.0) -> Dict[str, Any]:
+    started = time.time()
+    try:
+        answers = socket.getaddrinfo(name, None, proto=socket.IPPROTO_TCP)
+        latency_ms = round((time.time() - started) * 1000.0, 1)
+        resolved = sorted({str(item[4][0]) for item in answers if item and len(item) >= 5 and item[4]})
+        return {
+            'name': name,
+            'resolved': bool(resolved),
+            'answers': resolved[:4],
+            'latency_ms': latency_ms,
+            'error': '',
+            'probe': 'dns',
+        }
+    except Exception as exc:
+        return {
+            'name': name,
+            'resolved': False,
+            'answers': [],
+            'latency_ms': round((time.time() - started) * 1000.0, 1),
+            'error': str(exc),
+            'probe': 'dns',
+        }
+
+
+def collect_tcp_connect(host: str, port: int, timeout_sec: float = 2.0) -> Dict[str, Any]:
+    started = time.time()
+    try:
+        with socket.create_connection((host, int(port)), timeout=timeout_sec):
+            pass
+        return {
+            'target': f'{host}:{int(port)}',
+            'host': host,
+            'port': int(port),
+            'reachable': True,
+            'latency_ms': round((time.time() - started) * 1000.0, 1),
+            'error': '',
+            'probe': 'tcp',
+        }
+    except Exception as exc:
+        return {
+            'target': f'{host}:{int(port)}',
+            'host': host,
+            'port': int(port),
+            'reachable': False,
+            'latency_ms': round((time.time() - started) * 1000.0, 1),
+            'error': str(exc),
+            'probe': 'tcp',
+        }
+
+
+def collect_http_probe(url: str, method: str = 'HEAD', timeout_sec: float = 3.0) -> Dict[str, Any]:
+    started = time.time()
+    parsed = urlparse(str(url or '').strip())
+    if parsed.scheme not in {'http', 'https'} or not parsed.netloc:
+        return {
+            'target': url,
+            'url': url,
+            'reachable': False,
+            'status_code': 0,
+            'latency_ms': 0.0,
+            'error': 'invalid_url',
+            'probe': 'http',
+            'method': method,
+        }
+    request = Request(url=str(url), method=str(method or 'HEAD').upper())
+    try:
+        with urlopen(request, timeout=timeout_sec) as response:
+            code = int(getattr(response, 'status', 0) or 0)
+        return {
+            'target': url,
+            'url': url,
+            'reachable': 200 <= code < 500,
+            'status_code': code,
+            'latency_ms': round((time.time() - started) * 1000.0, 1),
+            'error': '',
+            'probe': 'http',
+            'method': method,
+        }
+    except Exception as exc:
+        return {
+            'target': url,
+            'url': url,
+            'reachable': False,
+            'status_code': 0,
+            'latency_ms': round((time.time() - started) * 1000.0, 1),
+            'error': str(exc),
+            'probe': 'http',
+            'method': method,
+        }
+
+
+def collect_service_probes(targets: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for target in targets:
+        if not isinstance(target, dict):
+            continue
+        name = str(target.get('name') or target.get('target') or '').strip()
+        probe = str(target.get('probe') or 'tcp').strip().lower()
+        if probe == 'http':
+            row = collect_http_probe(
+                str(target.get('url') or ''),
+                method=str(target.get('method') or 'HEAD'),
+                timeout_sec=float(target.get('timeout_sec') or 3.0),
+            )
+        else:
+            row = collect_tcp_connect(str(target.get('host') or ''), int(target.get('port') or 0), timeout_sec=float(target.get('timeout_sec') or 2.0))
+        row['name'] = name or row.get('target') or probe
+        rows.append(row)
+    return rows
+
+
 class LightweightNocMonitor:
     def __init__(
         self,
@@ -199,11 +322,194 @@ class LightweightNocMonitor:
         down_interface: str = 'usb0',
         gateway_ip: str = '',
         extra_interfaces: Optional[List[str]] = None,
+        capacity_window_size: int = 4,
+        probe_window_size: int = 4,
+        elevated_utilization_pct: int = 70,
+        congested_utilization_pct: int = 85,
+        resolution_targets: Optional[List[str]] = None,
+        service_probe_targets: Optional[List[Dict[str, Any]]] = None,
     ):
+        if int(capacity_window_size) < 2:
+            raise ValueError('capacity_window_size_must_be_at_least_2')
+        if int(probe_window_size) < 2:
+            raise ValueError('probe_window_size_must_be_at_least_2')
+        if not (0 < int(elevated_utilization_pct) < int(congested_utilization_pct) <= 100):
+            raise ValueError('invalid_capacity_thresholds')
         self.up_interface = up_interface
         self.down_interface = down_interface
         self.gateway_ip = gateway_ip
         self.extra_interfaces = [str(x).strip() for x in (extra_interfaces or []) if str(x).strip()]
+        self.capacity_window_size = int(capacity_window_size)
+        self.probe_window_size = int(probe_window_size)
+        self.elevated_utilization_pct = int(elevated_utilization_pct)
+        self.congested_utilization_pct = int(congested_utilization_pct)
+        self.resolution_targets = [str(x).strip() for x in (resolution_targets or list(DEFAULT_RESOLUTION_TARGETS)) if str(x).strip()]
+        self.service_probe_targets = [dict(x) for x in (service_probe_targets or list(DEFAULT_SERVICE_PROBE_TARGETS)) if isinstance(x, dict)]
+        self._capacity_history: Dict[str, deque[float]] = {}
+        self._last_iface_counters: Dict[str, Dict[str, Any]] = {}
+        self._path_probe_history: Dict[str, deque[Dict[str, Any]]] = {}
+        self._resolution_probe_history: Dict[str, deque[Dict[str, Any]]] = {}
+        self._service_probe_history: Dict[str, deque[Dict[str, Any]]] = {}
+
+    @staticmethod
+    def _safe_counter_delta(current: int, previous: int) -> Optional[int]:
+        curr = int(current or 0)
+        prev = int(previous or 0)
+        if curr < prev:
+            return None
+        return curr - prev
+
+    def _compute_capacity_view(self, iface_stats: List[Dict[str, Any]]) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        now = time.time()
+        samples: List[Dict[str, Any]] = []
+        pressure: List[Dict[str, Any]] = []
+        for row in iface_stats:
+            iface = str(row.get('interface') or '').strip()
+            if not iface:
+                continue
+            speed_mbps = int(row.get('speed_mbps') or 0)
+            prev = self._last_iface_counters.get(iface)
+            sample = {
+                'interface': iface,
+                'speed_mbps': speed_mbps,
+                'rx_bps': 0.0,
+                'tx_bps': 0.0,
+                'rx_pps': 0.0,
+                'tx_pps': 0.0,
+                'utilization_pct': None,
+                'mode': 'utilization_known' if speed_mbps > 0 else 'utilization_unknown_rate_only',
+                'sample_state': 'warmup',
+            }
+            if prev and float(now - float(prev.get('ts') or now)) > 0:
+                interval = float(now - float(prev.get('ts') or now))
+                rx_diff = self._safe_counter_delta(int(row.get('rx_bytes') or 0), int(prev.get('rx_bytes') or 0))
+                tx_diff = self._safe_counter_delta(int(row.get('tx_bytes') or 0), int(prev.get('tx_bytes') or 0))
+                rx_pkt_diff = self._safe_counter_delta(int(row.get('rx_packets') or 0), int(prev.get('rx_packets') or 0))
+                tx_pkt_diff = self._safe_counter_delta(int(row.get('tx_packets') or 0), int(prev.get('tx_packets') or 0))
+                if None in {rx_diff, tx_diff, rx_pkt_diff, tx_pkt_diff}:
+                    sample['sample_state'] = 'counter_reset'
+                else:
+                    sample['rx_bps'] = round((int(rx_diff) * 8) / interval, 2)
+                    sample['tx_bps'] = round((int(tx_diff) * 8) / interval, 2)
+                    sample['rx_pps'] = round(int(rx_pkt_diff) / interval, 2)
+                    sample['tx_pps'] = round(int(tx_pkt_diff) / interval, 2)
+                    sample['sample_state'] = 'sampled'
+                    if speed_mbps > 0:
+                        utilization = (max(sample['rx_bps'], sample['tx_bps']) / float(speed_mbps * 1_000_000)) * 100.0
+                        sample['utilization_pct'] = round(max(0.0, utilization), 2)
+            history = self._capacity_history.setdefault(iface, deque(maxlen=self.capacity_window_size))
+            if isinstance(sample.get('utilization_pct'), (int, float)):
+                history.append(float(sample['utilization_pct']))
+            state = 'unknown'
+            avg_utilization = None
+            peak_utilization = None
+            if history:
+                avg_utilization = round(sum(history) / len(history), 2)
+                peak_utilization = round(max(history), 2)
+                if peak_utilization >= self.congested_utilization_pct and avg_utilization >= self.elevated_utilization_pct:
+                    state = 'congested'
+                elif peak_utilization >= self.elevated_utilization_pct or avg_utilization >= self.elevated_utilization_pct:
+                    state = 'elevated'
+                else:
+                    state = 'normal'
+            pressure.append({
+                'interface': iface,
+                'mode': sample['mode'],
+                'state': state,
+                'window_size': self.capacity_window_size,
+                'samples_seen': len(history),
+                'avg_utilization_pct': avg_utilization,
+                'peak_utilization_pct': peak_utilization,
+                'speed_mbps': speed_mbps,
+                'rx_bps': sample['rx_bps'],
+                'tx_bps': sample['tx_bps'],
+            })
+            samples.append(sample)
+            self._last_iface_counters[iface] = {
+                'ts': now,
+                'rx_bytes': int(row.get('rx_bytes') or 0),
+                'tx_bytes': int(row.get('tx_bytes') or 0),
+                'rx_packets': int(row.get('rx_packets') or 0),
+                'tx_packets': int(row.get('tx_packets') or 0),
+            }
+        return samples, pressure
+
+    @staticmethod
+    def _latency_summary(history: deque[Dict[str, Any]]) -> tuple[Optional[float], Optional[float]]:
+        latencies = sorted(
+            float(item.get('latency_ms'))
+            for item in history
+            if isinstance(item.get('latency_ms'), (int, float)) and float(item.get('latency_ms')) >= 0.0
+        )
+        if not latencies:
+            return None, None
+        median_latency = round(float(statistics.median(latencies)), 2)
+        p95_index = max(0, min(len(latencies) - 1, int((len(latencies) - 1) * 0.95)))
+        return median_latency, round(float(latencies[p95_index]), 2)
+
+    def _record_probe_window(
+        self,
+        rows: List[Dict[str, Any]],
+        history_store: Dict[str, deque[Dict[str, Any]]],
+        key_builder: Callable[[Dict[str, Any]], str],
+        success_field: str,
+        classify: Callable[[float, int], str],
+    ) -> List[Dict[str, Any]]:
+        summaries: List[Dict[str, Any]] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            key = key_builder(row)
+            if not key:
+                continue
+            history = history_store.setdefault(key, deque(maxlen=self.probe_window_size))
+            history.append({
+                'ok': bool(row.get(success_field)),
+                'latency_ms': row.get('latency_ms'),
+            })
+            sample_count = len(history)
+            success_count = sum(1 for item in history if bool(item.get('ok')))
+            success_ratio_pct = round((success_count / sample_count) * 100.0, 2) if sample_count else 0.0
+            median_latency_ms, p95_latency_ms = self._latency_summary(history)
+            summary = dict(row)
+            summary.update({
+                'window_size': self.probe_window_size,
+                'samples_seen': sample_count,
+                'success_ratio_pct': success_ratio_pct,
+                'loss_pct': round(100.0 - success_ratio_pct, 2),
+                'median_latency_ms': median_latency_ms,
+                'p95_latency_ms': p95_latency_ms,
+                'state': classify(success_ratio_pct, sample_count),
+            })
+            summaries.append(summary)
+        return summaries
+
+    def _compute_path_probe_window(self, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return self._record_probe_window(
+            rows,
+            self._path_probe_history,
+            lambda row: f"{str(row.get('interface') or '-')}/{str(row.get('scope') or '-')}/{str(row.get('target') or '-')}",
+            'reachable',
+            lambda ratio, count: 'unknown' if count < 1 else ('normal' if ratio >= 100.0 else ('degraded' if ratio >= 50.0 else 'down')),
+        )
+
+    def _compute_resolution_probe_window(self, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return self._record_probe_window(
+            rows,
+            self._resolution_probe_history,
+            lambda row: str(row.get('name') or ''),
+            'resolved',
+            lambda ratio, count: 'unknown' if count < 1 else ('healthy' if ratio >= 100.0 else ('degraded' if ratio >= 50.0 else 'failed')),
+        )
+
+    def _compute_service_probe_window(self, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return self._record_probe_window(
+            rows,
+            self._service_probe_history,
+            lambda row: str(row.get('name') or row.get('target') or ''),
+            'reachable',
+            lambda ratio, count: 'unknown' if count < 1 else ('healthy' if ratio >= 100.0 else ('degraded' if ratio >= 50.0 else 'down')),
+        )
 
     def collect_snapshot(self) -> Dict[str, Any]:
         failures: List[Dict[str, str]] = []
@@ -216,21 +522,41 @@ class LightweightNocMonitor:
                 return default
 
         icmp_target = _default_icmp_target(self.gateway_ip)
+        iface_stats = capture(
+            'iface_stats',
+            lambda: collect_iface_stats([self.up_interface, self.down_interface]),
+            [],
+        )
+        capacity_samples, capacity_pressure = self._compute_capacity_view(iface_stats if isinstance(iface_stats, list) else [])
+        path_probes = capture(
+            'path_probes',
+            lambda: collect_path_probes_multi(
+                self.gateway_ip,
+                [self.up_interface, self.down_interface, *self.extra_interfaces],
+            ),
+            [],
+        )
+        resolution_probes = capture(
+            'resolution_probes',
+            lambda: [collect_dns_resolution(name) for name in self.resolution_targets],
+            [],
+        )
+        service_probes = capture(
+            'service_probes',
+            lambda: collect_service_probes(self.service_probe_targets),
+            [],
+        )
         snapshot = {
             'icmp': capture('icmp', lambda: collect_icmp(icmp_target, self.up_interface), {}),
-            'path_probes': capture(
-                'path_probes',
-                lambda: collect_path_probes_multi(
-                    self.gateway_ip,
-                    [self.up_interface, self.down_interface, *self.extra_interfaces],
-                ),
-                [],
-            ),
-            'iface_stats': capture(
-                'iface_stats',
-                lambda: collect_iface_stats([self.up_interface, self.down_interface]),
-                [],
-            ),
+            'path_probes': path_probes,
+            'path_probe_window': self._compute_path_probe_window(path_probes if isinstance(path_probes, list) else []),
+            'iface_stats': iface_stats,
+            'capacity_samples': capacity_samples,
+            'capacity_pressure': capacity_pressure,
+            'resolution_probes': resolution_probes,
+            'resolution_probe_window': self._compute_resolution_probe_window(resolution_probes if isinstance(resolution_probes, list) else []),
+            'service_probes': service_probes,
+            'service_probe_window': self._compute_service_probe_window(service_probes if isinstance(service_probes, list) else []),
             'cpu_mem_temp': capture('cpu_mem_temp', collect_cpu_mem_temp, {}),
             'dhcp_leases': capture('dhcp_leases', collect_dhcp_leases, []),
             'arp_table': capture('arp_table', collect_arp_table, []),

--- a/py/azazel_edge/sensors/system_metrics.py
+++ b/py/azazel_edge/sensors/system_metrics.py
@@ -90,6 +90,23 @@ def get_network_stats(interface: str) -> Dict[str, int]:
     return result
 
 
+def get_link_speed_mbps(interface: str) -> Optional[int]:
+    """リンク速度を取得（Mbps）。未知または unsupported の場合は None。"""
+    try:
+        path = Path(f"/sys/class/net/{interface}/speed")
+        if not path.exists():
+            return None
+        raw = path.read_text(encoding="utf-8").strip()
+        if not raw:
+            return None
+        speed = int(raw)
+        if speed <= 0:
+            return None
+        return speed
+    except Exception:
+        return None
+
+
 def calculate_throughput(
     prev_stats: Dict[str, int],
     curr_stats: Dict[str, int],

--- a/py/azazel_edge_ai/agent.py
+++ b/py/azazel_edge_ai/agent.py
@@ -1549,6 +1549,11 @@ def _handle_event(event: Dict[str, Any]) -> None:
         _persist_metrics()
 
 
+def _handle_line(raw: str) -> Dict[str, Any] | None:
+    """Backward-compatible single-line handler used by tests and legacy callers."""
+    return _handle_request_line(raw)
+
+
 def _handle_manual_query_request(req: Dict[str, Any]) -> Dict[str, Any]:
     params = req.get("params")
     if not isinstance(params, dict):

--- a/py/azazel_edge_epd_mode_refresh.py
+++ b/py/azazel_edge_epd_mode_refresh.py
@@ -27,16 +27,16 @@ def _safe_load(path: Path) -> Dict[str, Any]:
 
 
 def _read_runtime_snapshot() -> Dict[str, Any]:
+    for path in RUNTIME_SNAPSHOT_CANDIDATES:
+        data = _safe_load(path)
+        if isinstance(data, dict) and data:
+            return data
     try:
         payload, _source = read_snapshot_payload(prefer_control_plane=True)
         if isinstance(payload, dict) and payload:
             return payload
     except Exception:
         pass
-    for path in RUNTIME_SNAPSHOT_CANDIDATES:
-        data = _safe_load(path)
-        if isinstance(data, dict) and data:
-            return data
     return {}
 
 

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -86,6 +86,29 @@ class DashboardDataContractTests(unittest.TestCase):
                 "dns_mismatch": 2,
                 "signals": ["dns_mismatch"],
             },
+            "noc_capacity": {
+                "state": "elevated",
+                "mode": "utilization_known",
+                "utilization_pct": 78.4,
+                "top_sources": [{"src_ip": "192.168.40.12", "bytes": 4096}],
+                "signals": ["capacity_elevated"],
+            },
+            "noc_client_inventory": {
+                "current_client_count": 6,
+                "new_client_count": 1,
+                "unknown_client_count": 1,
+                "unauthorized_client_count": 0,
+                "inventory_mismatch_count": 1,
+                "stale_session_count": 0,
+            },
+            "noc_service_assurance": {
+                "status": "degraded",
+                "degraded_targets": ["resolver-tcp"],
+            },
+            "noc_resolution_assurance": {
+                "status": "failed",
+                "failed_targets": ["example.com"],
+            },
             "evidence": ["net_health=SUSPECTED signals=dns_mismatch"],
             "llm": {"status": "skipped_non_ambiguous"},
         }
@@ -233,6 +256,12 @@ class DashboardDataContractTests(unittest.TestCase):
         self.assertIn("decision_path", payload)
         self.assertEqual(payload["soc_focus"]["attack_type"], "dns anomaly")
         self.assertEqual(payload["noc_focus"]["path_health"]["uplink"], "eth1")
+        self.assertEqual(payload["noc_focus"]["capacity"]["state"], "elevated")
+        self.assertEqual(payload["noc_focus"]["capacity"]["top_talker"], "192.168.40.12")
+        self.assertEqual(payload["noc_focus"]["client_inventory"]["current_client_count"], 6)
+        self.assertEqual(payload["noc_focus"]["client_inventory"]["inventory_mismatch_count"], 1)
+        self.assertEqual(payload["noc_focus"]["service_assurance"]["status"], "degraded")
+        self.assertEqual(payload["noc_focus"]["resolution_health"]["status"], "failed")
         self.assertEqual(payload["decision_path"]["first_pass_engine"], "tactical_scorer_v1")
         self.assertEqual(payload["decision_path"]["second_pass_status"], "completed")
 

--- a/tests/test_evidence_plane_v1.py
+++ b/tests/test_evidence_plane_v1.py
@@ -18,6 +18,7 @@ from azazel_edge.evidence_plane import (
     EvidencePlaneService,
     NocProbeAdapter,
     adapt_suricata_record,
+    build_client_inventory,
     adapt_syslog_line,
     read_suricata_jsonl,
 )
@@ -124,6 +125,21 @@ class EvidencePlaneV1Tests(unittest.TestCase):
                     'tx_bytes': 50,
                 }
             ],
+            'path_probe_window': [
+                {'target': '1.1.1.1', 'interface': 'eth1', 'scope': 'external', 'state': 'down', 'success_ratio_pct': 0.0},
+            ],
+            'resolution_probes': [
+                {'name': 'example.com', 'resolved': False, 'answers': [], 'latency_ms': 4.0, 'probe': 'dns'},
+            ],
+            'resolution_probe_window': [
+                {'name': 'example.com', 'state': 'failed', 'success_ratio_pct': 0.0},
+            ],
+            'service_probes': [
+                {'name': 'resolver-tcp', 'target': '1.1.1.1:53', 'reachable': False, 'latency_ms': 10.0, 'probe': 'tcp'},
+            ],
+            'service_probe_window': [
+                {'name': 'resolver-tcp', 'target': '1.1.1.1:53', 'state': 'down', 'success_ratio_pct': 0.0},
+            ],
             'cpu_mem_temp': {
                 'cpu_percent': 12.0,
                 'memory': {'percent': 38},
@@ -147,7 +163,12 @@ class EvidencePlaneV1Tests(unittest.TestCase):
         events = adapter.collect(snapshot=snapshot)
         kinds = {item.to_dict()['kind'] for item in events}
         self.assertIn('icmp_probe', kinds)
+        self.assertIn('path_probe_window', kinds)
         self.assertIn('iface_stats', kinds)
+        self.assertIn('resolution_probe', kinds)
+        self.assertIn('resolution_probe_window', kinds)
+        self.assertIn('service_probe', kinds)
+        self.assertIn('service_probe_window', kinds)
         self.assertIn('cpu_mem_temp', kinds)
         self.assertIn('service_health', kinds)
         self.assertIn('dhcp_lease', kinds)
@@ -192,3 +213,63 @@ class EvidencePlaneV1Tests(unittest.TestCase):
                 for field in REQUIRED_FIELDS:
                     self.assertIn(field, payload)
                 self.assertIsInstance(payload['attrs'], dict)
+
+    def test_noc_probe_dispatch_derives_client_inventory_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bus = EvidenceBus(fanout_path=Path(tmp) / 'evidence.jsonl', queue_max=32)
+            service = EvidencePlaneService(bus)
+            snapshot = {
+                'icmp': {'target': '192.168.40.1', 'reachable': True},
+                'path_probes': [],
+                'path_probe_window': [],
+                'iface_stats': [],
+                'capacity_samples': [],
+                'capacity_pressure': [],
+                'resolution_probes': [],
+                'resolution_probe_window': [],
+                'service_probes': [],
+                'service_probe_window': [],
+                'cpu_mem_temp': {},
+                'service_health': {},
+                'dhcp_leases': [{'ip': '192.168.40.20', 'mac': 'aa:bb:cc:dd:ee:01', 'hostname': 'client-a'}],
+                'arp_table': [{'ip': '192.168.40.20', 'mac': 'aa:bb:cc:dd:ee:01', 'dev': 'eth1', 'state': 'REACHABLE'}],
+                'collector_failures': [],
+            }
+            items = service.dispatch_noc_probe(snapshot=snapshot)
+            kinds = {item['kind'] for item in items}
+            self.assertIn('client_session', kinds)
+            self.assertIn('client_inventory_summary', kinds)
+
+    def test_client_inventory_merges_flow_with_existing_dhcp_arp_session(self) -> None:
+        inventory = build_client_inventory([
+            EvidenceEvent.build(
+                ts='2026-03-10T00:00:00Z',
+                source='noc_probe',
+                kind='dhcp_lease',
+                subject='192.168.40.20',
+                severity=0,
+                confidence=0.9,
+                attrs={'ip': '192.168.40.20', 'mac': 'aa:bb:cc:dd:ee:01', 'hostname': 'client-a'},
+            ),
+            EvidenceEvent.build(
+                ts='2026-03-10T00:00:05Z',
+                source='noc_probe',
+                kind='arp_entry',
+                subject='192.168.40.20',
+                severity=0,
+                confidence=0.9,
+                attrs={'ip': '192.168.40.20', 'mac': 'aa:bb:cc:dd:ee:01', 'dev': 'eth1', 'state': 'REACHABLE'},
+            ),
+            EvidenceEvent.build(
+                ts='2026-03-10T00:00:10Z',
+                source='flow_min',
+                kind='flow_summary',
+                subject='192.168.40.20->8.8.8.8:443/TCP',
+                severity=20,
+                confidence=0.7,
+                attrs={'src_ip': '192.168.40.20', 'dst_ip': '8.8.8.8', 'dst_port': 443, 'proto': 'TCP', 'app_proto': 'tls'},
+            ),
+        ])
+        rows = [row for row in inventory['sessions'] if row['session_state'] != 'authorized_missing']
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['sources_present'], ['arp', 'dhcp', 'flow'])

--- a/tests/test_flow_input_v1.py
+++ b/tests/test_flow_input_v1.py
@@ -59,8 +59,10 @@ class FlowInputV1Tests(unittest.TestCase):
                 'flow_id': 'flow-1',
             }) + '\n', encoding='utf-8')
             items = service.dispatch_flow_jsonl(flow_path)
-        self.assertEqual(len(items), 1)
+        self.assertEqual(len(items), 2)
         self.assertEqual(items[0]['source'], 'flow_min')
+        self.assertEqual(items[1]['kind'], 'traffic_concentration')
+        self.assertTrue(items[1]['attrs']['top_sources'])
 
     def test_flow_supports_noc_and_soc_scores(self) -> None:
         flow_event = adapt_flow_record({

--- a/tests/test_noc_evaluator_v1.py
+++ b/tests/test_noc_evaluator_v1.py
@@ -44,9 +44,13 @@ class NocEvaluatorV1Tests(unittest.TestCase):
         self.assertIn('path_health', result)
         self.assertIn('device_health', result)
         self.assertIn('client_health', result)
+        self.assertIn('capacity_health', result)
+        self.assertIn('client_inventory_health', result)
+        self.assertIn('service_health', result)
+        self.assertIn('resolution_health', result)
         self.assertIn('summary', result)
         self.assertIn('evidence_ids', result)
-        for key in ('availability', 'path_health', 'device_health', 'client_health'):
+        for key in ('availability', 'path_health', 'device_health', 'client_health', 'capacity_health', 'client_inventory_health', 'service_health', 'resolution_health'):
             self.assertIn('score', result[key])
             self.assertIn('label', result[key])
 
@@ -75,7 +79,7 @@ class NocEvaluatorV1Tests(unittest.TestCase):
         result = evaluator.evaluate([])
         handoff = evaluator.to_arbiter_input(result)
         self.assertEqual(handoff['source'], 'noc_evaluator')
-        for key in ('summary', 'availability', 'path_health', 'device_health', 'client_health', 'evidence_ids'):
+        for key in ('summary', 'availability', 'path_health', 'device_health', 'client_health', 'capacity_health', 'client_inventory_health', 'service_health', 'resolution_health', 'evidence_ids'):
             self.assertIn(key, handoff)
 
     def test_sot_can_reduce_unknown_client_penalty(self) -> None:
@@ -95,6 +99,50 @@ class NocEvaluatorV1Tests(unittest.TestCase):
         base_score = base.evaluate(events)['availability']['score']
         tuned_score = tuned.evaluate(events)['availability']['score']
         self.assertGreater(tuned_score, base_score)
+
+    def test_invalid_extended_config_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            NocEvaluator(config={'capacity_health': {'elevated_penalty': 40, 'congested_penalty': 20}})
+        with self.assertRaises(ValueError):
+            NocEvaluator(config={'client_inventory_health': {'unknown_client_penalty_per_client': 10, 'unauthorized_client_penalty_per_client': 5}})
+        with self.assertRaises(ValueError):
+            NocEvaluator(config={'service_health': {'window_degraded_penalty': 20, 'window_down_penalty': 10}})
+        with self.assertRaises(ValueError):
+            NocEvaluator(config={'resolution_health': {'window_degraded_penalty': 20, 'window_failed_penalty': 10}})
+
+    def test_capacity_and_client_inventory_dimensions_consume_new_evidence(self) -> None:
+        evaluator = NocEvaluator()
+        events = [
+            _event('capacity_pressure', 'eth1', 65, {'interface': 'eth1', 'state': 'congested', 'mode': 'utilization_known'}),
+            _event('traffic_concentration', 'flow-window', 35, {'high_concentration': True}),
+            _event('client_inventory_summary', 'client_inventory', 60, {
+                'current_client_count': 4,
+                'unknown_client_count': 1,
+                'unauthorized_client_count': 1,
+                'inventory_mismatch_count': 1,
+                'stale_session_count': 0,
+                'authorized_missing_count': 0,
+            }),
+        ]
+        result = evaluator.evaluate(events)
+        self.assertIn('capacity_congested:utilization_known', result['capacity_health']['reasons'])
+        self.assertIn('traffic_concentration_high', result['capacity_health']['reasons'])
+        self.assertIn('client_inventory_unknown_present', result['client_inventory_health']['reasons'])
+        self.assertIn('client_inventory_unauthorized_present', result['client_inventory_health']['reasons'])
+
+    def test_service_and_resolution_dimensions_consume_probe_windows(self) -> None:
+        evaluator = NocEvaluator()
+        events = [
+            _event('service_probe', 'resolver-tcp', 60, {'name': 'resolver-tcp', 'reachable': False}, status='fail'),
+            _event('service_probe_window', 'resolver-tcp', 65, {'name': 'resolver-tcp', 'state': 'down', 'success_ratio_pct': 0.0}, status='warn'),
+            _event('resolution_probe', 'example.com', 60, {'name': 'example.com', 'resolved': False}, status='fail'),
+            _event('resolution_probe_window', 'example.com', 65, {'name': 'example.com', 'state': 'failed', 'success_ratio_pct': 0.0}, status='warn'),
+        ]
+        result = evaluator.evaluate(events)
+        self.assertIn('service_probe_failed:resolver-tcp', result['service_health']['reasons'])
+        self.assertIn('service_window_down:resolver-tcp', result['service_health']['reasons'])
+        self.assertIn('resolution_failed:example.com', result['resolution_health']['reasons'])
+        self.assertIn('resolution_window_failed:example.com', result['resolution_health']['reasons'])
 
 
 if __name__ == '__main__':

--- a/tests/test_noc_monitor_v1.py
+++ b/tests/test_noc_monitor_v1.py
@@ -18,6 +18,8 @@ class LightweightNocMonitorV1Tests(unittest.TestCase):
     def test_snapshot_contains_issue_defined_collectors(self) -> None:
         with patch('azazel_edge.sensors.noc_monitor.collect_icmp', return_value={'target': '192.168.40.1', 'reachable': True}), \
              patch('azazel_edge.sensors.noc_monitor.collect_path_probes', return_value=[{'target': '192.168.40.1', 'scope': 'gateway', 'reachable': True}]), \
+             patch('azazel_edge.sensors.noc_monitor.collect_dns_resolution', side_effect=lambda name: {'name': name, 'resolved': True, 'answers': ['93.184.216.34'], 'latency_ms': 5.0, 'probe': 'dns'}), \
+             patch('azazel_edge.sensors.noc_monitor.collect_service_probes', return_value=[{'name': 'resolver-tcp', 'target': '1.1.1.1:53', 'reachable': True, 'latency_ms': 8.0, 'probe': 'tcp'}]), \
              patch('azazel_edge.sensors.noc_monitor.collect_iface_stats', return_value=[{'interface': 'eth1', 'operstate': 'up', 'carrier': 1}]), \
              patch('azazel_edge.sensors.noc_monitor.collect_cpu_mem_temp', return_value={'cpu_percent': 10.0, 'memory': {'percent': 30}, 'temperature_c': 45.0}), \
              patch('azazel_edge.sensors.noc_monitor.collect_dhcp_leases', return_value=[{'ip': '192.168.40.10', 'mac': 'aa:bb:cc:dd:ee:ff'}]), \
@@ -28,14 +30,24 @@ class LightweightNocMonitorV1Tests(unittest.TestCase):
 
         self.assertEqual(
             set(snapshot.keys()),
-            {'icmp', 'path_probes', 'iface_stats', 'cpu_mem_temp', 'dhcp_leases', 'arp_table', 'service_health', 'collector_failures'},
+            {
+                'icmp', 'path_probes', 'path_probe_window', 'iface_stats', 'capacity_samples', 'capacity_pressure',
+                'resolution_probes', 'resolution_probe_window', 'service_probes', 'service_probe_window',
+                'cpu_mem_temp', 'dhcp_leases', 'arp_table', 'service_health', 'collector_failures',
+            },
         )
         self.assertEqual(snapshot['collector_failures'], [])
         self.assertEqual(set(snapshot['service_health'].keys()), set(SERVICE_TARGETS.keys()))
+        self.assertEqual(len(snapshot['capacity_samples']), 1)
+        self.assertEqual(snapshot['capacity_pressure'][0]['state'], 'unknown')
+        self.assertEqual(snapshot['resolution_probe_window'][0]['state'], 'healthy')
+        self.assertEqual(snapshot['service_probe_window'][0]['state'], 'healthy')
 
     def test_collector_failure_is_not_silenced(self) -> None:
         with patch('azazel_edge.sensors.noc_monitor.collect_icmp', side_effect=RuntimeError('icmp disabled')), \
              patch('azazel_edge.sensors.noc_monitor.collect_path_probes', return_value=[]), \
+             patch('azazel_edge.sensors.noc_monitor.collect_dns_resolution', side_effect=RuntimeError('dns disabled')), \
+             patch('azazel_edge.sensors.noc_monitor.collect_service_probes', side_effect=RuntimeError('service probes disabled')), \
              patch('azazel_edge.sensors.noc_monitor.collect_iface_stats', return_value=[]), \
              patch('azazel_edge.sensors.noc_monitor.collect_cpu_mem_temp', return_value={}), \
              patch('azazel_edge.sensors.noc_monitor.collect_dhcp_leases', return_value=[]), \
@@ -44,14 +56,18 @@ class LightweightNocMonitorV1Tests(unittest.TestCase):
             monitor = LightweightNocMonitor(up_interface='eth1', down_interface='usb0', gateway_ip='192.168.40.1')
             snapshot = monitor.collect_snapshot()
 
-        self.assertEqual(len(snapshot['collector_failures']), 1)
-        self.assertEqual(snapshot['collector_failures'][0]['collector'], 'icmp')
+        self.assertEqual({item['collector'] for item in snapshot['collector_failures']}, {'icmp', 'resolution_probes', 'service_probes'})
 
     def test_adapter_emits_evidence_plane_compatible_events(self) -> None:
         adapter = NocProbeAdapter(up_interface='eth1', down_interface='usb0', gateway_ip='192.168.40.1')
         snapshot = {
             'icmp': {'target': '192.168.40.1', 'reachable': False, 'latency_ms': None},
+            'path_probe_window': [{'target': '1.1.1.1', 'interface': 'eth1', 'scope': 'external', 'state': 'down'}],
             'iface_stats': [{'interface': 'eth1', 'operstate': 'down', 'carrier': 0, 'rx_bytes': 0, 'tx_bytes': 0}],
+            'resolution_probes': [{'name': 'example.com', 'resolved': False, 'answers': [], 'latency_ms': 10.0}],
+            'resolution_probe_window': [{'name': 'example.com', 'state': 'failed', 'success_ratio_pct': 0.0}],
+            'service_probes': [{'name': 'resolver-tcp', 'target': '1.1.1.1:53', 'reachable': False, 'latency_ms': 20.0, 'probe': 'tcp'}],
+            'service_probe_window': [{'name': 'resolver-tcp', 'target': '1.1.1.1:53', 'state': 'down', 'success_ratio_pct': 0.0}],
             'cpu_mem_temp': {'cpu_percent': 92.0, 'memory': {'percent': 91}, 'temperature_c': 82.0},
             'dhcp_leases': [{'ip': '192.168.40.50', 'mac': 'aa:bb:cc:dd:ee:ff', 'hostname': 'client-1'}],
             'arp_table': [{'ip': '192.168.40.50', 'mac': 'aa:bb:cc:dd:ee:ff', 'dev': 'eth1', 'state': 'STALE'}],
@@ -62,7 +78,11 @@ class LightweightNocMonitorV1Tests(unittest.TestCase):
         kinds = {event['kind'] for event in events}
         self.assertEqual(
             kinds,
-            {'icmp_probe', 'iface_stats', 'cpu_mem_temp', 'dhcp_lease', 'arp_entry', 'service_health', 'collector_failure'},
+            {
+                'icmp_probe', 'path_probe_window', 'iface_stats', 'resolution_probe', 'resolution_probe_window',
+                'service_probe', 'service_probe_window', 'cpu_mem_temp', 'dhcp_lease', 'arp_entry',
+                'service_health', 'collector_failure',
+            },
         )
         for event in events:
             self.assertEqual(event['source'], 'noc_probe')

--- a/tests/test_noc_monitor_v2.py
+++ b/tests/test_noc_monitor_v2.py
@@ -16,10 +16,20 @@ from azazel_edge.sensors.noc_monitor import LightweightNocMonitor, SERVICE_TARGE
 
 
 class LightweightNocMonitorV2Tests(unittest.TestCase):
+    def test_invalid_capacity_thresholds_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            LightweightNocMonitor(capacity_window_size=1)
+        with self.assertRaises(ValueError):
+            LightweightNocMonitor(probe_window_size=1)
+        with self.assertRaises(ValueError):
+            LightweightNocMonitor(elevated_utilization_pct=90, congested_utilization_pct=80)
+
     def test_snapshot_contains_path_probes_and_service_detail(self) -> None:
         service_payload = {k: {'target': k, 'unit': v, 'state': 'ON', 'detail': 'active', 'substate': 'running', 'result': 'success'} for k, v in SERVICE_TARGETS.items()}
         with patch('azazel_edge.sensors.noc_monitor.collect_icmp', return_value={'target': '192.168.40.1', 'reachable': True}), \
              patch('azazel_edge.sensors.noc_monitor.collect_path_probes', return_value=[{'target': '192.168.40.1', 'scope': 'gateway', 'reachable': True}, {'target': '1.1.1.1', 'scope': 'external', 'reachable': False}]), \
+             patch('azazel_edge.sensors.noc_monitor.collect_dns_resolution', side_effect=lambda name: {'name': name, 'resolved': name != 'openai.com', 'answers': ['1.1.1.1'], 'latency_ms': 3.0, 'probe': 'dns'}), \
+             patch('azazel_edge.sensors.noc_monitor.collect_service_probes', return_value=[{'name': 'resolver-tcp', 'target': '1.1.1.1:53', 'reachable': False, 'latency_ms': 11.0, 'probe': 'tcp'}]), \
              patch('azazel_edge.sensors.noc_monitor.collect_iface_stats', return_value=[{'interface': 'eth1', 'operstate': 'up', 'carrier': 1}]), \
              patch('azazel_edge.sensors.noc_monitor.collect_cpu_mem_temp', return_value={'cpu_percent': 10.0, 'memory': {'percent': 30}, 'temperature_c': 45.0}), \
              patch('azazel_edge.sensors.noc_monitor.collect_dhcp_leases', return_value=[]), \
@@ -29,6 +39,8 @@ class LightweightNocMonitorV2Tests(unittest.TestCase):
         self.assertIn('path_probes', snapshot)
         self.assertEqual(len(snapshot['path_probes']), 4)
         self.assertIn('substate', snapshot['service_health']['web'])
+        self.assertIn('resolution_probe_window', snapshot)
+        self.assertEqual(snapshot['service_probe_window'][0]['state'], 'down')
 
     def test_adapter_and_evaluator_reflect_path_and_service_detail(self) -> None:
         adapter = NocProbeAdapter(up_interface='eth1', down_interface='usb0', gateway_ip='192.168.40.1')
@@ -38,7 +50,14 @@ class LightweightNocMonitorV2Tests(unittest.TestCase):
                 {'target': '192.168.40.1', 'scope': 'gateway', 'reachable': True, 'latency_ms': 1.0},
                 {'target': '1.1.1.1', 'scope': 'external', 'reachable': False, 'latency_ms': None},
             ],
+            'path_probe_window': [
+                {'target': '1.1.1.1', 'interface': 'eth1', 'scope': 'external', 'state': 'down', 'success_ratio_pct': 0.0},
+            ],
             'iface_stats': [{'interface': 'eth1', 'operstate': 'up', 'carrier': 1, 'rx_bytes': 0, 'tx_bytes': 0}],
+            'resolution_probes': [{'name': 'example.com', 'resolved': False, 'answers': [], 'latency_ms': 4.0}],
+            'resolution_probe_window': [{'name': 'example.com', 'state': 'failed', 'success_ratio_pct': 0.0}],
+            'service_probes': [{'name': 'resolver-tcp', 'target': '1.1.1.1:53', 'reachable': False, 'latency_ms': 6.0, 'probe': 'tcp'}],
+            'service_probe_window': [{'name': 'resolver-tcp', 'target': '1.1.1.1:53', 'state': 'down', 'success_ratio_pct': 0.0}],
             'cpu_mem_temp': {'cpu_percent': 20.0, 'memory': {'percent': 30}, 'temperature_c': 40.0},
             'dhcp_leases': [],
             'arp_table': [],
@@ -51,6 +70,8 @@ class LightweightNocMonitorV2Tests(unittest.TestCase):
         self.assertIn('path_probe_failed:external', result['path_health']['reasons'])
         self.assertIn('path_target_divergence', result['path_health']['reasons'])
         self.assertIn('service_degraded:web', result['availability']['reasons'])
+        self.assertIn('service_probe_failed:resolver-tcp', result['service_health']['reasons'])
+        self.assertIn('resolution_failed:example.com', result['resolution_health']['reasons'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add NOC capacity/utilization collection, bounded traffic summaries, and merged client inventory events
- extend the NOC evaluator, evidence plane, explanation flow, and dashboard contracts with capacity and inventory health
- include the related regression fixes and tests needed to land the baseline safely

## Verification
- `PYTHONPATH=/home/azazel/Azazel-Edge ./.venv/bin/pytest -q` -> `146 passed`
- `bash -n installer/internal/install_migrated_tools.sh`
- `bash -n installer/internal/verify_runtime_sync.sh`
- `git diff --check`

## Notes
- this is the base branch for the later stacked NOC follow-up branches: `feature/noc-blast-radius`, `feature/noc-config-drift`, `feature/noc-incident-grouping`, `feature/noc-runbook-support`