### PR TITLE
Add NOC blast radius summaries

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -981,6 +981,7 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
         top_talker = str(top_sources[0].get("src_ip") or top_sources[0].get("id") or "-")
     noc_service_assurance = state.get("noc_service_assurance") if isinstance(state.get("noc_service_assurance"), dict) else {}
     noc_resolution_assurance = state.get("noc_resolution_assurance") if isinstance(state.get("noc_resolution_assurance"), dict) else {}
+    noc_blast_radius = state.get("noc_blast_radius") if isinstance(state.get("noc_blast_radius"), dict) else {}
     return {
         "ok": True,
         "risk": {
@@ -1077,6 +1078,13 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
             "resolution_health": {
                 "status": str(noc_resolution_assurance.get("status") or "unknown"),
                 "failed_targets": noc_resolution_assurance.get("failed_targets") if isinstance(noc_resolution_assurance.get("failed_targets"), list) else [],
+            },
+            "blast_radius": {
+                "affected_uplinks": noc_blast_radius.get("affected_uplinks") if isinstance(noc_blast_radius.get("affected_uplinks"), list) else [],
+                "affected_segments": noc_blast_radius.get("affected_segments") if isinstance(noc_blast_radius.get("affected_segments"), list) else [],
+                "related_service_targets": noc_blast_radius.get("related_service_targets") if isinstance(noc_blast_radius.get("related_service_targets"), list) else [],
+                "affected_client_count": _as_int(noc_blast_radius.get("affected_client_count"), 0),
+                "critical_client_count": _as_int(noc_blast_radius.get("critical_client_count"), 0),
             },
             "capacity": {
                 "state": str(noc_capacity.get("state") or "unknown"),

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -1008,6 +1008,7 @@ function updateSplitBoard(summary, actions) {
     const services = noc.service_health || {};
     const serviceAssurance = noc.service_assurance || {};
     const resolutionHealth = noc.resolution_health || {};
+    const blastRadius = noc.blast_radius || {};
     const capacity = noc.capacity || {};
     const clientInventory = noc.client_inventory || {};
     const clientImpact = noc.client_impact || {};
@@ -1038,6 +1039,8 @@ function updateSplitBoard(summary, actions) {
     updateElement('nocPathUplink', path.uplink || '-');
     updateElement('nocPathGateway', path.gateway || '-');
     updateElement('nocPathInternet', path.internet_check || '-');
+    updateElement('nocBlastSegments', (blastRadius.affected_segments || []).join(', ') || '-');
+    updateElement('nocBlastClients', String(blastRadius.affected_client_count ?? 0));
     renderList('nocPathSignals', path.signals || [], (item) => item);
     renderList(
         'nocServiceList',
@@ -1046,6 +1049,7 @@ function updateSplitBoard(summary, actions) {
     );
     updateElement('nocServiceAssurance', String(serviceAssurance.status || 'unknown').toUpperCase());
     updateElement('nocResolutionHealth', String(resolutionHealth.status || 'unknown').toUpperCase());
+    updateElement('nocBlastTargets', (blastRadius.related_service_targets || []).join(', ') || '-');
     const utilization = capacity.utilization_pct == null || capacity.utilization_pct === ''
         ? '-'
         : `${capacity.utilization_pct}%`;

--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -289,6 +289,8 @@
                                         <div class="fact-item"><span>Uplink</span><strong id="nocPathUplink">-</strong></div>
                                         <div class="fact-item"><span>Gateway</span><strong id="nocPathGateway">-</strong></div>
                                         <div class="fact-item"><span>Internet</span><strong id="nocPathInternet">-</strong></div>
+                                        <div class="fact-item"><span>Segments</span><strong id="nocBlastSegments">-</strong></div>
+                                        <div class="fact-item"><span>Impacted</span><strong id="nocBlastClients">0</strong></div>
                                     </div>
                                     <ul class="action-list" id="nocPathSignals">
                                         <li>{{ tr('dashboard.no_path_signal_summary', 'No path signal summary.') }}</li>
@@ -300,6 +302,7 @@
                                         <div class="fact-list compact-list">
                                             <div class="fact-item"><span>Assurance</span><strong id="nocServiceAssurance">-</strong></div>
                                             <div class="fact-item"><span>Resolution</span><strong id="nocResolutionHealth">-</strong></div>
+                                            <div class="fact-item"><span>Targets</span><strong id="nocBlastTargets">-</strong></div>
                                         </div>
                                         <ul class="action-list" id="nocServiceList">
                                             <li>{{ tr('dashboard.no_service_summary', 'No service summary.') }}</li>

--- a/py/azazel_edge/evaluators/noc.py
+++ b/py/azazel_edge/evaluators/noc.py
@@ -195,6 +195,8 @@ class NocEvaluator:
             if 'sot_missing' not in client_health['reasons']:
                 client_health['reasons'].append('sot_missing')
 
+        affected_scope = self._evaluate_affected_scope(payloads, by_kind, sot=sot)
+
         dimensions = [
             availability,
             path_health,
@@ -230,6 +232,8 @@ class NocEvaluator:
         if sot and isinstance(sot.get('networks'), list):
             segment_status = self._evaluate_segment_scope(payloads, sot.get('networks', []))
             summary['segment_scope'] = segment_status
+        if affected_scope:
+            summary['blast_radius'] = affected_scope
 
         result = {
             'availability': availability,
@@ -240,6 +244,7 @@ class NocEvaluator:
             'client_inventory_health': client_inventory_health,
             'service_health': service_health,
             'resolution_health': resolution_health,
+            'affected_scope': affected_scope,
             'summary': summary,
             'evidence_ids': sorted(dict.fromkeys(all_evidence_ids)),
         }
@@ -258,6 +263,7 @@ class NocEvaluator:
             'client_inventory_health': evaluation.get('client_inventory_health', {}),
             'service_health': evaluation.get('service_health', {}),
             'resolution_health': evaluation.get('resolution_health', {}),
+            'affected_scope': evaluation.get('affected_scope', {}),
             'evidence_ids': evaluation.get('evidence_ids', []),
         }
 
@@ -657,4 +663,144 @@ class NocEvaluator:
         return {
             'affected_segments': sorted(segments),
             'multi_segment': len(segments) > 1,
+        }
+
+    @staticmethod
+    def _evaluate_affected_scope(
+        payloads: List[Dict[str, Any]],
+        by_kind: Dict[str, List[Dict[str, Any]]],
+        sot: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        networks = sot.get('networks', []) if isinstance(sot, dict) and isinstance(sot.get('networks'), list) else []
+        devices = sot.get('devices', []) if isinstance(sot, dict) and isinstance(sot.get('devices'), list) else []
+        services = sot.get('services', []) if isinstance(sot, dict) and isinstance(sot.get('services'), list) else []
+        service_ids = {str(item.get('id') or item.get('name') or '').strip() for item in services if isinstance(item, dict)}
+        service_ids.discard('')
+
+        affected_uplinks: set[str] = set()
+        affected_segments: set[str] = set()
+        related_service_targets: set[str] = set()
+        evidence_ids: set[str] = set()
+
+        for kind in ('path_probe', 'path_probe_window'):
+            for event in by_kind.get(kind, []):
+                attrs = event.get('attrs', {})
+                interface = str(attrs.get('interface') or '').strip()
+                reachable = bool(attrs.get('reachable', True))
+                state = str(attrs.get('state') or '').lower()
+                if interface and (not reachable or state in {'degraded', 'down'}):
+                    affected_uplinks.add(interface)
+                    if str(event.get('event_id') or ''):
+                        evidence_ids.add(str(event.get('event_id')))
+
+        for event in by_kind.get('capacity_pressure', []):
+            attrs = event.get('attrs', {})
+            interface = str(attrs.get('interface') or '').strip()
+            state = str(attrs.get('state') or '').lower()
+            if interface and state in {'elevated', 'congested'}:
+                affected_uplinks.add(interface)
+                if str(event.get('event_id') or ''):
+                    evidence_ids.add(str(event.get('event_id')))
+
+        for kind in ('service_health', 'service_probe', 'service_probe_window'):
+            for event in by_kind.get(kind, []):
+                attrs = event.get('attrs', {})
+                target = str(attrs.get('target') or attrs.get('name') or event.get('subject') or '').strip()
+                if not target:
+                    continue
+                degraded = False
+                if kind == 'service_health':
+                    degraded = str(attrs.get('state') or '').upper() != 'ON' or str(attrs.get('substate') or '').lower() not in {'running', 'listening', 'unknown'}
+                elif kind == 'service_probe':
+                    degraded = not bool(attrs.get('reachable'))
+                else:
+                    degraded = str(attrs.get('state') or '').lower() in {'degraded', 'down'}
+                if degraded:
+                    related_service_targets.add(target)
+                    if str(event.get('event_id') or ''):
+                        evidence_ids.add(str(event.get('event_id')))
+
+        for event in by_kind.get('resolution_probe_window', []):
+            attrs = event.get('attrs', {})
+            state = str(attrs.get('state') or '').lower()
+            if state in {'degraded', 'failed'}:
+                target = str(attrs.get('name') or event.get('subject') or '').strip()
+                if target:
+                    related_service_targets.add(target)
+                    if str(event.get('event_id') or ''):
+                        evidence_ids.add(str(event.get('event_id')))
+
+        for payload in payloads:
+            attrs = payload.get('attrs', {})
+            event_id = str(payload.get('event_id') or '')
+            if payload.get('source') in {'suricata_eve', 'flow_min'}:
+                src, dst = _parse_subject(str(payload.get('subject') or ''))
+                for ip in (src, dst):
+                    if ip:
+                        segment = _network_id_for_ip(networks, ip)
+                        if segment:
+                            affected_segments.add(segment)
+                            if event_id:
+                                evidence_ids.add(event_id)
+                app_proto = str(attrs.get('app_proto') or '').strip()
+                if app_proto:
+                    related_service_targets.add(app_proto)
+            elif payload.get('kind') in {'dhcp_lease', 'arp_entry', 'client_session'}:
+                ip = str(attrs.get('ip') or '')
+                segment = str(attrs.get('interface_or_segment') or '')
+                if not segment and ip:
+                    segment = _network_id_for_ip(networks, ip)
+                if segment:
+                    affected_segments.add(segment)
+                    if event_id:
+                        evidence_ids.add(event_id)
+
+        device_by_ip = {
+            str(item.get('ip') or ''): item
+            for item in devices
+            if isinstance(item, dict) and str(item.get('ip') or '')
+        }
+        affected_client_count = 0
+        critical_client_count = 0
+        client_groups: set[str] = set()
+        for event in by_kind.get('client_session', []):
+            attrs = event.get('attrs', {})
+            ip = str(attrs.get('ip') or '')
+            segment = str(attrs.get('interface_or_segment') or '')
+            session_state = str(attrs.get('session_state') or '')
+            if not segment and ip:
+                segment = _network_id_for_ip(networks, ip)
+            impacted = False
+            if segment and segment in affected_segments:
+                impacted = True
+            if attrs.get('interface_or_segment') and str(attrs.get('interface_or_segment')) in affected_uplinks:
+                impacted = True
+            if session_state in {'authorized_missing', 'stale_session'}:
+                impacted = False
+            if impacted:
+                affected_client_count += 1
+                device = device_by_ip.get(ip, {})
+                criticality = str(device.get('criticality') or '').lower()
+                if criticality in {'critical', 'high', 'core', 'mission'}:
+                    critical_client_count += 1
+                    client_groups.add('critical')
+                elif criticality:
+                    client_groups.add(criticality)
+
+        related_service_targets = {
+            target
+            for target in related_service_targets
+            if not service_ids or target in service_ids or ':' in target or '.' in target
+        }
+        if not affected_segments and not affected_uplinks and not related_service_targets:
+            return {}
+        return {
+            'affected_uplinks': sorted(affected_uplinks),
+            'affected_segments': sorted(affected_segments),
+            'related_service_targets': sorted(related_service_targets),
+            'affected_client_count': affected_client_count,
+            'critical_client_count': critical_client_count,
+            'client_groups': sorted(client_groups),
+            'multi_segment': len(affected_segments) > 1,
+            'evidence_ids': sorted(evidence_ids),
         }

--- a/py/azazel_edge/explanations/decision.py
+++ b/py/azazel_edge/explanations/decision.py
@@ -61,6 +61,7 @@ class DecisionExplainer:
                 'service_health': (noc.get('service_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
                 'resolution_health': (noc.get('resolution_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
             },
+            'affected_scope': (noc.get('affected_scope') or (noc_summary.get('blast_radius') if isinstance(noc_summary.get('blast_radius'), dict) else {})) if isinstance(noc, dict) else {},
             'ti_matches': soc_summary.get('ti_matches', []),
             'attack_candidates': attack_candidates,
             'sigma_hits': sigma_hits,
@@ -91,6 +92,7 @@ class DecisionExplainer:
             correlation=correlation,
             control_mode=control_mode,
             client_impact=client_impact,
+            affected_scope=why_chosen['affected_scope'],
         )
         explanation = {
             'ts': datetime.now(timezone.utc).isoformat(timespec='seconds'),
@@ -130,6 +132,7 @@ class DecisionExplainer:
         correlation: Dict[str, Any],
         control_mode: str,
         client_impact: Dict[str, Any],
+        affected_scope: Dict[str, Any],
     ) -> str:
         rejected_text = '; '.join(
             f"{item['action']} was rejected because {item['reason']}"
@@ -161,6 +164,12 @@ class DecisionExplainer:
                 f" Client impact: score {int(client_impact.get('score') or 0)}, "
                 f"affected {int(client_impact.get('affected_client_count') or 0)}, "
                 f"critical {int(client_impact.get('critical_client_count') or 0)}."
+            )
+        if isinstance(affected_scope, dict) and affected_scope:
+            sentence += (
+                f" Affected scope: uplinks {', '.join(affected_scope.get('affected_uplinks', [])[:3]) or '-'}, "
+                f"segments {', '.join(affected_scope.get('affected_segments', [])[:3]) or '-'}, "
+                f"estimated clients {int(affected_scope.get('affected_client_count') or 0)}."
             )
         if rejected_text:
             sentence += f" Alternatives: {rejected_text}."

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -109,6 +109,13 @@ class DashboardDataContractTests(unittest.TestCase):
                 "status": "failed",
                 "failed_targets": ["example.com"],
             },
+            "noc_blast_radius": {
+                "affected_uplinks": ["eth1"],
+                "affected_segments": ["lan-main", "wan"],
+                "related_service_targets": ["dns", "resolver-tcp"],
+                "affected_client_count": 4,
+                "critical_client_count": 1,
+            },
             "evidence": ["net_health=SUSPECTED signals=dns_mismatch"],
             "llm": {"status": "skipped_non_ambiguous"},
         }
@@ -262,6 +269,8 @@ class DashboardDataContractTests(unittest.TestCase):
         self.assertEqual(payload["noc_focus"]["client_inventory"]["inventory_mismatch_count"], 1)
         self.assertEqual(payload["noc_focus"]["service_assurance"]["status"], "degraded")
         self.assertEqual(payload["noc_focus"]["resolution_health"]["status"], "failed")
+        self.assertEqual(payload["noc_focus"]["blast_radius"]["affected_client_count"], 4)
+        self.assertEqual(payload["noc_focus"]["blast_radius"]["related_service_targets"], ["dns", "resolver-tcp"])
         self.assertEqual(payload["decision_path"]["first_pass_engine"], "tactical_scorer_v1")
         self.assertEqual(payload["decision_path"]["second_pass_status"], "completed")
 

--- a/tests/test_decision_explanation_v2.py
+++ b/tests/test_decision_explanation_v2.py
@@ -18,7 +18,7 @@ class DecisionExplanationV2Tests(unittest.TestCase):
     def test_explanation_contains_structured_v2_fields(self) -> None:
         explainer = DecisionExplainer(output_path=Path('/tmp/unused-decision-explanations.jsonl'))
         result = explainer.explain(
-            noc={'summary': {'status': 'good'}},
+            noc={'summary': {'status': 'good', 'blast_radius': {'affected_uplinks': ['eth1'], 'affected_segments': ['lan-a'], 'affected_client_count': 2}}, 'affected_scope': {'affected_uplinks': ['eth1'], 'affected_segments': ['lan-a'], 'affected_client_count': 2}},
             soc={'summary': {'status': 'critical', 'attack_candidates': ['T1071 Application Layer Protocol'], 'ai_attack_candidates': ['T1190 Exploit Public-Facing Application'], 'ti_matches': [{'indicator_type': 'ip', 'value': '10.0.0.5'}]}},
             arbiter={
                 'action': 'redirect',
@@ -36,6 +36,8 @@ class DecisionExplanationV2Tests(unittest.TestCase):
         self.assertIn('next_checks', result)
         self.assertIn('attack_candidates', result['why_chosen'])
         self.assertIn('ATT&CK candidates', result['operator_wording'])
+        self.assertEqual(result['why_chosen']['affected_scope']['affected_segments'], ['lan-a'])
+        self.assertIn('Affected scope: uplinks eth1, segments lan-a, estimated clients 2.', result['operator_wording'])
         self.assertIn('T1190 Exploit Public-Facing Application', result['why_chosen']['attack_candidates'])
 
     def test_explanation_can_be_persisted_as_jsonl(self) -> None:

--- a/tests/test_multi_segment_noc_v2.py
+++ b/tests/test_multi_segment_noc_v2.py
@@ -39,11 +39,13 @@ class MultiSegmentNocV2Tests(unittest.TestCase):
         events = [
             {'event_id': 'probe-1', 'source': 'noc_probe', 'kind': 'path_probe', 'subject': '192.168.40.1', 'severity': 0, 'confidence': 0.95, 'attrs': {'scope': 'gateway', 'reachable': True, 'interface': 'eth1'}},
             {'event_id': 'probe-2', 'source': 'noc_probe', 'kind': 'path_probe', 'subject': '192.168.40.1', 'severity': 70, 'confidence': 0.95, 'attrs': {'scope': 'gateway', 'reachable': False, 'interface': 'usb0'}},
+            {'event_id': 'svc-1', 'source': 'noc_probe', 'kind': 'service_probe_window', 'subject': 'resolver-tcp', 'severity': 65, 'confidence': 0.9, 'attrs': {'name': 'resolver-tcp', 'state': 'down'}},
+            {'event_id': 'client-1', 'source': 'noc_probe', 'kind': 'client_session', 'subject': '192.168.40.10', 'severity': 0, 'confidence': 0.85, 'attrs': {'ip': '192.168.40.10', 'interface_or_segment': 'lan-a', 'session_state': 'authorized_present'}},
             {'event_id': 'flow-1', 'source': 'flow_min', 'kind': 'flow_summary', 'subject': '192.168.40.10->10.20.0.10:443/TCP', 'severity': 60, 'confidence': 0.8, 'attrs': {'src_ip': '192.168.40.10', 'dst_ip': '10.20.0.10', 'dst_port': 443}},
         ]
         sot = {
-            'devices': [],
-            'services': [],
+            'devices': [{'id': 'dev1', 'hostname': 'client-1', 'ip': '192.168.40.10', 'mac': 'aa:bb:cc:dd:ee:ff', 'criticality': 'critical', 'allowed_networks': ['lan-a']}],
+            'services': [{'id': 'resolver-tcp', 'target': '1.1.1.1:53'}],
             'expected_paths': [],
             'networks': [
                 {'id': 'lan-a', 'cidr': '192.168.40.0/24', 'zone': 'lan', 'gateway': '192.168.40.1'},
@@ -54,6 +56,10 @@ class MultiSegmentNocV2Tests(unittest.TestCase):
         self.assertIn('uplink_divergence', result['path_health']['reasons'])
         self.assertTrue(result['summary']['segment_scope']['multi_segment'])
         self.assertEqual(result['summary']['segment_scope']['affected_segments'], ['lan-a', 'lan-b'])
+        self.assertEqual(result['affected_scope']['affected_uplinks'], ['usb0'])
+        self.assertEqual(result['affected_scope']['related_service_targets'], ['resolver-tcp'])
+        self.assertEqual(result['affected_scope']['affected_client_count'], 1)
+        self.assertEqual(result['affected_scope']['critical_client_count'], 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add a lightweight NOC dependency model for uplinks, segments, service targets, and client groups
- generate blast-radius summaries from NOC evidence and expose the affected scope through evaluator output
- surface the compact blast-radius view in dashboard and decision explanation flows

## Verification
- `PYTHONPATH=/home/azazel/Azazel-Edge ./.venv/bin/pytest -q` -> `146 passed`
- `git diff --check`

## Notes
- this branch depends on PR #69 already being merged into `main`