### PR TITLE
Add NOC incident compression summaries

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -983,6 +983,7 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
     noc_resolution_assurance = state.get("noc_resolution_assurance") if isinstance(state.get("noc_resolution_assurance"), dict) else {}
     noc_blast_radius = state.get("noc_blast_radius") if isinstance(state.get("noc_blast_radius"), dict) else {}
     noc_config_drift = state.get("noc_config_drift") if isinstance(state.get("noc_config_drift"), dict) else {}
+    noc_incident_summary = state.get("noc_incident_summary") if isinstance(state.get("noc_incident_summary"), dict) else {}
     return {
         "ok": True,
         "risk": {
@@ -1092,6 +1093,12 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
                 "baseline_state": str(noc_config_drift.get("baseline_state") or "unknown"),
                 "changed_fields": noc_config_drift.get("changed_fields") if isinstance(noc_config_drift.get("changed_fields"), list) else [],
                 "rollback_hint": str(noc_config_drift.get("rollback_hint") or ""),
+            },
+            "incident_summary": {
+                "incident_id": str(noc_incident_summary.get("incident_id") or ""),
+                "probable_cause": str(noc_incident_summary.get("probable_cause") or "stable"),
+                "confidence": _as_float(noc_incident_summary.get("confidence"), 0.0),
+                "supporting_symptoms": noc_incident_summary.get("supporting_symptoms") if isinstance(noc_incident_summary.get("supporting_symptoms"), list) else [],
             },
             "capacity": {
                 "state": str(noc_capacity.get("state") or "unknown"),

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -1010,6 +1010,7 @@ function updateSplitBoard(summary, actions) {
     const resolutionHealth = noc.resolution_health || {};
     const blastRadius = noc.blast_radius || {};
     const configDrift = noc.config_drift || {};
+    const incidentSummary = noc.incident_summary || {};
     const capacity = noc.capacity || {};
     const clientInventory = noc.client_inventory || {};
     const clientImpact = noc.client_impact || {};
@@ -1036,7 +1037,9 @@ function updateSplitBoard(summary, actions) {
         (item) => item,
     );
 
-    updateElement('nocPathStatus', String(path.status || 'unknown').toUpperCase());
+    updateElement('nocPathStatus', String(incidentSummary.probable_cause || path.status || 'unknown').toUpperCase());
+    updateElement('nocIncidentCause', incidentSummary.probable_cause || '-');
+    updateElement('nocIncidentConfidence', incidentSummary.confidence ? String(incidentSummary.confidence) : '-');
     updateElement('nocPathUplink', path.uplink || '-');
     updateElement('nocPathGateway', path.gateway || '-');
     updateElement('nocPathInternet', path.internet_check || '-');

--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -286,6 +286,8 @@
                                 <div class="split-subcard noc-path-card">
                                     <div class="assistant-label">Path Health</div>
                                     <div class="fact-list compact-list">
+                                        <div class="fact-item"><span>Incident</span><strong id="nocIncidentCause">-</strong></div>
+                                        <div class="fact-item"><span>Confidence</span><strong id="nocIncidentConfidence">-</strong></div>
                                         <div class="fact-item"><span>Uplink</span><strong id="nocPathUplink">-</strong></div>
                                         <div class="fact-item"><span>Gateway</span><strong id="nocPathGateway">-</strong></div>
                                         <div class="fact-item"><span>Internet</span><strong id="nocPathInternet">-</strong></div>

--- a/py/azazel_edge/evaluators/noc.py
+++ b/py/azazel_edge/evaluators/noc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import hashlib
 from typing import Any, Dict, Iterable, List
 import ipaddress
 import re
@@ -205,6 +206,18 @@ class NocEvaluator:
                 client_health['reasons'].append('sot_missing')
 
         affected_scope = self._evaluate_affected_scope(payloads, by_kind, sot=sot)
+        incident_summary = self._build_incident_summary(
+            availability=availability,
+            path_health=path_health,
+            device_health=device_health,
+            client_health=client_health,
+            capacity_health=capacity_health,
+            client_inventory_health=client_inventory_health,
+            service_health=service_health,
+            resolution_health=resolution_health,
+            config_drift_health=config_drift_health,
+            affected_scope=affected_scope,
+        )
 
         dimensions = [
             availability,
@@ -245,6 +258,8 @@ class NocEvaluator:
             summary['segment_scope'] = segment_status
         if affected_scope:
             summary['blast_radius'] = affected_scope
+        if incident_summary:
+            summary['incident_summary'] = incident_summary
 
         result = {
             'availability': availability,
@@ -257,6 +272,7 @@ class NocEvaluator:
             'resolution_health': resolution_health,
             'config_drift_health': config_drift_health,
             'affected_scope': affected_scope,
+            'incident_summary': incident_summary,
             'summary': summary,
             'evidence_ids': sorted(dict.fromkeys(all_evidence_ids)),
         }
@@ -277,6 +293,7 @@ class NocEvaluator:
             'resolution_health': evaluation.get('resolution_health', {}),
             'config_drift_health': evaluation.get('config_drift_health', {}),
             'affected_scope': evaluation.get('affected_scope', {}),
+            'incident_summary': evaluation.get('incident_summary', {}),
             'evidence_ids': evaluation.get('evidence_ids', []),
         }
 
@@ -663,6 +680,103 @@ class NocEvaluator:
         result = _make_dimension(score, reasons, evidence_ids)
         result['rollback_hint'] = rollback_hint
         return result
+
+    @staticmethod
+    def _build_incident_summary(
+        availability: Dict[str, Any],
+        path_health: Dict[str, Any],
+        device_health: Dict[str, Any],
+        client_health: Dict[str, Any],
+        capacity_health: Dict[str, Any],
+        client_inventory_health: Dict[str, Any],
+        service_health: Dict[str, Any],
+        resolution_health: Dict[str, Any],
+        config_drift_health: Dict[str, Any],
+        affected_scope: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        dimensions = {
+            'availability': availability,
+            'path_health': path_health,
+            'device_health': device_health,
+            'client_health': client_health,
+            'capacity_health': capacity_health,
+            'client_inventory_health': client_inventory_health,
+            'service_health': service_health,
+            'resolution_health': resolution_health,
+            'config_drift_health': config_drift_health,
+        }
+        degraded = {
+            name: dim
+            for name, dim in dimensions.items()
+            if str(dim.get('label') or 'good') != 'good'
+        }
+        if not degraded:
+            return {
+                'incident_id': 'incident:none',
+                'probable_cause': 'stable',
+                'confidence': 0.95,
+                'supporting_symptoms': [],
+                'affected_scope': affected_scope or {},
+                'evidence_ids': [],
+                'drill_down': {'dimension_reasons': {}, 'evidence_ids': []},
+            }
+
+        probable_cause = 'general_noc_degradation'
+        if str(config_drift_health.get('label') or 'good') != 'good':
+            probable_cause = 'misconfiguration_drift'
+        elif str(resolution_health.get('label') or 'good') != 'good':
+            probable_cause = 'resolution_failure'
+        elif str(service_health.get('label') or 'good') != 'good':
+            probable_cause = 'service_assurance_failure'
+        elif str(capacity_health.get('label') or 'good') != 'good':
+            probable_cause = 'capacity_pressure'
+        elif str(path_health.get('label') or 'good') != 'good':
+            probable_cause = 'uplink_or_path_instability'
+        elif str(client_inventory_health.get('label') or 'good') != 'good':
+            probable_cause = 'client_inventory_anomaly'
+        elif str(device_health.get('label') or 'good') != 'good':
+            probable_cause = 'device_resource_pressure'
+        elif str(client_health.get('label') or 'good') != 'good':
+            probable_cause = 'client_connectivity_anomaly'
+
+        supporting_symptoms: List[str] = []
+        evidence_ids: List[str] = []
+        drill_down: Dict[str, List[str]] = {}
+        severity_map = {'critical': 4, 'poor': 3, 'degraded': 2, 'good': 1, 'unknown': 0}
+        top_label_weight = 0
+        for name, dim in degraded.items():
+            reasons = [str(item) for item in dim.get('reasons', []) if str(item)]
+            if reasons:
+                supporting_symptoms.extend(f'{name}:{reason}' for reason in reasons[:3])
+                drill_down[name] = reasons
+            evidence_ids.extend(str(item) for item in dim.get('evidence_ids', []) if str(item))
+            top_label_weight = max(top_label_weight, severity_map.get(str(dim.get('label') or 'unknown'), 0))
+        confidence = 0.6
+        if probable_cause in {'misconfiguration_drift', 'resolution_failure', 'service_assurance_failure', 'capacity_pressure'}:
+            confidence = 0.88
+        elif top_label_weight >= 3:
+            confidence = 0.8
+        elif len(degraded) >= 2:
+            confidence = 0.74
+        basis = '|'.join([
+            probable_cause,
+            ','.join(sorted(affected_scope.get('affected_uplinks', []) if isinstance(affected_scope, dict) else [])),
+            ','.join(sorted(affected_scope.get('affected_segments', []) if isinstance(affected_scope, dict) else [])),
+            ','.join(sorted(dict.fromkeys(evidence_ids))[:8]),
+        ])
+        incident_id = 'incident:' + hashlib.sha256(basis.encode('utf-8')).hexdigest()[:12]
+        return {
+            'incident_id': incident_id,
+            'probable_cause': probable_cause,
+            'confidence': round(confidence, 2),
+            'supporting_symptoms': supporting_symptoms[:8],
+            'affected_scope': affected_scope or {},
+            'evidence_ids': sorted(dict.fromkeys(evidence_ids)),
+            'drill_down': {
+                'dimension_reasons': drill_down,
+                'evidence_ids': sorted(dict.fromkeys(evidence_ids)),
+            },
+        }
 
     @staticmethod
     def _apply_sot_diff_to_path_health(path_health: Dict[str, Any], sot_diff: Dict[str, Any]) -> Dict[str, Any]:

--- a/py/azazel_edge/explanations/decision.py
+++ b/py/azazel_edge/explanations/decision.py
@@ -64,6 +64,7 @@ class DecisionExplainer:
             },
             'affected_scope': (noc.get('affected_scope') or (noc_summary.get('blast_radius') if isinstance(noc_summary.get('blast_radius'), dict) else {})) if isinstance(noc, dict) else {},
             'config_drift': (noc.get('config_drift_health') or {}) if isinstance(noc, dict) else {},
+            'incident_summary': (noc.get('incident_summary') or (noc_summary.get('incident_summary') if isinstance(noc_summary.get('incident_summary'), dict) else {})) if isinstance(noc, dict) else {},
             'ti_matches': soc_summary.get('ti_matches', []),
             'attack_candidates': attack_candidates,
             'sigma_hits': sigma_hits,
@@ -96,6 +97,7 @@ class DecisionExplainer:
             client_impact=client_impact,
             affected_scope=why_chosen['affected_scope'],
             config_drift=why_chosen['config_drift'],
+            incident_summary=why_chosen['incident_summary'],
         )
         explanation = {
             'ts': datetime.now(timezone.utc).isoformat(timespec='seconds'),
@@ -137,6 +139,7 @@ class DecisionExplainer:
         client_impact: Dict[str, Any],
         affected_scope: Dict[str, Any],
         config_drift: Dict[str, Any],
+        incident_summary: Dict[str, Any],
     ) -> str:
         rejected_text = '; '.join(
             f"{item['action']} was rejected because {item['reason']}"
@@ -175,6 +178,11 @@ class DecisionExplainer:
                 f"segments {', '.join(affected_scope.get('affected_segments', [])[:3]) or '-'}, "
                 f"estimated clients {int(affected_scope.get('affected_client_count') or 0)}."
             )
+        if isinstance(incident_summary, dict) and incident_summary:
+            incident_id = str(incident_summary.get('incident_id') or '')
+            probable_cause = str(incident_summary.get('probable_cause') or '')
+            if incident_id or probable_cause:
+                sentence += f" Incident summary: {incident_id or '-'} cause={probable_cause or 'unknown'}."
         if isinstance(config_drift, dict) and config_drift:
             drift_reasons = [str(item) for item in config_drift.get('reasons', []) if str(item)]
             if drift_reasons:
@@ -205,6 +213,8 @@ class DecisionExplainer:
             checks.append('review_path_and_service_assurance')
         if any(str(noc_summary.get('reasons') or '').find(token) >= 0 for token in ('config_drift_health', 'config_drift')):
             checks.append('review_config_drift_and_last_known_good')
+        if isinstance(noc_summary.get('incident_summary'), dict) and str((noc_summary.get('incident_summary') or {}).get('incident_id') or ''):
+            checks.append('review_incident_summary_and_drill_down')
         if int(client_impact.get('critical_client_count') or 0) > 0:
             checks.append('confirm_critical_client_owner_before_control')
         return checks

--- a/py/azazel_edge/notify/delivery.py
+++ b/py/azazel_edge/notify/delivery.py
@@ -78,6 +78,7 @@ class DecisionNotifier:
             'evidence_ids': [str(x) for x in arbiter.get('chosen_evidence_ids', []) if str(x)],
             'level': 'critical' if 'high' in str(arbiter.get('reason') or '') else 'warning',
             'operator_wording': str(explanation.get('operator_wording') or ''),
+            'incident_id': str((((explanation.get('why_chosen') or {}) if isinstance(explanation.get('why_chosen'), dict) else {}).get('incident_summary') or {}).get('incident_id') or ''),
         }
 
         errors: List[str] = []

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -122,6 +122,15 @@ class DashboardDataContractTests(unittest.TestCase):
                 "changed_fields": ["uplink_preference.preferred_uplink", "policy_markers.policy_version"],
                 "rollback_hint": "review_changed_fields_and_restore_last_known_good",
             },
