### PR TITLE
Add NOC runbook workflow support

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -67,6 +67,7 @@ try:
         TriageSessionStore,
         classify_intent_candidates,
         list_flows as triage_list_flows,
+        select_noc_runbook_support,
         select_runbooks_for_diagnostic_state,
     )
     from azazel_edge.demo_overlay import (
@@ -102,6 +103,7 @@ except Exception:
     TriageSessionStore = None  # type: ignore
     classify_intent_candidates = None  # type: ignore
     triage_list_flows = None  # type: ignore
+    select_noc_runbook_support = None  # type: ignore
     select_runbooks_for_diagnostic_state = None  # type: ignore
     DEMO_OVERLAY_PATH = Path("/run/azazel-edge/demo_overlay.json")
     build_demo_overlay = lambda result: {"active": True, "raw_result": result}  # type: ignore
@@ -759,6 +761,7 @@ def _dashboard_action_guidance(
     advisory: Dict[str, Any],
     latest_ai: Dict[str, Any],
     suggested_runbook: Dict[str, Any],
+    noc_runbook_support: Dict[str, Any] | None = None,
 ) -> Dict[str, List[str]]:
     network_health = state.get("network_health") if isinstance(state.get("network_health"), dict) else {}
     monitoring = state.get("monitoring") if isinstance(state.get("monitoring"), dict) else {}
@@ -770,6 +773,7 @@ def _dashboard_action_guidance(
     internet_check = str((state.get("connection") or {}).get("internet_check") or "").upper() if isinstance(state.get("connection"), dict) else ""
     critical = _as_int(state.get("suricata_critical"), 0)
     warning = _as_int(state.get("suricata_warning"), 0)
+    support = noc_runbook_support if isinstance(noc_runbook_support, dict) else {}
 
     why_now: List[str] = []
     do_next: List[str] = []
@@ -790,6 +794,8 @@ def _dashboard_action_guidance(
         _append_unique(why_now, f"Recommended runbook is {suggested_runbook['title']}.")
     elif latest_ai.get("answer"):
         _append_unique(why_now, "Latest M.I.O. assist is advisory only and no runbook is currently selected.")
+    if support.get("why_this_runbook"):
+        _append_unique(why_now, str(support.get("why_this_runbook")))
 
     recommendation = str(state.get("recommendation") or advisory.get("recommendation") or "").strip()
     _append_unique(do_next, recommendation or _tr("api.keep_monitoring", default="Keep monitoring the current state."))
@@ -797,6 +803,8 @@ def _dashboard_action_guidance(
         _append_unique(do_next, f"Open {suggested_runbook['title']} and follow the read-only checks first.")
     for step in suggested_runbook.get("steps", []):
         _append_unique(do_next, str(step))
+    for check in support.get("operator_checks", []) if isinstance(support.get("operator_checks"), list) else []:
+        _append_unique(do_next, str(check))
     if not do_next:
         _append_unique(do_next, _tr("api.keep_monitoring", default="Keep monitoring the current state."))
 
@@ -817,6 +825,8 @@ def _dashboard_action_guidance(
         _append_unique(escalate_if, "Escalate if a core monitoring service remains OFF after local verification.")
     if user_state not in ("SAFE", ""):
         _append_unique(escalate_if, "Escalate if the state does not return to SAFE after the recommended checks.")
+    if support.get("escalation_hint"):
+        _append_unique(escalate_if, str(support.get("escalation_hint")))
     if not escalate_if:
         _append_unique(escalate_if, "Escalate if the state leaves SAFE or new alerts appear.")
 
@@ -844,6 +854,43 @@ def _runbook_brief(runbook_id: str, lang: str | None = None) -> Dict[str, Any]:
         "steps": [str(item) for item in steps[:3]],
         "user_message_template": localize_runbook_user_message(runbook, lang=lang),
     }
+
+
+def _dashboard_noc_runbook_support(state: Dict[str, Any], lang: str) -> Dict[str, Any]:
+    if select_noc_runbook_support is None:
+        return {}
+    network_health = state.get("network_health") if isinstance(state.get("network_health"), dict) else {}
+    noc_capacity = state.get("noc_capacity") if isinstance(state.get("noc_capacity"), dict) else {}
+    noc_client_inventory = state.get("noc_client_inventory") if isinstance(state.get("noc_client_inventory"), dict) else {}
+    noc_service_assurance = state.get("noc_service_assurance") if isinstance(state.get("noc_service_assurance"), dict) else {}
+    noc_resolution_assurance = state.get("noc_resolution_assurance") if isinstance(state.get("noc_resolution_assurance"), dict) else {}
+    noc_blast_radius = state.get("noc_blast_radius") if isinstance(state.get("noc_blast_radius"), dict) else {}
+    noc_config_drift = state.get("noc_config_drift") if isinstance(state.get("noc_config_drift"), dict) else {}
+    noc_incident_summary = state.get("noc_incident_summary") if isinstance(state.get("noc_incident_summary"), dict) else {}
+    return select_noc_runbook_support(
+        {
+            "summary": {
+                "status": str(network_health.get("status") or "unknown"),
+                "blast_radius": noc_blast_radius,
+                "incident_summary": noc_incident_summary,
+            },
+            "path_health": {
+                "status": str(network_health.get("status") or "unknown"),
+                "signals": network_health.get("signals") if isinstance(network_health.get("signals"), list) else [],
+            },
+            "capacity": noc_capacity,
+            "client_inventory": noc_client_inventory,
+            "service_health": noc_service_assurance,
+            "resolution_health": noc_resolution_assurance,
+            "config_drift": noc_config_drift,
+            "affected_scope": noc_blast_radius,
+            "incident_summary": noc_incident_summary,
+        },
+        audience="professional",
+        lang=lang,
+        context={"source": "dashboard"},
+        source="dashboard",
+    )
 
 
 def _normalize_alert_event(item: Dict[str, Any]) -> Dict[str, Any]:
@@ -1144,19 +1191,26 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
 def _dashboard_actions_payload(state: Dict[str, Any], advisory: Dict[str, Any], llm_rows: List[Dict[str, Any]]) -> Dict[str, Any]:
     lang = _request_lang()
     latest_ai = _dashboard_visible_ai_context(state, advisory, llm_rows)
-    suggested_runbook = _runbook_brief(latest_ai.get("runbook_id", ""), lang=lang)
-    guidance = _dashboard_action_guidance(state, advisory, latest_ai, suggested_runbook)
+    noc_runbook_support = _dashboard_noc_runbook_support(state, lang=lang)
+    selected_runbook_id = str(latest_ai.get("runbook_id") or noc_runbook_support.get("runbook_candidate_id") or "")
+    suggested_runbook = _runbook_brief(selected_runbook_id, lang=lang)
+    guidance = _dashboard_action_guidance(state, advisory, latest_ai, suggested_runbook, noc_runbook_support=noc_runbook_support)
     user_guidance = str(
         latest_ai.get("user_message")
         or suggested_runbook.get("user_message_template")
+        or noc_runbook_support.get("why_this_runbook")
         or state.get("recommendation")
         or ""
     )
     recommendation = str(state.get("recommendation") or advisory.get("recommendation") or "").strip()
     review = latest_ai.get("review") if isinstance(latest_ai.get("review"), dict) else {}
+    if not review:
+        review = ((noc_runbook_support.get("reviewed_runbook") or {}) if isinstance(noc_runbook_support.get("reviewed_runbook"), dict) else {}).get("review") if isinstance((noc_runbook_support.get("reviewed_runbook") or {}), dict) else {}
     rationale: List[str] = []
     for item in guidance["why_now"][:2]:
         _append_unique(rationale, item)
+    if noc_runbook_support.get("why_this_runbook"):
+        _append_unique(rationale, str(noc_runbook_support.get("why_this_runbook")))
     if review.get("final_status"):
         _append_unique(rationale, f"{_tr('api.review_prefix', default='Review')}: {review.get('final_status')}.")
     findings = review.get("findings") if isinstance(review.get("findings"), list) else []
@@ -1193,7 +1247,14 @@ def _dashboard_actions_payload(state: Dict[str, Any], advisory: Dict[str, Any], 
         "suggested_runbook": suggested_runbook,
         "approval_required": bool(suggested_runbook.get("requires_approval")),
         "current_recommendation": recommendation,
-        "operator_note": str(latest_ai.get("operator_note") or ""),
+        "operator_note": str(latest_ai.get("operator_note") or noc_runbook_support.get("operator_note") or ""),
+        "noc_runbook_support": {
+            "runbook_candidate_id": str(noc_runbook_support.get("runbook_candidate_id") or ""),
+            "why_this_runbook": str(noc_runbook_support.get("why_this_runbook") or ""),
+            "operator_checks": noc_runbook_support.get("operator_checks") if isinstance(noc_runbook_support.get("operator_checks"), list) else [],
+            "escalation_hint": str(noc_runbook_support.get("escalation_hint") or ""),
+            "ai_used": bool(noc_runbook_support.get("ai_used")),
+        },
         "rejected_stronger_actions": stronger_actions[:4],
         "mio": {
             "answer": str(latest_ai.get("answer") or ""),

--- a/py/azazel_edge/explanations/decision.py
+++ b/py/azazel_edge/explanations/decision.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from azazel_edge.knowledge import AttackDefendKnowledge
+from azazel_edge.triage import select_noc_runbook_support
 
 
 class DecisionExplainer:
@@ -42,6 +43,7 @@ class DecisionExplainer:
         sigma_hits = soc_summary.get('sigma_hits', []) if isinstance(soc_summary.get('sigma_hits'), list) else []
         yara_hits = soc_summary.get('yara_hits', []) if isinstance(soc_summary.get('yara_hits'), list) else []
         visualization = self.knowledge.build_visualization(attack_candidates, soc_summary.get('ti_matches', []))
+        runbook_support = select_noc_runbook_support(noc if isinstance(noc, dict) else {}, audience='professional', lang='en')
         next_checks = self._next_checks(action, noc_summary, soc_summary, client_impact)
         why_chosen = {
             'format_version': 'v2',
@@ -65,6 +67,7 @@ class DecisionExplainer:
             'affected_scope': (noc.get('affected_scope') or (noc_summary.get('blast_radius') if isinstance(noc_summary.get('blast_radius'), dict) else {})) if isinstance(noc, dict) else {},
             'config_drift': (noc.get('config_drift_health') or {}) if isinstance(noc, dict) else {},
             'incident_summary': (noc.get('incident_summary') or (noc_summary.get('incident_summary') if isinstance(noc_summary.get('incident_summary'), dict) else {})) if isinstance(noc, dict) else {},
+            'runbook_support': runbook_support,
             'ti_matches': soc_summary.get('ti_matches', []),
             'attack_candidates': attack_candidates,
             'sigma_hits': sigma_hits,
@@ -98,6 +101,7 @@ class DecisionExplainer:
             affected_scope=why_chosen['affected_scope'],
             config_drift=why_chosen['config_drift'],
             incident_summary=why_chosen['incident_summary'],
+            runbook_support=runbook_support,
         )
         explanation = {
             'ts': datetime.now(timezone.utc).isoformat(timespec='seconds'),
@@ -140,6 +144,7 @@ class DecisionExplainer:
         affected_scope: Dict[str, Any],
         config_drift: Dict[str, Any],
         incident_summary: Dict[str, Any],
+        runbook_support: Dict[str, Any],
     ) -> str:
         rejected_text = '; '.join(
             f"{item['action']} was rejected because {item['reason']}"
@@ -187,6 +192,12 @@ class DecisionExplainer:
             drift_reasons = [str(item) for item in config_drift.get('reasons', []) if str(item)]
             if drift_reasons:
                 sentence += f" Config drift indicators: {', '.join(drift_reasons[:3])}."
+        if isinstance(runbook_support, dict) and str(runbook_support.get('runbook_candidate_id') or ''):
+            runbook_title = str((((runbook_support.get('reviewed_runbook') or {}) if isinstance(runbook_support.get('reviewed_runbook'), dict) else {}).get('title')) or runbook_support.get('runbook_candidate_id') or '')
+            sentence += (
+                f" Suggested NOC runbook: {runbook_title} "
+                f"because {str(runbook_support.get('why_this_runbook') or '').rstrip('.') or 'deterministic NOC review is required'}."
+            )
         if rejected_text:
             sentence += f" Alternatives: {rejected_text}."
         return sentence

--- a/py/azazel_edge/notify/delivery.py
+++ b/py/azazel_edge/notify/delivery.py
@@ -79,6 +79,7 @@ class DecisionNotifier:
             'level': 'critical' if 'high' in str(arbiter.get('reason') or '') else 'warning',
             'operator_wording': str(explanation.get('operator_wording') or ''),
             'incident_id': str((((explanation.get('why_chosen') or {}) if isinstance(explanation.get('why_chosen'), dict) else {}).get('incident_summary') or {}).get('incident_id') or ''),
+            'runbook_candidate_id': str((((explanation.get('why_chosen') or {}) if isinstance(explanation.get('why_chosen'), dict) else {}).get('runbook_support') or {}).get('runbook_candidate_id') or ''),
         }
 
         errors: List[str] = []

--- a/py/azazel_edge/triage/__init__.py
+++ b/py/azazel_edge/triage/__init__.py
@@ -1,7 +1,7 @@
 from .classifier import classify_intent_candidates
 from .engine import TriageFlowEngine, TriageProgress
 from .loader import list_flows, load_flow, validate_flow
-from .selector import select_runbooks_for_diagnostic_state
+from .selector import select_noc_runbook_support, select_runbooks_for_diagnostic_state
 from .session import TriageSessionStore
 from .types import DiagnosticState, IntentCandidate, TriageFlow, TriageSession, TriageStep
 
@@ -12,6 +12,7 @@ __all__ = [
     "TriageSession",
     "TriageSessionStore",
     "select_runbooks_for_diagnostic_state",
+    "select_noc_runbook_support",
     "TriageStep",
     "classify_intent_candidates",
     "TriageFlowEngine",

--- a/py/azazel_edge/triage/selector.py
+++ b/py/azazel_edge/triage/selector.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 from azazel_edge.runbook_review import review_runbook_id
 from azazel_edge.runbooks import get_runbook
@@ -88,6 +88,35 @@ STATE_RUNBOOKS: Dict[str, List[str]] = {
     ],
 }
 
+NOC_RULE_RUNBOOKS: Dict[str, Dict[str, str]] = {
+    "resolution_failure": {
+        "diagnostic_state": "dns_global_failure",
+        "runbook_id": "rb.noc.dns.failure.check",
+    },
+    "service_assurance_failure": {
+        "diagnostic_state": "service_multiple_failure",
+        "runbook_id": "rb.noc.service.status.check",
+    },
+    "path_degradation": {
+        "diagnostic_state": "uplink_issue",
+        "runbook_id": "rb.noc.default-route.check",
+    },
+    "config_drift": {
+        "runbook_id": "rb.noc.ui-snapshot.check",
+    },
+    "client_inventory_anomaly": {
+        "runbook_id": "rb.noc.ui-snapshot.check",
+    },
+    "capacity_pressure": {
+        "runbook_id": "rb.noc.ui-snapshot.check",
+    },
+    "stable_observe": {
+        "runbook_id": "rb.noc.ui-snapshot.check",
+    },
+}
+
+GOOD_LABELS = {"", "good", "ok", "healthy", "stable", "present", "known", "none", "normal", "on"}
+
 
 def _score_for_audience(runbook: Dict[str, Any], audience: str, order_index: int = 0) -> int:
     score = 100 - (order_index * 5)
@@ -111,6 +140,284 @@ def _score_for_audience(runbook: Dict[str, Any], audience: str, order_index: int
         if domain == "user":
             score -= 5
     return score
+
+
+def _string_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _dict_value(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _health_value(payload: Dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        text = str(payload.get(key) or "").strip().lower()
+        if text:
+            return text
+    return ""
+
+
+def _is_problem_state(payload: Dict[str, Any], *keys: str) -> bool:
+    state = _health_value(payload, *keys)
+    return bool(state and state not in GOOD_LABELS)
+
+
+def _hydrate_runbook_candidate(
+    runbook_id: str,
+    audience: str,
+    lang: str,
+    context: Dict[str, Any],
+    order_index: int = 0,
+) -> Dict[str, Any]:
+    runbook = get_runbook(runbook_id, lang=lang)
+    review = review_runbook_id(runbook_id, context=context)
+    return {
+        "runbook_id": runbook_id,
+        "title": str(runbook.get("title") or ""),
+        "domain": str(runbook.get("domain") or ""),
+        "audience": str(runbook.get("audience") or ""),
+        "effect": str(runbook.get("effect") or ""),
+        "requires_approval": bool(runbook.get("requires_approval")),
+        "steps": list(runbook.get("steps") or []),
+        "user_message_template": str(runbook.get("user_message_template") or ""),
+        "score": _score_for_audience(runbook, audience, order_index=order_index),
+        "review": review,
+    }
+
+
+def _candidate_from_noc_rule(
+    rule_id: str,
+    audience: str,
+    lang: str,
+    context: Dict[str, Any],
+) -> Dict[str, Any]:
+    rule = NOC_RULE_RUNBOOKS.get(rule_id, NOC_RULE_RUNBOOKS["stable_observe"])
+    diagnostic_state = str(rule.get("diagnostic_state") or "").strip()
+    if diagnostic_state:
+        payload = select_runbooks_for_diagnostic_state(
+            diagnostic_state,
+            audience=audience,
+            lang=lang,
+            max_items=1,
+            context=context,
+        )
+        items = payload.get("items") if isinstance(payload.get("items"), list) else []
+        if items:
+            return items[0]
+    return _hydrate_runbook_candidate(str(rule.get("runbook_id") or "rb.noc.ui-snapshot.check"), audience, lang, context)
+
+
+def _primary_noc_rule(noc: Dict[str, Any]) -> Dict[str, Any]:
+    summary = _dict_value(noc.get("summary"))
+    incident = _dict_value(noc.get("incident_summary") or summary.get("incident_summary"))
+    affected_scope = _dict_value(noc.get("affected_scope") or noc.get("blast_radius") or summary.get("blast_radius"))
+    config_drift = _dict_value(noc.get("config_drift_health") or noc.get("config_drift"))
+    resolution_health = _dict_value(noc.get("resolution_health"))
+    service_health = _dict_value(noc.get("service_health"))
+    path_health = _dict_value(noc.get("path_health"))
+    availability = _dict_value(noc.get("availability"))
+    capacity = _dict_value(noc.get("capacity_health") or noc.get("capacity"))
+    client_inventory = _dict_value(noc.get("client_inventory_health") or noc.get("client_inventory"))
+
+    probable_cause = str(incident.get("probable_cause") or "").strip().lower()
+    if probable_cause == "config_drift":
+        return {"rule_id": "config_drift", "severity": 80}
+    if probable_cause == "resolution_failure":
+        return {"rule_id": "resolution_failure", "severity": 75}
+    if probable_cause == "service_assurance_failure":
+        return {"rule_id": "service_assurance_failure", "severity": 70}
+    if probable_cause in {"path_degradation", "uplink_degradation"}:
+        return {"rule_id": "path_degradation", "severity": 65}
+    if probable_cause == "client_inventory_anomaly":
+        return {"rule_id": "client_inventory_anomaly", "severity": 60}
+    if probable_cause == "capacity_pressure":
+        return {"rule_id": "capacity_pressure", "severity": 55}
+
+    if _is_problem_state(config_drift, "label", "status", "baseline_state"):
+        return {"rule_id": "config_drift", "severity": 80}
+    if _is_problem_state(resolution_health, "label", "status", "state"):
+        return {"rule_id": "resolution_failure", "severity": 75}
+    if _is_problem_state(service_health, "label", "status", "state"):
+        return {"rule_id": "service_assurance_failure", "severity": 70}
+    if _is_problem_state(path_health, "label", "status") or _is_problem_state(availability, "label", "status") or _string_list(affected_scope.get("affected_uplinks")):
+        return {"rule_id": "path_degradation", "severity": 65}
+
+    unknown_clients = int(client_inventory.get("unknown_client_count") or 0)
+    unauthorized_clients = int(client_inventory.get("unauthorized_client_count") or 0)
+    mismatched_clients = int(client_inventory.get("inventory_mismatch_count") or 0)
+    stale_sessions = int(client_inventory.get("stale_session_count") or 0)
+    if (
+        _is_problem_state(client_inventory, "label", "status", "state")
+        or unknown_clients > 0
+        or unauthorized_clients > 0
+        or mismatched_clients > 0
+        or stale_sessions > 0
+    ):
+        return {"rule_id": "client_inventory_anomaly", "severity": 60}
+
+    utilization = float(capacity.get("utilization_pct") or 0.0)
+    if _is_problem_state(capacity, "label", "status", "state") or utilization >= 75.0:
+        return {"rule_id": "capacity_pressure", "severity": 55}
+    return {"rule_id": "stable_observe", "severity": 20}
+
+
+def _noc_reasoning(
+    rule_id: str,
+    noc: Dict[str, Any],
+) -> Dict[str, Any]:
+    incident = _dict_value(noc.get("incident_summary") or _dict_value(noc.get("summary")).get("incident_summary"))
+    affected_scope = _dict_value(noc.get("affected_scope") or noc.get("blast_radius") or _dict_value(noc.get("summary")).get("blast_radius"))
+    config_drift = _dict_value(noc.get("config_drift_health") or noc.get("config_drift"))
+    resolution_health = _dict_value(noc.get("resolution_health"))
+    service_health = _dict_value(noc.get("service_health"))
+    capacity = _dict_value(noc.get("capacity_health") or noc.get("capacity"))
+    client_inventory = _dict_value(noc.get("client_inventory_health") or noc.get("client_inventory"))
+    evidence_ids: List[str] = []
+    for payload in (config_drift, resolution_health, service_health, capacity, client_inventory):
+        evidence_ids.extend(_string_list(payload.get("evidence_ids")))
+    supporting_symptoms = _string_list(incident.get("supporting_symptoms"))
+    if not evidence_ids:
+        evidence_ids.extend(supporting_symptoms[:4])
+
+    if rule_id == "config_drift":
+        changed_fields = _string_list(config_drift.get("changed_fields"))
+        return {
+            "why_this_runbook": "Health-impacting config drift was detected and should be compared against the last known good baseline.",
+            "operator_checks": [
+                "Review changed health-relevant fields against the current baseline.",
+                "Confirm whether the change was approved before making any corrective action.",
+                "Validate uplink, probe target, and policy marker consistency in the current snapshot.",
+            ] + ([f"Changed fields: {', '.join(changed_fields[:3])}."] if changed_fields else []),
+            "escalation_hint": "Escalate if the drift is unapproved or if restoring the baseline does not recover service health.",
+            "evidence_ids": evidence_ids[:8],
+        }
+    if rule_id == "resolution_failure":
+        failed_targets = _string_list(resolution_health.get("failed_targets"))
+        return {
+            "why_this_runbook": "Resolver failures are the clearest current symptom and need DNS-specific read-only checks first.",
+            "operator_checks": [
+                "Check gateway, resolver reachability, and DNS target health before changing control mode.",
+                "Confirm whether failures are local to the edge or shared across the affected segment.",
+            ] + ([f"Failed targets: {', '.join(failed_targets[:3])}."] if failed_targets else []),
+            "escalation_hint": "Escalate if resolver failures persist after gateway and default-route verification.",
+            "evidence_ids": evidence_ids[:8],
+        }
+    if rule_id == "service_assurance_failure":
+        degraded_targets = _string_list(service_health.get("degraded_targets"))
+        return {
+            "why_this_runbook": "Service assurance degraded before stronger containment criteria were met.",
+            "operator_checks": [
+                "Run read-only service status checks and confirm which targets are degraded or down.",
+                "Compare service failures with the currently affected uplinks and segments.",
+            ] + ([f"Service targets: {', '.join(degraded_targets[:3])}."] if degraded_targets else []),
+            "escalation_hint": "Escalate if multiple service targets remain degraded after read-only verification.",
+            "evidence_ids": evidence_ids[:8],
+        }
+    if rule_id == "path_degradation":
+        affected_uplinks = _string_list(affected_scope.get("affected_uplinks"))
+        return {
+            "why_this_runbook": "Path degradation is affecting current reachability and should be verified at the uplink and default-route layer first.",
+            "operator_checks": [
+                "Confirm uplink state, default route, and gateway reachability with read-only checks.",
+                "Compare the impacted scope before assuming a wider upstream outage.",
+            ] + ([f"Affected uplinks: {', '.join(affected_uplinks[:3])}."] if affected_uplinks else []),
+            "escalation_hint": "Escalate if uplink reachability remains degraded after route verification.",
+            "evidence_ids": evidence_ids[:8],
+        }
+    if rule_id == "client_inventory_anomaly":
+        return {
+            "why_this_runbook": "Client inventory drift or unknown sessions were detected and need operator review before stronger action.",
+            "operator_checks": [
+                "Review unknown, unauthorized, and mismatched sessions in the latest inventory snapshot.",
+                "Confirm whether new sessions align with the expected segment and SoT policy.",
+                f"Inventory counts: unknown={int(client_inventory.get('unknown_client_count') or 0)}, unauthorized={int(client_inventory.get('unauthorized_client_count') or 0)}, mismatch={int(client_inventory.get('inventory_mismatch_count') or 0)}.",
+            ],
+            "escalation_hint": "Escalate if unauthorized or spreading unknown sessions remain after inventory confirmation.",
+            "evidence_ids": evidence_ids[:8],
+        }
+    if rule_id == "capacity_pressure":
+        return {
+            "why_this_runbook": "Current utilization or traffic concentration suggests congestion pressure rather than an immediate outage.",
+            "operator_checks": [
+                "Confirm utilization trend and top talker concentration across the bounded observation window.",
+                "Check whether impacted clients overlap with the current blast-radius estimate before throttling.",
+            ] + ([f"Capacity signals: {', '.join(_string_list(capacity.get('signals'))[:3])}."] if _string_list(capacity.get("signals")) else []),
+            "escalation_hint": "Escalate if elevated utilization persists across windows or impacts critical clients.",
+            "evidence_ids": evidence_ids[:8],
+        }
+    return {
+        "why_this_runbook": "No dominant NOC failure was confirmed, so the snapshot check remains the safest first step.",
+        "operator_checks": [
+            "Capture the latest UI and service snapshot before making any control change.",
+            "Keep monitoring until a stronger NOC symptom or operator request appears.",
+        ],
+        "escalation_hint": "Escalate if the state leaves stable or if new symptoms appear during observation.",
+        "evidence_ids": evidence_ids[:8],
+    }
+
+
+def select_noc_runbook_support(
+    noc: Dict[str, Any],
+    audience: str = "professional",
+    lang: str = "ja",
+    context: Dict[str, Any] | None = None,
+    ai_governance: Any | None = None,
+    ai_invoker: Callable[[Dict[str, Any]], Dict[str, Any]] | None = None,
+    source: str = "dashboard",
+) -> Dict[str, Any]:
+    ctx = dict(context) if isinstance(context, dict) else {}
+    ctx.setdefault("lang", lang)
+    ctx.setdefault("audience", audience)
+    ctx.setdefault("source", source)
+    primary = _primary_noc_rule(noc if isinstance(noc, dict) else {})
+    rule_id = str(primary.get("rule_id") or "stable_observe")
+    candidate = _candidate_from_noc_rule(rule_id, audience, lang, ctx)
+    reasoning = _noc_reasoning(rule_id, noc if isinstance(noc, dict) else {})
+    support = {
+        "ok": True,
+        "rule_id": rule_id,
+        "risk_score": int(primary.get("severity") or 0),
+        "runbook_candidate_id": str(candidate.get("runbook_id") or ""),
+        "why_this_runbook": str(reasoning.get("why_this_runbook") or ""),
+        "operator_checks": _string_list(reasoning.get("operator_checks"))[:4],
+        "escalation_hint": str(reasoning.get("escalation_hint") or ""),
+        "candidate_scope": rule_id,
+        "reviewed_runbook": candidate,
+        "operator_note": str(reasoning.get("why_this_runbook") or ""),
+        "evidence_ids": _string_list(reasoning.get("evidence_ids"))[:8],
+        "ai_used": False,
+        "ai_summary": "",
+        "ai_advice": "",
+    }
+    if ai_governance is not None and ai_invoker is not None:
+        ai_result = ai_governance.invoke(
+            context={
+                "trace_id": str(ctx.get("trace_id") or ""),
+                "source": source,
+                "intent": "summary",
+            },
+            raw_payload={
+                "trace_id": str(ctx.get("trace_id") or ""),
+                "source": source,
+                "subject": "noc_runbook_support",
+                "intent": "summary",
+                "risk_score": int(primary.get("severity") or 0),
+                "category": rule_id,
+                "summary": f"{support['why_this_runbook']} {' '.join(support['operator_checks'][:2])}".strip(),
+                "evidence_ids": support["evidence_ids"],
+                "candidate_scope": support["runbook_candidate_id"],
+            },
+            invoker=ai_invoker,
+        )
+        support["ai_summary"] = str(ai_result.get("summary") or "")
+        support["ai_advice"] = str(ai_result.get("advice") or "")
+        support["ai_used"] = bool(support["ai_summary"] or support["ai_advice"])
+        if support["ai_summary"]:
+            support["operator_note"] = support["ai_summary"]
+    return support
 
 
 def select_runbooks_for_diagnostic_state(

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -311,8 +311,23 @@ class DashboardDataContractTests(unittest.TestCase):
         self.assertTrue(payload["mio"]["rationale"])
         self.assertEqual(payload["mio"]["handoff"]["ops_comm"], "/ops-comm")
         self.assertTrue(payload["rejected_stronger_actions"])
+        self.assertEqual(payload["noc_runbook_support"]["runbook_candidate_id"], "rb.noc.dns.failure.check")
+        self.assertTrue(payload["noc_runbook_support"]["operator_checks"])
         self.assertEqual(payload["decision_path"]["first_pass_role"], "first_minute_triage")
         self.assertEqual(payload["decision_path"]["second_pass_flow_support_count"], 1)
+
+    def test_dashboard_actions_falls_back_to_deterministic_noc_runbook_without_ai_context(self) -> None:
+        webapp.AI_LLM_LOG.write_text("", encoding="utf-8")
+        advisory = json.loads(webapp.AI_ADVISORY_PATH.read_text(encoding="utf-8"))
+        advisory["ops_coach"]["runbook_id"] = ""
+        webapp.AI_ADVISORY_PATH.write_text(json.dumps(advisory), encoding="utf-8")
+        response = self.client.get("/api/dashboard/actions")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["suggested_runbook"]["id"], "rb.noc.dns.failure.check")
+        self.assertIn("resolver", payload["noc_runbook_support"]["why_this_runbook"].lower())
+        self.assertTrue(payload["current_operator_actions"])
 
     def test_dashboard_actions_hides_dashboard_demo_context_when_overlay_is_inactive(self) -> None:
         now = time.time()

--- a/tests/test_decision_explanation_v2.py
+++ b/tests/test_decision_explanation_v2.py
@@ -54,6 +54,8 @@ class DecisionExplanationV2Tests(unittest.TestCase):
         self.assertEqual(result['why_chosen']['incident_summary']['incident_id'], 'incident:abc123')
         self.assertIn('Incident summary: incident:abc123 cause=resolution_failure.', result['operator_wording'])
         self.assertIn('Config drift indicators: config_drift_detected, config_drift:uplink_preference.preferred_uplink.', result['operator_wording'])
+        self.assertEqual(result['why_chosen']['runbook_support']['runbook_candidate_id'], 'rb.noc.dns.failure.check')
+        self.assertIn('Suggested NOC runbook', result['operator_wording'])
         self.assertIn('T1190 Exploit Public-Facing Application', result['why_chosen']['attack_candidates'])
 
     def test_explanation_can_be_persisted_as_jsonl(self) -> None:

--- a/tests/test_notification_v1.py
+++ b/tests/test_notification_v1.py
@@ -43,6 +43,7 @@ class NotificationV1Tests(unittest.TestCase):
         self.assertEqual(lines[-1]['decision'], 'sent')
         self.assertEqual(lines[-1]['payload']['payload']['target'], 'edge-uplink')
         self.assertEqual(lines[-1]['payload']['payload']['incident_id'], 'incident:abc123')
+        self.assertEqual(lines[-1]['payload']['payload']['runbook_candidate_id'], '')
 
     def test_non_notify_action_is_skipped(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_triage_slice4_v1.py
+++ b/tests/test_triage_slice4_v1.py
@@ -10,7 +10,9 @@ PY_ROOT = ROOT / 'py'
 if str(PY_ROOT) not in sys.path:
     sys.path.insert(0, str(PY_ROOT))
 
-from azazel_edge.triage import TriageFlowEngine, TriageSessionStore, select_runbooks_for_diagnostic_state
+from azazel_edge.ai_governance import AIGovernance
+from azazel_edge.audit import P0AuditLogger
+from azazel_edge.triage import TriageFlowEngine, TriageSessionStore, select_noc_runbook_support, select_runbooks_for_diagnostic_state
 
 
 class TriageSlice4Tests(unittest.TestCase):
@@ -33,6 +35,45 @@ class TriageSlice4Tests(unittest.TestCase):
             progress = engine.answer(progress.session.session_id, 'yes')
             self.assertTrue(progress.completed)
             self.assertIn('rb.user.portal-access-guide', progress.session.proposed_runbooks)
+
+    def test_noc_selector_prefers_dns_runbook_for_resolution_failure(self) -> None:
+        payload = select_noc_runbook_support(
+            {
+                'incident_summary': {'incident_id': 'incident:abc123', 'probable_cause': 'resolution_failure'},
+                'resolution_health': {'label': 'failed', 'failed_targets': ['example.com'], 'evidence_ids': ['ev-dns-1']},
+                'affected_scope': {'affected_segments': ['lan-main']},
+            },
+            audience='professional',
+            lang='en',
+            context={'trace_id': 'trace-53a'},
+        )
+        self.assertTrue(payload['ok'])
+        self.assertEqual(payload['runbook_candidate_id'], 'rb.noc.dns.failure.check')
+        self.assertIn('resolver failures', payload['why_this_runbook'].lower())
+        self.assertIn('ev-dns-1', payload['evidence_ids'])
+
+    def test_noc_selector_keeps_runbook_deterministic_when_ai_helper_is_used(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = select_noc_runbook_support(
+                {
+                    'incident_summary': {'probable_cause': 'service_assurance_failure'},
+                    'service_health': {'label': 'degraded', 'degraded_targets': ['resolver-tcp'], 'evidence_ids': ['ev-svc-1']},
+                },
+                audience='professional',
+                lang='en',
+                context={'trace_id': 'trace-53b'},
+                ai_governance=AIGovernance(P0AuditLogger(Path(tmp) / 'ai.jsonl')),
+                ai_invoker=lambda payload: {
+                    'summary': 'Operator wording helper suggests confirming resolver service first.',
+                    'advice': 'Keep the read-only service checks ahead of any action change.',
+                    'candidate': 'rb.noc.default-route.check',
+                    'runbook_candidates': ['rb.noc.default-route.check'],
+                },
+                source='dashboard',
+            )
+        self.assertEqual(payload['runbook_candidate_id'], 'rb.noc.service.status.check')
+        self.assertTrue(payload['ai_used'])
+        self.assertEqual(payload['operator_note'], 'Operator wording helper suggests confirming resolver service first.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add deterministic NOC runbook selection tied to incident and health context instead of creating a parallel runbook engine
- keep AI optional and wording-only while exposing runbook support through dashboard actions and decision explanations
- extend notification and regression coverage so operator workflow output stays consistent without AI input

## Verification
- `PYTHONPATH=/home/azazel/Azazel-Edge ./.venv/bin/pytest -q` -> `154 passed`
- `PYTHONPATH=/home/azazel/Azazel-Edge/py python3 -m py_compile py/azazel_edge/triage/selector.py py/azazel_edge/triage/__init__.py py/azazel_edge/explanations/decision.py py/azazel_edge/notify/delivery.py azazel_edge_web/app.py`
- `bash -n installer/internal/install_migrated_tools.sh`
- `bash -n installer/internal/verify_runtime_sync.sh`
- `git diff --check`

## Notes
- this branch depends on PR #72 already being merged into `main`