### PR TITLE
Add NOC config drift health tracking

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -982,6 +982,7 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
     noc_service_assurance = state.get("noc_service_assurance") if isinstance(state.get("noc_service_assurance"), dict) else {}
     noc_resolution_assurance = state.get("noc_resolution_assurance") if isinstance(state.get("noc_resolution_assurance"), dict) else {}
     noc_blast_radius = state.get("noc_blast_radius") if isinstance(state.get("noc_blast_radius"), dict) else {}
+    noc_config_drift = state.get("noc_config_drift") if isinstance(state.get("noc_config_drift"), dict) else {}
     return {
         "ok": True,
         "risk": {
@@ -1085,6 +1086,12 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
                 "related_service_targets": noc_blast_radius.get("related_service_targets") if isinstance(noc_blast_radius.get("related_service_targets"), list) else [],
                 "affected_client_count": _as_int(noc_blast_radius.get("affected_client_count"), 0),
                 "critical_client_count": _as_int(noc_blast_radius.get("critical_client_count"), 0),
+            },
+            "config_drift": {
+                "status": str(noc_config_drift.get("status") or "unknown"),
+                "baseline_state": str(noc_config_drift.get("baseline_state") or "unknown"),
+                "changed_fields": noc_config_drift.get("changed_fields") if isinstance(noc_config_drift.get("changed_fields"), list) else [],
+                "rollback_hint": str(noc_config_drift.get("rollback_hint") or ""),
             },
             "capacity": {
                 "state": str(noc_capacity.get("state") or "unknown"),

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -1009,6 +1009,7 @@ function updateSplitBoard(summary, actions) {
     const serviceAssurance = noc.service_assurance || {};
     const resolutionHealth = noc.resolution_health || {};
     const blastRadius = noc.blast_radius || {};
+    const configDrift = noc.config_drift || {};
     const capacity = noc.capacity || {};
     const clientInventory = noc.client_inventory || {};
     const clientImpact = noc.client_impact || {};
@@ -1050,6 +1051,7 @@ function updateSplitBoard(summary, actions) {
     updateElement('nocServiceAssurance', String(serviceAssurance.status || 'unknown').toUpperCase());
     updateElement('nocResolutionHealth', String(resolutionHealth.status || 'unknown').toUpperCase());
     updateElement('nocBlastTargets', (blastRadius.related_service_targets || []).join(', ') || '-');
+    updateElement('nocConfigDrift', `${String(configDrift.status || 'unknown').toUpperCase()} / ${String(configDrift.baseline_state || 'unknown').toUpperCase()}`);
     const utilization = capacity.utilization_pct == null || capacity.utilization_pct === ''
         ? '-'
         : `${capacity.utilization_pct}%`;

--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -303,6 +303,7 @@
                                             <div class="fact-item"><span>Assurance</span><strong id="nocServiceAssurance">-</strong></div>
                                             <div class="fact-item"><span>Resolution</span><strong id="nocResolutionHealth">-</strong></div>
                                             <div class="fact-item"><span>Targets</span><strong id="nocBlastTargets">-</strong></div>
+                                            <div class="fact-item"><span>Config Drift</span><strong id="nocConfigDrift">-</strong></div>
                                         </div>
                                         <ul class="action-list" id="nocServiceList">
                                             <li>{{ tr('dashboard.no_service_summary', 'No service summary.') }}</li>

--- a/py/azazel_edge/arbiter/action.py
+++ b/py/azazel_edge/arbiter/action.py
@@ -131,7 +131,7 @@ class ActionArbiter:
             chosen.extend(noc.get('evidence_ids', []))
             chosen.extend(soc.get('evidence_ids', []))
         elif action == 'notify':
-            for key in ('availability', 'path_health', 'device_health', 'capacity_health', 'client_inventory_health'):
+            for key in ('availability', 'path_health', 'device_health', 'capacity_health', 'client_inventory_health', 'config_drift_health'):
                 chosen.extend(noc.get(key, {}).get('evidence_ids', []))
             chosen.extend(soc.get('suspicion', {}).get('evidence_ids', []))
         else:
@@ -141,6 +141,7 @@ class ActionArbiter:
             chosen.extend(noc.get('path_health', {}).get('evidence_ids', []))
             chosen.extend(noc.get('capacity_health', {}).get('evidence_ids', []))
             chosen.extend(noc.get('client_inventory_health', {}).get('evidence_ids', []))
+            chosen.extend(noc.get('config_drift_health', {}).get('evidence_ids', []))
         return sorted(dict.fromkeys(str(x) for x in chosen if str(x)))
 
     @staticmethod
@@ -207,6 +208,7 @@ class ActionArbiter:
             'device_label': str(noc.get('device_health', {}).get('label') or 'unknown'),
             'capacity_label': str(noc.get('capacity_health', {}).get('label') or 'unknown'),
             'client_inventory_label': str(noc.get('client_inventory_health', {}).get('label') or 'unknown'),
+            'config_drift_label': str(noc.get('config_drift_health', {}).get('label') or 'unknown'),
             'suspicion_label': str(soc.get('suspicion', {}).get('label') or 'unknown'),
             'suspicion_score': int(soc.get('suspicion', {}).get('score') or 0),
             'confidence_score': int(confidence_score or 0),

--- a/py/azazel_edge/config_drift.py
+++ b/py/azazel_edge/config_drift.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Tuple
 
 from azazel_edge.audit import P0AuditLogger
 from azazel_edge.path_schema import (
@@ -13,6 +13,149 @@ from azazel_edge.path_schema import (
     mode_state_candidates,
     opencanary_config_candidates,
 )
+from azazel_edge.sensors.noc_monitor import DEFAULT_DHCP_LEASE_PATHS, DEFAULT_RESOLUTION_TARGETS, DEFAULT_SERVICE_PROBE_TARGETS, EXTERNAL_PATH_TARGETS
+
+
+HEALTH_CONFIG_SCHEMA = 'noc_health_config_snapshot_v1'
+
+
+def _normalize_list(values: Iterable[Any]) -> List[str]:
+    return sorted(dict.fromkeys(str(item).strip() for item in values if str(item).strip()))
+
+
+def _normalize_service_targets(values: Iterable[Any]) -> List[str]:
+    normalized: List[str] = []
+    for item in values:
+        if isinstance(item, dict):
+            target = str(item.get('name') or item.get('target') or item.get('url') or f"{item.get('host') or ''}:{item.get('port') or ''}").strip(':')
+        else:
+            target = str(item).strip()
+        if target:
+            normalized.append(target)
+    return _normalize_list(normalized)
+
+
+def _flatten_dict(payload: Dict[str, Any], prefix: str = '') -> Dict[str, Any]:
+    flat: Dict[str, Any] = {}
+    for key, value in sorted(payload.items()):
+        current = f'{prefix}.{key}' if prefix else str(key)
+        if isinstance(value, dict):
+            flat.update(_flatten_dict(value, current))
+        else:
+            flat[current] = value
+    return flat
+
+
+def extract_health_config_snapshot(runtime: Dict[str, Any] | None = None, sot: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    state = runtime if isinstance(runtime, dict) else {}
+    source_of_truth = sot if isinstance(sot, dict) else {}
+    preferred_uplink = str(state.get('preferred_uplink') or state.get('up_if') or '')
+    uplink_order = state.get('uplink_order') if isinstance(state.get('uplink_order'), list) else ([preferred_uplink] if preferred_uplink else [])
+    path_targets = state.get('path_targets') if isinstance(state.get('path_targets'), list) else list(EXTERNAL_PATH_TARGETS)
+    if str(state.get('gateway_ip') or '').strip():
+        path_targets = [str(state.get('gateway_ip')).strip(), *[item for item in path_targets if str(item).strip() and str(item).strip() != str(state.get('gateway_ip')).strip()]]
+    snapshot = {
+        'schema': HEALTH_CONFIG_SCHEMA,
+        'uplink_preference': {
+            'preferred_uplink': preferred_uplink,
+            'failover_order': _normalize_list(uplink_order),
+        },
+        'probe_targets': {
+            'path_targets': _normalize_list(path_targets),
+            'resolution_targets': _normalize_list(state.get('resolution_targets') if isinstance(state.get('resolution_targets'), list) else DEFAULT_RESOLUTION_TARGETS),
+            'service_targets': _normalize_service_targets(state.get('service_probe_targets') if isinstance(state.get('service_probe_targets'), list) else DEFAULT_SERVICE_PROBE_TARGETS),
+        },
+        'dhcp_settings': {
+            'gateway_ip': str(state.get('gateway_ip') or ''),
+            'lease_sources': _normalize_list(state.get('dhcp_lease_paths') if isinstance(state.get('dhcp_lease_paths'), list) else [str(path) for path in DEFAULT_DHCP_LEASE_PATHS]),
+            'managed_networks': _normalize_list(item.get('id') for item in source_of_truth.get('networks', []) if isinstance(item, dict)),
+        },
+        'segment_membership': {
+            'network_ids': _normalize_list(item.get('id') for item in source_of_truth.get('networks', []) if isinstance(item, dict)),
+            'service_ids': _normalize_list(item.get('id') for item in source_of_truth.get('services', []) if isinstance(item, dict)),
+            'device_networks': {
+                str(item.get('id') or ''): _normalize_list(item.get('allowed_networks', []))
+                for item in source_of_truth.get('devices', [])
+                if isinstance(item, dict) and str(item.get('id') or '')
+            },
+        },
+        'policy_markers': {
+            'current_mode': str(((state.get('mode') or {}) if isinstance(state.get('mode'), dict) else {}).get('current_mode') or state.get('current_mode') or ''),
+            'policy_version': str(state.get('policy_version') or state.get('defaults_version') or ''),
+            'expected_path_count': len([item for item in source_of_truth.get('expected_paths', []) if isinstance(item, dict)]),
+            'service_count': len([item for item in source_of_truth.get('services', []) if isinstance(item, dict)]),
+        },
+    }
+    validate_health_config_snapshot(snapshot)
+    return snapshot
+
+
+def validate_health_config_snapshot(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(snapshot, dict):
+        raise ValueError('health_config_snapshot_invalid')
+    if str(snapshot.get('schema') or '') != HEALTH_CONFIG_SCHEMA:
+        raise ValueError('health_config_snapshot_invalid')
+    required_sections = ('uplink_preference', 'probe_targets', 'dhcp_settings', 'segment_membership', 'policy_markers')
+    for section in required_sections:
+        if not isinstance(snapshot.get(section), dict):
+            raise ValueError('health_config_snapshot_invalid')
+    if not isinstance(snapshot['uplink_preference'].get('failover_order'), list):
+        raise ValueError('health_config_snapshot_invalid')
+    if not isinstance(snapshot['probe_targets'].get('path_targets'), list):
+        raise ValueError('health_config_snapshot_invalid')
+    if not isinstance(snapshot['probe_targets'].get('resolution_targets'), list):
+        raise ValueError('health_config_snapshot_invalid')
+    if not isinstance(snapshot['probe_targets'].get('service_targets'), list):
+        raise ValueError('health_config_snapshot_invalid')
+    if not isinstance(snapshot['dhcp_settings'].get('lease_sources'), list):
+        raise ValueError('health_config_snapshot_invalid')
+    if not isinstance(snapshot['dhcp_settings'].get('managed_networks'), list):
+        raise ValueError('health_config_snapshot_invalid')
+    if not isinstance(snapshot['segment_membership'].get('network_ids'), list):
+        raise ValueError('health_config_snapshot_invalid')
+    if not isinstance(snapshot['segment_membership'].get('service_ids'), list):
+        raise ValueError('health_config_snapshot_invalid')
+    if not isinstance(snapshot['segment_membership'].get('device_networks'), dict):
+        raise ValueError('health_config_snapshot_invalid')
+    return snapshot
+
+
+def diff_health_config_snapshots(baseline: Dict[str, Any] | None, current: Dict[str, Any] | None) -> Dict[str, Any]:
+    if not isinstance(baseline, dict):
+        return {
+            'status': 'baseline_missing',
+            'baseline_state': 'missing',
+            'changed_fields': [],
+            'baseline_values': {},
+            'current_values': {},
+            'rollback_hint': 'create_last_known_good_baseline',
+        }
+    try:
+        validated_baseline = validate_health_config_snapshot(dict(baseline))
+    except ValueError:
+        return {
+            'status': 'baseline_invalid',
+            'baseline_state': 'invalid',
+            'changed_fields': [],
+            'baseline_values': {},
+            'current_values': {},
+            'rollback_hint': 'repair_or_replace_invalid_baseline',
+        }
+    validated_current = validate_health_config_snapshot(dict(current or {}))
+    baseline_flat = _flatten_dict({k: v for k, v in validated_baseline.items() if k != 'schema'})
+    current_flat = _flatten_dict({k: v for k, v in validated_current.items() if k != 'schema'})
+    changed_fields = sorted(field for field in set(baseline_flat) | set(current_flat) if baseline_flat.get(field) != current_flat.get(field))
+    return {
+        'status': 'drift' if changed_fields else 'baseline_match',
+        'baseline_state': 'present',
+        'changed_fields': changed_fields,
+        'baseline_values': {field: baseline_flat.get(field) for field in changed_fields},
+        'current_values': {field: current_flat.get(field) for field in changed_fields},
+        'rollback_hint': (
+            'review_changed_fields_and_restore_last_known_good'
+            if changed_fields else 'baseline_matches_current'
+        ),
+    }
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -123,6 +266,26 @@ class ConfigDriftAuditor:
         }
         return result
 
+    def create_health_baseline(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
+        validated = validate_health_config_snapshot(dict(snapshot))
+        payload = {
+            'ts': datetime.now(timezone.utc).isoformat(timespec='seconds'),
+            'schema': HEALTH_CONFIG_SCHEMA,
+            'snapshot': validated,
+        }
+        self.baseline_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2), encoding='utf-8')
+        return payload
+
+    def detect_health_drift(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            baseline = self._load_health_baseline()
+        except ValueError:
+            baseline = {'ts': '', 'snapshot': {'schema': 'invalid'}}
+        diff = diff_health_config_snapshots(baseline.get('snapshot'), snapshot)
+        diff['baseline_path'] = str(self.baseline_path)
+        diff['baseline_ts'] = baseline.get('ts', '')
+        return diff
+
     def audit_drift(self, trace_id: str, drift: Dict[str, Any]) -> Dict[str, Any]:
         if self.audit is None:
             return drift
@@ -152,3 +315,15 @@ class ConfigDriftAuditor:
         if not isinstance(payload.get('entries', []), list):
             raise ValueError('config_drift_baseline_invalid')
         return payload
+
+    def _load_health_baseline(self) -> Dict[str, Any]:
+        if not self.baseline_path.exists():
+            return {'ts': '', 'snapshot': None}
+        payload = json.loads(self.baseline_path.read_text(encoding='utf-8'))
+        if not isinstance(payload, dict):
+            raise ValueError('config_drift_baseline_invalid')
+        snapshot = payload.get('snapshot')
+        if snapshot is None:
+            return {'ts': '', 'snapshot': None}
+        validate_health_config_snapshot(snapshot)
+        return {'ts': str(payload.get('ts') or ''), 'snapshot': snapshot}

--- a/py/azazel_edge/evaluators/noc.py
+++ b/py/azazel_edge/evaluators/noc.py
@@ -73,6 +73,12 @@ DEFAULT_CONFIG: Dict[str, Dict[str, int]] = {
         'window_failed_penalty': 30,
         'collector_failure_penalty': 10,
     },
+    'config_drift_health': {
+        'drift_penalty_per_field': 8,
+        'drift_penalty_cap': 32,
+        'baseline_missing_penalty': 12,
+        'baseline_invalid_penalty': 20,
+    },
 }
 
 
@@ -94,6 +100,8 @@ def _merge_config(config: Dict[str, Any] | None) -> Dict[str, Dict[str, int]]:
         raise ValueError('invalid_service_health_config')
     if merged['resolution_health']['window_failed_penalty'] < merged['resolution_health']['window_degraded_penalty']:
         raise ValueError('invalid_resolution_health_config')
+    if merged['config_drift_health']['drift_penalty_cap'] < merged['config_drift_health']['drift_penalty_per_field']:
+        raise ValueError('invalid_config_drift_health_config')
     return merged
 
 
@@ -184,6 +192,7 @@ class NocEvaluator:
         client_inventory_health = self._evaluate_client_inventory_health(payloads, by_kind, sot=sot, sot_diff=sot_diff)
         service_health = self._evaluate_service_health(by_kind)
         resolution_health = self._evaluate_resolution_health(by_kind)
+        config_drift_health = self._evaluate_config_drift_health(by_kind)
         if sot_diff:
             path_health = self._apply_sot_diff_to_path_health(path_health, sot_diff)
 
@@ -206,6 +215,7 @@ class NocEvaluator:
             client_inventory_health,
             service_health,
             resolution_health,
+            config_drift_health,
         ]
         worst_score = min(int(dim['score']) for dim in dimensions) if dimensions else 100
         if worst_score < 90:
@@ -220,6 +230,7 @@ class NocEvaluator:
                     ('client_inventory_health', client_inventory_health),
                     ('service_health', service_health),
                     ('resolution_health', resolution_health),
+                    ('config_drift_health', config_drift_health),
                 )
                 if dim['label'] != 'good'
             )
@@ -244,6 +255,7 @@ class NocEvaluator:
             'client_inventory_health': client_inventory_health,
             'service_health': service_health,
             'resolution_health': resolution_health,
+            'config_drift_health': config_drift_health,
             'affected_scope': affected_scope,
             'summary': summary,
             'evidence_ids': sorted(dict.fromkeys(all_evidence_ids)),
@@ -263,6 +275,7 @@ class NocEvaluator:
             'client_inventory_health': evaluation.get('client_inventory_health', {}),
             'service_health': evaluation.get('service_health', {}),
             'resolution_health': evaluation.get('resolution_health', {}),
+            'config_drift_health': evaluation.get('config_drift_health', {}),
             'affected_scope': evaluation.get('affected_scope', {}),
             'evidence_ids': evaluation.get('evidence_ids', []),
         }
@@ -620,6 +633,36 @@ class NocEvaluator:
                 reasons.append('collector_failure:resolution_probes')
 
         return _make_dimension(score, reasons, evidence_ids)
+
+    def _evaluate_config_drift_health(self, by_kind: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+        cfg = self.config['config_drift_health']
+        score = 100
+        reasons: List[str] = []
+        evidence_ids: List[str] = []
+        rollback_hint = ''
+
+        for event in by_kind.get('config_drift', []):
+            evidence_ids.append(str(event.get('event_id') or ''))
+            attrs = event.get('attrs', {})
+            status = str(attrs.get('status') or 'baseline_missing')
+            changed_fields = [str(item) for item in attrs.get('changed_fields', []) if str(item)]
+            if not rollback_hint:
+                rollback_hint = str(attrs.get('rollback_hint') or '')
+            if status == 'drift':
+                penalty = min(cfg['drift_penalty_cap'], cfg['drift_penalty_per_field'] * max(1, len(changed_fields)))
+                score -= penalty
+                reasons.append('config_drift_detected')
+                reasons.extend(f'config_drift:{field}' for field in changed_fields[:4])
+            elif status == 'baseline_missing':
+                score -= cfg['baseline_missing_penalty']
+                reasons.append('config_baseline_missing')
+            elif status == 'baseline_invalid':
+                score -= cfg['baseline_invalid_penalty']
+                reasons.append('config_baseline_invalid')
+
+        result = _make_dimension(score, reasons, evidence_ids)
+        result['rollback_hint'] = rollback_hint
+        return result
 
     @staticmethod
     def _apply_sot_diff_to_path_health(path_health: Dict[str, Any], sot_diff: Dict[str, Any]) -> Dict[str, Any]:

--- a/py/azazel_edge/evidence_plane/__init__.py
+++ b/py/azazel_edge/evidence_plane/__init__.py
@@ -1,5 +1,6 @@
 from .schema import EvidenceEvent, REQUIRED_FIELDS, iso_utc_now, make_event_id
 from .bus import EvidenceBus
+from .config_drift import build_config_drift_event
 from .flow_min import adapt_flow_record, iter_flow_jsonl, read_flow_jsonl, summarize_flow_events
 from .noc_inventory import build_client_inventory, build_client_inventory_events
 from .suricata import adapt_suricata_record, iter_suricata_jsonl, read_suricata_jsonl
@@ -25,4 +26,5 @@ __all__ = [
     'NocProbeAdapter',
     'adapt_syslog_line',
     'EvidencePlaneService',
+    'build_config_drift_event',
 ]

--- a/py/azazel_edge/evidence_plane/config_drift.py
+++ b/py/azazel_edge/evidence_plane/config_drift.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from .schema import EvidenceEvent
+
+
+def build_config_drift_event(diff: Dict[str, Any], ts: str | None = None) -> EvidenceEvent:
+    status = str(diff.get('status') or 'baseline_missing')
+    severity = 0
+    if status == 'drift':
+        severity = 45
+    elif status == 'baseline_invalid':
+        severity = 35
+    elif status == 'baseline_missing':
+        severity = 20
+    attrs = {
+        'status': status,
+        'baseline_state': str(diff.get('baseline_state') or 'missing'),
+        'changed_fields': list(diff.get('changed_fields') or []),
+        'baseline_values': dict(diff.get('baseline_values') or {}),
+        'current_values': dict(diff.get('current_values') or {}),
+        'rollback_hint': str(diff.get('rollback_hint') or ''),
+    }
+    return EvidenceEvent.build(
+        ts=ts or datetime.now(timezone.utc).isoformat(timespec='seconds'),
+        source='config_drift',
+        kind='config_drift',
+        subject='health_config',
+        severity=severity,
+        confidence=0.9 if status in {'drift', 'baseline_match'} else 0.75,
+        attrs=attrs,
+        status='warn' if severity > 0 else 'info',
+    )

--- a/py/azazel_edge/evidence_plane/service.py
+++ b/py/azazel_edge/evidence_plane/service.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from .bus import EvidenceBus
+from .config_drift import build_config_drift_event
 from .flow_min import read_flow_jsonl
 from .noc_inventory import build_client_inventory_events
 from .noc_probe import NocProbeAdapter
@@ -30,6 +31,9 @@ class EvidencePlaneService:
         events = probe.collect(snapshot=snapshot if isinstance(snapshot, dict) else None)
         events.extend(build_client_inventory_events(events))
         return self.dispatch_events(events)
+
+    def dispatch_config_drift(self, diff: Dict[str, object]) -> Dict[str, object]:
+        return self.bus.publish(build_config_drift_event(diff))
 
     def dispatch_syslog_line(self, line: str) -> Dict[str, object]:
         return self.bus.publish(adapt_syslog_line(line))

--- a/py/azazel_edge/explanations/decision.py
+++ b/py/azazel_edge/explanations/decision.py
@@ -60,8 +60,10 @@ class DecisionExplainer:
                 'client_inventory_health': (noc.get('client_inventory_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
                 'service_health': (noc.get('service_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
                 'resolution_health': (noc.get('resolution_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
+                'config_drift_health': (noc.get('config_drift_health') or {}).get('label', 'unknown') if isinstance(noc, dict) else 'unknown',
             },
             'affected_scope': (noc.get('affected_scope') or (noc_summary.get('blast_radius') if isinstance(noc_summary.get('blast_radius'), dict) else {})) if isinstance(noc, dict) else {},
+            'config_drift': (noc.get('config_drift_health') or {}) if isinstance(noc, dict) else {},
             'ti_matches': soc_summary.get('ti_matches', []),
             'attack_candidates': attack_candidates,
             'sigma_hits': sigma_hits,
@@ -93,6 +95,7 @@ class DecisionExplainer:
             control_mode=control_mode,
             client_impact=client_impact,
             affected_scope=why_chosen['affected_scope'],
+            config_drift=why_chosen['config_drift'],
         )
         explanation = {
             'ts': datetime.now(timezone.utc).isoformat(timespec='seconds'),
@@ -133,6 +136,7 @@ class DecisionExplainer:
         control_mode: str,
         client_impact: Dict[str, Any],
         affected_scope: Dict[str, Any],
+        config_drift: Dict[str, Any],
     ) -> str:
         rejected_text = '; '.join(
             f"{item['action']} was rejected because {item['reason']}"
@@ -171,6 +175,10 @@ class DecisionExplainer:
                 f"segments {', '.join(affected_scope.get('affected_segments', [])[:3]) or '-'}, "
                 f"estimated clients {int(affected_scope.get('affected_client_count') or 0)}."
             )
+        if isinstance(config_drift, dict) and config_drift:
+            drift_reasons = [str(item) for item in config_drift.get('reasons', []) if str(item)]
+            if drift_reasons:
+                sentence += f" Config drift indicators: {', '.join(drift_reasons[:3])}."
         if rejected_text:
             sentence += f" Alternatives: {rejected_text}."
         return sentence
@@ -195,6 +203,8 @@ class DecisionExplainer:
             checks.append('review_capacity_and_client_inventory_summary')
         if any(str(noc_summary.get('reasons') or '').find(token) >= 0 for token in ('service_health', 'resolution_health')):
             checks.append('review_path_and_service_assurance')
+        if any(str(noc_summary.get('reasons') or '').find(token) >= 0 for token in ('config_drift_health', 'config_drift')):
+            checks.append('review_config_drift_and_last_known_good')
         if int(client_impact.get('critical_client_count') or 0) > 0:
             checks.append('confirm_critical_client_owner_before_control')
         return checks

--- a/tests/test_config_drift_audit_v1.py
+++ b/tests/test_config_drift_audit_v1.py
@@ -12,7 +12,12 @@ if str(PY_ROOT) not in sys.path:
     sys.path.insert(0, str(PY_ROOT))
 
 from azazel_edge.audit import P0AuditLogger
-from azazel_edge.config_drift import ConfigDriftAuditor
+from azazel_edge.config_drift import (
+    ConfigDriftAuditor,
+    HEALTH_CONFIG_SCHEMA,
+    extract_health_config_snapshot,
+)
+from azazel_edge.evidence_plane import build_config_drift_event
 
 
 class ConfigDriftAuditV1Tests(unittest.TestCase):
@@ -55,6 +60,50 @@ class ConfigDriftAuditV1Tests(unittest.TestCase):
         self.assertEqual(record['kind'], 'evaluation')
         self.assertEqual(rows[-1]['source'], 'config_drift_audit')
         self.assertEqual(rows[-1]['status'], 'drift')
+
+    def test_health_config_snapshot_and_drift_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            auditor = ConfigDriftAuditor(root / 'health-baseline.json')
+            sot = {
+                'devices': [{'id': 'dev1', 'hostname': 'client-1', 'ip': '192.168.40.10', 'mac': 'aa:bb:cc:dd:ee:ff', 'criticality': 'critical', 'allowed_networks': ['lan-main']}],
+                'networks': [{'id': 'lan-main', 'cidr': '192.168.40.0/24', 'zone': 'lan', 'gateway': '192.168.40.1'}],
+                'services': [{'id': 'resolver-tcp', 'proto': 'tcp', 'port': 53, 'owner': 'noc', 'exposure': 'internal'}],
+                'expected_paths': [],
+            }
+            baseline_snapshot = extract_health_config_snapshot(
+                {'up_if': 'eth1', 'gateway_ip': '192.168.40.1', 'policy_version': 'v1'},
+                sot=sot,
+            )
+            self.assertEqual(baseline_snapshot['schema'], HEALTH_CONFIG_SCHEMA)
+            auditor.create_health_baseline(baseline_snapshot)
+
+            current_snapshot = extract_health_config_snapshot(
+                {'up_if': 'usb0', 'gateway_ip': '192.168.40.1', 'policy_version': 'v2'},
+                sot=sot,
+            )
+            diff = auditor.detect_health_drift(current_snapshot)
+            event = build_config_drift_event(diff).to_dict()
+
+        self.assertEqual(diff['status'], 'drift')
+        self.assertIn('uplink_preference.preferred_uplink', diff['changed_fields'])
+        self.assertIn('policy_markers.policy_version', diff['changed_fields'])
+        self.assertEqual(event['kind'], 'config_drift')
+        self.assertEqual(event['attrs']['rollback_hint'], 'review_changed_fields_and_restore_last_known_good')
+
+    def test_missing_and_invalid_health_baseline_are_degraded_not_green(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            auditor = ConfigDriftAuditor(root / 'health-baseline.json')
+            current_snapshot = extract_health_config_snapshot({'up_if': 'eth1'}, sot={'devices': [], 'networks': [], 'services': [], 'expected_paths': []})
+            missing = auditor.detect_health_drift(current_snapshot)
+            auditor.baseline_path.write_text(json.dumps({'ts': '2026-03-13T00:00:00Z', 'snapshot': {'schema': 'broken'}}), encoding='utf-8')
+            invalid = auditor.detect_health_drift(current_snapshot)
+
+        self.assertEqual(missing['status'], 'baseline_missing')
+        self.assertEqual(missing['rollback_hint'], 'create_last_known_good_baseline')
+        self.assertEqual(invalid['status'], 'baseline_invalid')
+        self.assertEqual(invalid['rollback_hint'], 'repair_or_replace_invalid_baseline')
 
 
 if __name__ == '__main__':

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -116,6 +116,12 @@ class DashboardDataContractTests(unittest.TestCase):
                 "affected_client_count": 4,
                 "critical_client_count": 1,
             },
+            "noc_config_drift": {
+                "status": "drift",
+                "baseline_state": "present",
+                "changed_fields": ["uplink_preference.preferred_uplink", "policy_markers.policy_version"],
+                "rollback_hint": "review_changed_fields_and_restore_last_known_good",
+            },
             "evidence": ["net_health=SUSPECTED signals=dns_mismatch"],
             "llm": {"status": "skipped_non_ambiguous"},
         }
@@ -271,6 +277,8 @@ class DashboardDataContractTests(unittest.TestCase):
         self.assertEqual(payload["noc_focus"]["resolution_health"]["status"], "failed")
         self.assertEqual(payload["noc_focus"]["blast_radius"]["affected_client_count"], 4)
         self.assertEqual(payload["noc_focus"]["blast_radius"]["related_service_targets"], ["dns", "resolver-tcp"])
+        self.assertEqual(payload["noc_focus"]["config_drift"]["status"], "drift")
+        self.assertEqual(payload["noc_focus"]["config_drift"]["rollback_hint"], "review_changed_fields_and_restore_last_known_good")
         self.assertEqual(payload["decision_path"]["first_pass_engine"], "tactical_scorer_v1")
         self.assertEqual(payload["decision_path"]["second_pass_status"], "completed")
 

--- a/tests/test_decision_explanation_v2.py
+++ b/tests/test_decision_explanation_v2.py
@@ -18,7 +18,15 @@ class DecisionExplanationV2Tests(unittest.TestCase):
     def test_explanation_contains_structured_v2_fields(self) -> None:
         explainer = DecisionExplainer(output_path=Path('/tmp/unused-decision-explanations.jsonl'))
         result = explainer.explain(
-            noc={'summary': {'status': 'good', 'blast_radius': {'affected_uplinks': ['eth1'], 'affected_segments': ['lan-a'], 'affected_client_count': 2}}, 'affected_scope': {'affected_uplinks': ['eth1'], 'affected_segments': ['lan-a'], 'affected_client_count': 2}},
+            noc={
+                'summary': {'status': 'good', 'blast_radius': {'affected_uplinks': ['eth1'], 'affected_segments': ['lan-a'], 'affected_client_count': 2}},
+                'affected_scope': {'affected_uplinks': ['eth1'], 'affected_segments': ['lan-a'], 'affected_client_count': 2},
+                'config_drift_health': {
+                    'label': 'degraded',
+                    'reasons': ['config_drift_detected', 'config_drift:uplink_preference.preferred_uplink'],
+                    'rollback_hint': 'review_changed_fields_and_restore_last_known_good',
+                },
+            },
             soc={'summary': {'status': 'critical', 'attack_candidates': ['T1071 Application Layer Protocol'], 'ai_attack_candidates': ['T1190 Exploit Public-Facing Application'], 'ti_matches': [{'indicator_type': 'ip', 'value': '10.0.0.5'}]}},
             arbiter={
                 'action': 'redirect',
@@ -38,6 +46,7 @@ class DecisionExplanationV2Tests(unittest.TestCase):
         self.assertIn('ATT&CK candidates', result['operator_wording'])
         self.assertEqual(result['why_chosen']['affected_scope']['affected_segments'], ['lan-a'])
         self.assertIn('Affected scope: uplinks eth1, segments lan-a, estimated clients 2.', result['operator_wording'])
+        self.assertIn('Config drift indicators: config_drift_detected, config_drift:uplink_preference.preferred_uplink.', result['operator_wording'])
         self.assertIn('T1190 Exploit Public-Facing Application', result['why_chosen']['attack_candidates'])
 
     def test_explanation_can_be_persisted_as_jsonl(self) -> None:

--- a/tests/test_evidence_plane_v1.py
+++ b/tests/test_evidence_plane_v1.py
@@ -18,6 +18,7 @@ from azazel_edge.evidence_plane import (
     EvidencePlaneService,
     NocProbeAdapter,
     adapt_suricata_record,
+    build_config_drift_event,
     build_client_inventory,
     adapt_syslog_line,
     read_suricata_jsonl,
@@ -213,6 +214,22 @@ class EvidencePlaneV1Tests(unittest.TestCase):
                 for field in REQUIRED_FIELDS:
                     self.assertIn(field, payload)
                 self.assertIsInstance(payload['attrs'], dict)
+
+    def test_config_drift_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bus = EvidenceBus(fanout_path=Path(tmp) / 'evidence.jsonl', queue_max=8)
+            service = EvidencePlaneService(bus)
+            item = service.dispatch_config_drift({
+                'status': 'drift',
+                'baseline_state': 'present',
+                'changed_fields': ['uplink_preference.preferred_uplink'],
+                'baseline_values': {'uplink_preference.preferred_uplink': 'eth1'},
+                'current_values': {'uplink_preference.preferred_uplink': 'usb0'},
+                'rollback_hint': 'review_changed_fields_and_restore_last_known_good',
+            })
+        self.assertEqual(item['kind'], 'config_drift')
+        self.assertEqual(item['source'], 'config_drift')
+        self.assertEqual(item['attrs']['changed_fields'], ['uplink_preference.preferred_uplink'])
 
     def test_noc_probe_dispatch_derives_client_inventory_events(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_noc_evaluator_v1.py
+++ b/tests/test_noc_evaluator_v1.py
@@ -48,9 +48,10 @@ class NocEvaluatorV1Tests(unittest.TestCase):
         self.assertIn('client_inventory_health', result)
         self.assertIn('service_health', result)
         self.assertIn('resolution_health', result)
+        self.assertIn('config_drift_health', result)
         self.assertIn('summary', result)
         self.assertIn('evidence_ids', result)
-        for key in ('availability', 'path_health', 'device_health', 'client_health', 'capacity_health', 'client_inventory_health', 'service_health', 'resolution_health'):
+        for key in ('availability', 'path_health', 'device_health', 'client_health', 'capacity_health', 'client_inventory_health', 'service_health', 'resolution_health', 'config_drift_health'):
             self.assertIn('score', result[key])
             self.assertIn('label', result[key])
 
@@ -79,7 +80,7 @@ class NocEvaluatorV1Tests(unittest.TestCase):
         result = evaluator.evaluate([])
         handoff = evaluator.to_arbiter_input(result)
         self.assertEqual(handoff['source'], 'noc_evaluator')
-        for key in ('summary', 'availability', 'path_health', 'device_health', 'client_health', 'capacity_health', 'client_inventory_health', 'service_health', 'resolution_health', 'evidence_ids'):
+        for key in ('summary', 'availability', 'path_health', 'device_health', 'client_health', 'capacity_health', 'client_inventory_health', 'service_health', 'resolution_health', 'config_drift_health', 'evidence_ids'):
             self.assertIn(key, handoff)
 
     def test_sot_can_reduce_unknown_client_penalty(self) -> None:
@@ -109,6 +110,8 @@ class NocEvaluatorV1Tests(unittest.TestCase):
             NocEvaluator(config={'service_health': {'window_degraded_penalty': 20, 'window_down_penalty': 10}})
         with self.assertRaises(ValueError):
             NocEvaluator(config={'resolution_health': {'window_degraded_penalty': 20, 'window_failed_penalty': 10}})
+        with self.assertRaises(ValueError):
+            NocEvaluator(config={'config_drift_health': {'drift_penalty_per_field': 20, 'drift_penalty_cap': 10}})
 
     def test_capacity_and_client_inventory_dimensions_consume_new_evidence(self) -> None:
         evaluator = NocEvaluator()
@@ -143,6 +146,28 @@ class NocEvaluatorV1Tests(unittest.TestCase):
         self.assertIn('service_window_down:resolver-tcp', result['service_health']['reasons'])
         self.assertIn('resolution_failed:example.com', result['resolution_health']['reasons'])
         self.assertIn('resolution_window_failed:example.com', result['resolution_health']['reasons'])
+
+    def test_config_drift_dimension_handles_drift_and_missing_baseline(self) -> None:
+        evaluator = NocEvaluator()
+        drift_result = evaluator.evaluate([
+            _event('config_drift', 'health_config', 45, {
+                'status': 'drift',
+                'baseline_state': 'present',
+                'changed_fields': ['uplink_preference.preferred_uplink', 'policy_markers.policy_version'],
+                'rollback_hint': 'review_changed_fields_and_restore_last_known_good',
+            }, status='warn'),
+        ])
+        missing_result = evaluator.evaluate([
+            _event('config_drift', 'health_config', 20, {
+                'status': 'baseline_missing',
+                'baseline_state': 'missing',
+                'changed_fields': [],
+                'rollback_hint': 'create_last_known_good_baseline',
+            }, status='warn'),
+        ])
+        self.assertIn('config_drift_detected', drift_result['config_drift_health']['reasons'])
+        self.assertIn('config_drift:uplink_preference.preferred_uplink', drift_result['config_drift_health']['reasons'])
+        self.assertIn('config_baseline_missing', missing_result['config_drift_health']['reasons'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add health-relevant config snapshot extraction and last-known-good baseline handling for NOC workflows
- normalize config drift evidence and extend the NOC evaluator with additive `config_drift_health`
- expose drift status, changed fields, and rollback-oriented guidance through dashboard and explanation outputs

## Verification
- `PYTHONPATH=/home/azazel/Azazel-Edge ./.venv/bin/pytest -q` -> `150 passed`
- `git diff --check`

## Notes
- this branch depends on PR #70 already being merged into `main`