+            "noc_incident_summary": {
+                "incident_id": "incident:abc123",
+                "probable_cause": "resolution_failure",
+                "confidence": 0.88,
+                "supporting_symptoms": [
+                    "resolution_health:resolution_window_failed:example.com",
+                    "service_health:service_window_down:resolver-tcp",
+                ],
+            },
             "evidence": ["net_health=SUSPECTED signals=dns_mismatch"],
             "llm": {"status": "skipped_non_ambiguous"},
         }
@@ -279,6 +288,8 @@ class DashboardDataContractTests(unittest.TestCase):
         self.assertEqual(payload["noc_focus"]["blast_radius"]["related_service_targets"], ["dns", "resolver-tcp"])
         self.assertEqual(payload["noc_focus"]["config_drift"]["status"], "drift")
         self.assertEqual(payload["noc_focus"]["config_drift"]["rollback_hint"], "review_changed_fields_and_restore_last_known_good")
+        self.assertEqual(payload["noc_focus"]["incident_summary"]["incident_id"], "incident:abc123")
+        self.assertEqual(payload["noc_focus"]["incident_summary"]["probable_cause"], "resolution_failure")
         self.assertEqual(payload["decision_path"]["first_pass_engine"], "tactical_scorer_v1")
         self.assertEqual(payload["decision_path"]["second_pass_status"], "completed")
 

--- a/tests/test_decision_explanation_v2.py
+++ b/tests/test_decision_explanation_v2.py
@@ -26,6 +26,11 @@ class DecisionExplanationV2Tests(unittest.TestCase):
                     'reasons': ['config_drift_detected', 'config_drift:uplink_preference.preferred_uplink'],
                     'rollback_hint': 'review_changed_fields_and_restore_last_known_good',
                 },
+                'incident_summary': {
+                    'incident_id': 'incident:abc123',
+                    'probable_cause': 'resolution_failure',
+                    'confidence': 0.88,
+                },
             },
             soc={'summary': {'status': 'critical', 'attack_candidates': ['T1071 Application Layer Protocol'], 'ai_attack_candidates': ['T1190 Exploit Public-Facing Application'], 'ti_matches': [{'indicator_type': 'ip', 'value': '10.0.0.5'}]}},
             arbiter={
@@ -46,6 +51,8 @@ class DecisionExplanationV2Tests(unittest.TestCase):
         self.assertIn('ATT&CK candidates', result['operator_wording'])
         self.assertEqual(result['why_chosen']['affected_scope']['affected_segments'], ['lan-a'])
         self.assertIn('Affected scope: uplinks eth1, segments lan-a, estimated clients 2.', result['operator_wording'])
+        self.assertEqual(result['why_chosen']['incident_summary']['incident_id'], 'incident:abc123')
+        self.assertIn('Incident summary: incident:abc123 cause=resolution_failure.', result['operator_wording'])
         self.assertIn('Config drift indicators: config_drift_detected, config_drift:uplink_preference.preferred_uplink.', result['operator_wording'])
         self.assertIn('T1190 Exploit Public-Facing Application', result['why_chosen']['attack_candidates'])
 

--- a/tests/test_noc_evaluator_v1.py
+++ b/tests/test_noc_evaluator_v1.py
@@ -49,6 +49,7 @@ class NocEvaluatorV1Tests(unittest.TestCase):
         self.assertIn('service_health', result)
         self.assertIn('resolution_health', result)
         self.assertIn('config_drift_health', result)
+        self.assertIn('incident_summary', result)
         self.assertIn('summary', result)
         self.assertIn('evidence_ids', result)
         for key in ('availability', 'path_health', 'device_health', 'client_health', 'capacity_health', 'client_inventory_health', 'service_health', 'resolution_health', 'config_drift_health'):
@@ -80,7 +81,7 @@ class NocEvaluatorV1Tests(unittest.TestCase):
         result = evaluator.evaluate([])
         handoff = evaluator.to_arbiter_input(result)
         self.assertEqual(handoff['source'], 'noc_evaluator')
-        for key in ('summary', 'availability', 'path_health', 'device_health', 'client_health', 'capacity_health', 'client_inventory_health', 'service_health', 'resolution_health', 'config_drift_health', 'evidence_ids'):
+        for key in ('summary', 'availability', 'path_health', 'device_health', 'client_health', 'capacity_health', 'client_inventory_health', 'service_health', 'resolution_health', 'config_drift_health', 'incident_summary', 'evidence_ids'):
             self.assertIn(key, handoff)
 
     def test_sot_can_reduce_unknown_client_penalty(self) -> None:
@@ -168,6 +169,24 @@ class NocEvaluatorV1Tests(unittest.TestCase):
         self.assertIn('config_drift_detected', drift_result['config_drift_health']['reasons'])
         self.assertIn('config_drift:uplink_preference.preferred_uplink', drift_result['config_drift_health']['reasons'])
         self.assertIn('config_baseline_missing', missing_result['config_drift_health']['reasons'])
+
+    def test_incident_summary_groups_primary_noc_symptoms(self) -> None:
+        evaluator = NocEvaluator()
+        events = [
+            _event('capacity_pressure', 'eth1', 65, {'interface': 'eth1', 'state': 'congested', 'mode': 'utilization_known'}, status='warn'),
+            _event('service_probe_window', 'resolver-tcp', 65, {'name': 'resolver-tcp', 'state': 'down', 'success_ratio_pct': 0.0}, status='warn'),
+            _event('client_session', '192.168.40.10', 0, {'ip': '192.168.40.10', 'interface_or_segment': 'lan-main', 'session_state': 'authorized_present'}, status='info'),
+        ]
+        sot = {
+            'devices': [{'id': 'dev1', 'hostname': 'client-1', 'ip': '192.168.40.10', 'mac': 'aa:bb:cc:dd:ee:ff', 'criticality': 'critical', 'allowed_networks': ['lan-main']}],
+            'networks': [{'id': 'lan-main', 'cidr': '192.168.40.0/24', 'zone': 'lan', 'gateway': '192.168.40.1'}],
+            'services': [{'id': 'resolver-tcp', 'proto': 'tcp', 'port': 53, 'owner': 'noc', 'exposure': 'internal'}],
+            'expected_paths': [],
+        }
+        result = evaluator.evaluate(events, sot=sot)
+        self.assertEqual(result['incident_summary']['probable_cause'], 'service_assurance_failure')
+        self.assertTrue(str(result['incident_summary']['incident_id']).startswith('incident:'))
+        self.assertIn('service_health:service_window_down:resolver-tcp', result['incident_summary']['supporting_symptoms'])
 
 
 if __name__ == '__main__':

--- a/tests/test_notification_v1.py
+++ b/tests/test_notification_v1.py
@@ -34,7 +34,7 @@ class NotificationV1Tests(unittest.TestCase):
             notifier = DecisionNotifier([NtfyNotifier('http://127.0.0.1:8081', 'azazel-alerts')], logger)
             result = notifier.notify(
                 arbiter={'action': 'notify', 'reason': 'soc_high_but_noc_fragile', 'chosen_evidence_ids': ['ev-1']},
-                explanation={'operator_wording': 'Notify operator now.'},
+                explanation={'operator_wording': 'Notify operator now.', 'why_chosen': {'incident_summary': {'incident_id': 'incident:abc123'}}},
                 target='edge-uplink',
             )
             lines = [json.loads(line) for line in (Path(tmp) / 'audit.jsonl').read_text(encoding='utf-8').splitlines()]
@@ -42,6 +42,7 @@ class NotificationV1Tests(unittest.TestCase):
         self.assertEqual(lines[-1]['kind'], 'notification')
         self.assertEqual(lines[-1]['decision'], 'sent')
         self.assertEqual(lines[-1]['payload']['payload']['target'], 'edge-uplink')
+        self.assertEqual(lines[-1]['payload']['payload']['incident_id'], 'incident:abc123')
 
     def test_non_notify_action_is_skipped(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add deterministic NOC incident grouping and probable-cause summaries on top of the existing health dimensions
- expose grouped incident IDs, supporting symptoms, and affected scope through the evaluator and dashboard contracts
- include notification and explanation integration so operators can work from an incident-first summary instead of raw symptom lists

## Verification
- `PYTHONPATH=/home/azazel/Azazel-Edge ./.venv/bin/pytest -q` -> `151 passed`
- `git diff --check`

## Notes
- this branch depends on PR #71 already being merged into `main`