### PR TITLE
Separate demo UI from live dashboard

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -1205,7 +1205,8 @@ def _dashboard_actions_payload(state: Dict[str, Any], advisory: Dict[str, Any], 
     recommendation = str(state.get("recommendation") or advisory.get("recommendation") or "").strip()
     review = latest_ai.get("review") if isinstance(latest_ai.get("review"), dict) else {}
     if not review:
-        review = ((noc_runbook_support.get("reviewed_runbook") or {}) if isinstance(noc_runbook_support.get("reviewed_runbook"), dict) else {}).get("review") if isinstance((noc_runbook_support.get("reviewed_runbook") or {}), dict) else {}
+        reviewed_runbook = (noc_runbook_support.get("reviewed_runbook") or {}) if isinstance(noc_runbook_support.get("reviewed_runbook"), dict) else {}
+        review = reviewed_runbook.get("review") if isinstance(reviewed_runbook.get("review"), dict) else {}
     rationale: List[str] = []
     for item in guidance["why_now"][:2]:
         _append_unique(rationale, item)
@@ -2795,6 +2796,12 @@ def _triage_progress_payload(progress: Any, lang: str) -> Dict[str, Any]:
 def index():
     """Main dashboard page"""
     return render_template("index.html")
+
+
+@app.route("/demo")
+def demo_page():
+    """Dedicated demo and review workspace."""
+    return render_template("demo.html")
 
 
 @app.route("/ops-comm")

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -4,6 +4,7 @@ const LANG_KEY = 'azazel_lang';
 const POLL_INTERVAL_MS = 4000;
 const CURRENT_LANG = window.AZAZEL_LANG || localStorage.getItem(LANG_KEY) || 'ja';
 const I18N = window.AZAZEL_I18N || {};
+const CURRENT_PAGE = document.body?.dataset?.page || 'dashboard';
 
 let dashboardTimer = null;
 let currentAudience = localStorage.getItem(AUDIENCE_KEY) || 'professional';
@@ -53,7 +54,7 @@ function syncLanguageUi() {
 }
 
 function setDemoOverlayVisualState(active) {
-    document.body.classList.toggle('demo-overlay-active', !!active);
+    document.body.classList.toggle('demo-overlay-active', CURRENT_PAGE === 'demo' && !!active);
 }
 
 function resetDemoOverlayPresentation() {
@@ -92,6 +93,25 @@ function resetDemoOverlayPresentation() {
     renderList('demoNextChecks', [tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.')], (item) => item);
     renderList('demoEvidenceIds', [tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.')], (item) => item);
     renderList('demoRejectedAlternatives', [tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.')], (item) => item);
+}
+
+function updateDemoModeBanner(result) {
+    const banner = document.getElementById('demoModeBanner');
+    const text = document.getElementById('demoModeBannerText');
+    if (!banner || CURRENT_PAGE !== 'dashboard') return;
+    if (!result || !result.active) {
+        banner.hidden = true;
+        if (text) {
+            text.textContent = 'A demo overlay is active. Review replay output on the dedicated demo page, not on the operational dashboard.';
+        }
+        return;
+    }
+    banner.hidden = false;
+    const scenarioId = String(result.scenario_id || 'demo').trim() || 'demo';
+    const action = String(result.arbiter?.action || '-').trim() || '-';
+    if (text) {
+        text.textContent = `Demo overlay ${scenarioId} is active with action ${action}. The operational dashboard remains on live telemetry; use /demo for replay output and reviewer state.`;
+    }
 }
 
 const shortcutQuestions = {
@@ -562,6 +582,7 @@ async function refreshDashboard() {
     latestMattermost = mattermost || {};
     demoOverlayResult = demoOverlay && demoOverlay.active ? demoOverlay : null;
     setDemoOverlayVisualState(!!demoOverlayResult);
+    updateDemoModeBanner(demoOverlayResult);
     if (!demoOverlayResult) {
         resetDemoOverlayPresentation();
     }
@@ -576,9 +597,11 @@ async function refreshDashboard() {
         updateTemporaryMission(actions);
         updateEvidenceBoard(evidence, health);
         updateAssistant(actions, mattermost, capabilities);
-        updateReviewReadiness(resultMap.health, resultMap.demoCapabilities, demoOverlayResult);
+        if (CURRENT_PAGE === 'demo') {
+            updateReviewReadiness(resultMap.health, resultMap.demoCapabilities, demoOverlayResult);
+        }
         updateControlButtons(summary, state);
-        if (demoOverlayResult) {
+        if (CURRENT_PAGE === 'demo' && demoOverlayResult) {
             applyDemoOverlay(demoOverlayResult);
         }
     } catch (error) {

--- a/azazel_edge_web/static/style.css
+++ b/azazel_edge_web/static/style.css
@@ -210,6 +210,126 @@ body[data-audience="professional"] .temp-only {
     padding: 24px 22px 64px;
 }
 
+.demo-shell {
+    max-width: 1280px;
+}
+
+.demo-page-grid {
+    display: grid;
+    grid-template-columns: 1.15fr 0.85fr;
+    gap: 18px;
+    align-items: start;
+}
+
+.demo-mode-banner {
+    padding: 18px 22px;
+    margin-bottom: 18px;
+    border-color: rgba(224, 164, 88, 0.28);
+    background: linear-gradient(145deg, rgba(57, 42, 20, 0.42), rgba(24, 27, 34, 0.88));
+}
+
+.demo-mode-banner-static {
+    border-color: rgba(116, 212, 255, 0.24);
+    background: linear-gradient(145deg, rgba(30, 66, 92, 0.32), rgba(17, 30, 46, 0.7));
+}
+
+.demo-panel,
+.review-panel {
+    overflow: hidden;
+}
+
+.demo-sidebar {
+    position: sticky;
+    top: 96px;
+}
+
+.demo-hero-grid,
+.demo-card-grid,
+.demo-copy-grid {
+    display: grid;
+    gap: 14px;
+}
+
+.demo-hero-grid {
+    grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+    margin-top: 8px;
+    margin-bottom: 18px;
+}
+
+.demo-card-grid,
+.demo-copy-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-top: 16px;
+}
+
+.demo-control-card,
+.demo-result-block,
+.demo-metric-card,
+.demo-copy-card,
+.review-summary-banner {
+    margin-top: 0;
+}
+
+.demo-control-card {
+    min-height: 100%;
+}
+
+.demo-shortcuts {
+    margin-top: 14px;
+}
+
+.demo-result-block {
+    padding: 18px 18px 20px;
+    border-radius: 18px;
+    background: linear-gradient(145deg, rgba(255,255,255,0.055), rgba(255,255,255,0.028));
+    border: 1px solid rgba(116, 212, 255, 0.12);
+}
+
+.demo-kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.demo-kpi {
+    min-height: 92px;
+    padding: 14px 14px 12px;
+    border-radius: 14px;
+    background: rgba(10, 15, 20, 0.34);
+    border: 1px solid rgba(255,255,255,0.06);
+}
+
+.demo-kpi strong {
+    display: block;
+    margin-top: 10px;
+    font-size: 1.08rem;
+    line-height: 1.2;
+    color: var(--text-main);
+}
+
+.demo-kpi-wide {
+    grid-column: span 2;
+}
+
+.demo-metric-card,
+.demo-copy-card {
+    min-height: 100%;
+    padding: 18px 18px 20px;
+    border-radius: 18px;
+    background: rgba(11, 18, 24, 0.44);
+    border: 1px solid rgba(255,255,255,0.06);
+}
+
+.demo-copy-card #demoOperatorWording {
+    line-height: 1.62;
+    color: var(--text-main);
+}
+
+.review-summary-banner {
+    margin-bottom: 16px;
+}
+
 .panel {
     background: linear-gradient(180deg, rgba(255,255,255,0.06), rgba(255,255,255,0.025));
     border: 1px solid var(--line-soft);
@@ -906,6 +1026,28 @@ body.demo-overlay-active #healthSummaryLine {
 
     .board-layout {
         grid-template-columns: 1fr;
+    }
+
+    .demo-page-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .demo-sidebar {
+        position: static;
+    }
+
+    .demo-hero-grid,
+    .demo-card-grid,
+    .demo-copy-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .demo-kpi-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .demo-kpi-wide {
+        grid-column: span 2;
     }
 
     .split-grid,

--- a/azazel_edge_web/templates/demo.html
+++ b/azazel_edge_web/templates/demo.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="{{ tr('dashboard.html_lang', 'en') }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ tr('dashboard.demo_runner', 'Demo Runner') }} | Azazel-Edge</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body data-audience="professional" data-page="demo">
+    <header class="topbar">
+        <div class="brand-block">
+            <div class="brand-kicker">Azazel-Edge</div>
+            <h1>{{ tr('dashboard.demo_runner', 'Demo Runner') }}</h1>
+            <p class="brand-subtitle">Dedicated replay and reviewer workspace. Operational dashboard concerns stay on the main page.</p>
+        </div>
+        <div class="topbar-controls">
+            <div class="language-toggle" role="tablist" aria-label="{{ tr('lang.label', 'Language') }}">
+                <button id="langJaBtn" class="audience-btn{% if ui_lang == 'ja' %} active lang-active-ja{% endif %}" data-lang="ja">{{ tr('lang.ja', '日本語') }}</button>
+                <button id="langEnBtn" class="audience-btn{% if ui_lang == 'en' %} active lang-active-en{% endif %}" data-lang="en">{{ tr('lang.en', 'English') }}</button>
+            </div>
+            <div class="topbar-links">
+                <a class="topbar-link" href="/">Dashboard</a>
+                <a class="topbar-link" href="/ops-comm">Ops Comm</a>
+            </div>
+            <div class="topbar-meta">
+                <div class="meta-item">
+                    <span class="meta-label">CPU</span>
+                    <strong id="headerCpuUsage">--%</strong>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-label">MEM</span>
+                    <strong id="headerMemUsage">--%</strong>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-label">TEMP</span>
+                    <strong id="headerCpuTemp">--°C</strong>
+                </div>
+                <div class="meta-clock" id="headerClock">--:--:--</div>
+            </div>
+        </div>
+    </header>
+
+    <main class="dashboard-shell demo-shell">
+        <section class="panel demo-mode-banner demo-mode-banner-static">
+            <div class="panel-heading">
+                <div>
+                    <div class="panel-kicker">Separation</div>
+                    <h2>Replay and reviewer view</h2>
+                </div>
+            </div>
+            <p class="panel-note">This page owns deterministic replay, capability boundary, and reviewer-facing status. The main dashboard stays focused on live operations.</p>
+        </section>
+
+        <div class="demo-page-grid">
+            <section class="panel assistant-panel demo-panel" id="demoPanel">
+                <div class="panel-heading assistant-heading">
+                    <div>
+                        <div class="panel-kicker">{{ tr('dashboard.demo_runner', 'Demo Runner') }}</div>
+                        <h2>{{ tr('dashboard.scenario_replay', 'Scenario Replay') }}</h2>
+                    </div>
+                    <span class="assistant-status status-neutral" id="demoStatusBadge">READY</span>
+                </div>
+                <p class="assistant-intro">{{ tr('dashboard.demo_intro', 'Run deterministic backend scenarios and inspect the resulting NOC, SOC, arbiter, and explanation outputs.') }}</p>
+
+                <div class="demo-hero-grid">
+                    <form id="demoRunForm" class="assistant-form demo-control-card">
+                        <label for="demoScenarioSelect">Scenario</label>
+                        <select id="demoScenarioSelect" class="demo-select">
+                            <option value="">Loading scenarios...</option>
+                        </select>
+                        <div id="demoScenarioDescription" class="demo-description">-</div>
+                        <div class="assistant-shortcuts demo-shortcuts">
+                            <button type="submit" id="demoRunSubmit" class="assistant-submit">{{ tr('dashboard.run_demo', 'Run Demo') }}</button>
+                            <button type="button" id="demoClearOverlayBtn" class="shortcut-btn">{{ tr('dashboard.clear_demo', 'Clear Demo Overlay') }}</button>
+                        </div>
+                    </form>
+
+                    <div class="demo-boundary-banner demo-control-card" id="demoBoundaryBanner">
+                        <strong id="demoBoundaryMode">DETERMINISTIC REPLAY</strong>
+                        <span id="demoBoundarySummary">{{ tr('dashboard.demo_boundary_summary', 'Deterministic replay path. This does not replace the live Tactical first-pass path, and AI is not used in the core demo decision loop.') }}</span>
+                    </div>
+                </div>
+
+                <div class="assistant-block demo-result-block">
+                    <div class="assistant-label">Scenario Result</div>
+                    <div class="demo-kpi-grid">
+                        <div class="fact-item demo-kpi"><span>Scenario</span><strong id="demoScenarioId">-</strong></div>
+                        <div class="fact-item demo-kpi"><span>Events</span><strong id="demoEventCount">-</strong></div>
+                        <div class="fact-item demo-kpi"><span>Execution</span><strong id="demoExecutionMode">-</strong></div>
+                        <div class="fact-item demo-kpi"><span>AI Core</span><strong id="demoAiCore">-</strong></div>
+                        <div class="fact-item demo-kpi"><span>NOC</span><strong id="demoNocStatus">-</strong></div>
+                        <div class="fact-item demo-kpi"><span>SOC</span><strong id="demoSocStatus">-</strong></div>
+                        <div class="fact-item demo-kpi"><span>Action</span><strong id="demoAction">-</strong></div>
+                        <div class="fact-item demo-kpi demo-kpi-wide"><span>Reason</span><strong id="demoReason">-</strong></div>
+                    </div>
+                </div>
+
+                <div class="demo-card-grid">
+                    <div class="assistant-block demo-metric-card">
+                        <div class="assistant-label">Action Safety</div>
+                        <div class="fact-list compact-list">
+                            <div class="fact-item"><span>Reversible</span><strong id="demoSafetyReversible">-</strong></div>
+                            <div class="fact-item"><span>Approval</span><strong id="demoSafetyApproval">-</strong></div>
+                            <div class="fact-item"><span>Audited</span><strong id="demoSafetyAudited">-</strong></div>
+                            <div class="fact-item"><span>Effect</span><strong id="demoSafetyEffect">-</strong></div>
+                        </div>
+                    </div>
+
+                    <div class="assistant-block demo-metric-card">
+                        <div class="assistant-label">Arbiter Trace</div>
+                        <div class="fact-list compact-list">
+                            <div class="fact-item"><span>NOC Fragile</span><strong id="demoTraceNocFragile">-</strong></div>
+                            <div class="fact-item"><span>Strong SOC</span><strong id="demoTraceStrongSoc">-</strong></div>
+                            <div class="fact-item"><span>Blast / Confidence</span><strong id="demoTraceBlastConfidence">-</strong></div>
+                            <div class="fact-item"><span>Client Impact</span><strong id="demoTraceClientImpact">-</strong></div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="demo-copy-grid">
+                    <div class="assistant-block demo-copy-card">
+                        <div class="assistant-label">Operator Wording</div>
+                        <div id="demoOperatorWording">{{ tr('dashboard.no_demo', 'No demo overlay is active.') }}</div>
+                    </div>
+                    <div class="assistant-block demo-copy-card">
+                        <div class="assistant-label">Next Checks</div>
+                        <ul class="action-list" id="demoNextChecks">
+                            <li>{{ tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.') }}</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="demo-copy-grid">
+                    <div class="assistant-block demo-copy-card">
+                        <div class="assistant-label">Chosen Evidence</div>
+                        <ul class="action-list" id="demoEvidenceIds">
+                            <li>{{ tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.') }}</li>
+                        </ul>
+                    </div>
+                    <div class="assistant-block demo-copy-card">
+                        <div class="assistant-label">Rejected Alternatives</div>
+                        <ul class="action-list" id="demoRejectedAlternatives">
+                            <li>{{ tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.') }}</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <details class="demo-raw-panel">
+                    <summary>Raw JSON</summary>
+                    <pre class="assistant-response demo-raw-response" id="demoResponse">{{ tr('dashboard.no_demo_response', 'Run a scenario to preview the deterministic pipeline.') }}</pre>
+                </details>
+            </section>
+
+            <aside class="demo-sidebar">
+                <section class="panel assistant-panel review-panel" id="reviewPanel">
+                    <div class="panel-heading assistant-heading">
+                        <div>
+                            <div class="panel-kicker">Review Readiness</div>
+                            <h2>Capability Boundary and Resource Guard</h2>
+                        </div>
+                        <span class="assistant-status status-neutral" id="reviewStatusBadge">READY</span>
+                    </div>
+                    <p class="assistant-intro">Compact proof that the deterministic path is bounded, local-first, and running within visible resource limits.</p>
+                    <div class="demo-boundary-banner review-summary-banner">
+                        <strong id="reviewSummary">Deterministic edge pipeline, bounded controls, local-first operation, auditable outputs.</strong>
+                        <span id="reviewSummaryDetail">Waiting for capability and health data.</span>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Capability Boundary</div>
+                        <div class="fact-list compact-list">
+                            <div class="fact-item"><span>Execution</span><strong id="reviewExecutionMode">-</strong></div>
+                            <div class="fact-item"><span>AI Core</span><strong id="reviewAiCore">-</strong></div>
+                            <div class="fact-item"><span>Local Only</span><strong id="reviewLocalOnly">-</strong></div>
+                            <div class="fact-item"><span>Live Telemetry</span><strong id="reviewLiveTelemetry">-</strong></div>
+                            <div class="fact-item"><span>Demo State</span><strong id="reviewDemoState">-</strong></div>
+                            <div class="fact-item"><span>Implemented / Experimental</span><strong id="reviewBoundaryCounts">-</strong></div>
+                        </div>
+                        <div class="assistant-shortcuts demo-shortcuts">
+                            <button type="button" class="shortcut-btn" id="reviewOpenCapabilitiesBtn">Open Capability JSON</button>
+                            <button type="button" class="shortcut-btn" id="reviewOpenExplanationBtn">Open Latest Explanation</button>
+                        </div>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Implemented Now</div>
+                        <ul class="action-list" id="reviewImplementedList">
+                            <li>No data</li>
+                        </ul>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Experimental / Non-goals</div>
+                        <ul class="action-list" id="reviewExperimentalList">
+                            <li>No data</li>
+                        </ul>
+                        <ul class="action-list" id="reviewNonGoalsList">
+                            <li>No data</li>
+                        </ul>
+                    </div>
+                    <div class="assistant-block">
+                        <div class="assistant-label">Resource Guard</div>
+                        <div class="fact-list compact-list">
+                            <div class="fact-item"><span>Queue</span><strong id="reviewQueueDepth">-</strong></div>
+                            <div class="fact-item"><span>Deferred</span><strong id="reviewDeferredCount">-</strong></div>
+                            <div class="fact-item"><span>Fallback</span><strong id="reviewFallbackRate">-</strong></div>
+                            <div class="fact-item"><span>Policy</span><strong id="reviewPolicyMode">-</strong></div>
+                            <div class="fact-item"><span>Latency</span><strong id="reviewLatency">-</strong></div>
+                            <div class="fact-item"><span>Stale</span><strong id="reviewStaleFlags">-</strong></div>
+                        </div>
+                    </div>
+                </section>
+            </aside>
+        </div>
+    </main>
+
+    <div id="toast" class="toast"></div>
+    <script>
+        window.AZAZEL_LANG = {{ ui_lang|tojson }};
+        window.AZAZEL_I18N = {{ ui_catalog|tojson }};
+    </script>
+    <script src="/static/app.js"></script>
+</body>
+</html>

--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -6,7 +6,7 @@
     <title>{{ tr('dashboard.title', 'Azazel-Edge Command Dashboard') }}</title>
     <link rel="stylesheet" href="/static/style.css">
 </head>
-<body data-audience="professional">
+<body data-audience="professional" data-page="dashboard">
     <header class="topbar">
         <div class="brand-block">
             <div class="brand-kicker">Azazel-Edge</div>
@@ -25,6 +25,7 @@
             <div class="topbar-links">
                 <a id="askMioLink" class="topbar-link" href="#assistantPanel">{{ tr('dashboard.ask_mio', 'Ask M.I.O.') }}</a>
                 <a id="openMattermostLink" class="topbar-link" href="/ops-comm">{{ tr('dashboard.open_mattermost', 'Open Mattermost') }}</a>
+                <a class="topbar-link" href="/demo">Demo</a>
             </div>
             <div class="topbar-meta">
                 <div class="meta-item">
@@ -45,6 +46,16 @@
     </header>
 
     <main class="dashboard-shell">
+        <section class="panel demo-mode-banner" id="demoModeBanner" hidden>
+            <div class="panel-heading">
+                <div>
+                    <div class="panel-kicker">Demo Overlay</div>
+                    <h2>Operational dashboard remains live</h2>
+                </div>
+                <a class="topbar-link" href="/demo">Open Demo Page</a>
+            </div>
+            <p class="panel-note" id="demoModeBannerText">A demo overlay is active. Review replay output on the dedicated demo page, not on the operational dashboard.</p>
+        </section>
         <section class="command-strip panel">
             <div class="panel-heading">
                 <div>
@@ -527,144 +538,6 @@
                     </div>
                 </section>
 
-                <section class="panel assistant-panel demo-panel" id="demoPanel">
-                    <div class="panel-heading assistant-heading">
-                        <div>
-                            <div class="panel-kicker">{{ tr('dashboard.demo_runner', 'Demo Runner') }}</div>
-                            <h2>{{ tr('dashboard.scenario_replay', 'Scenario Replay') }}</h2>
-                        </div>
-                        <span class="assistant-status status-neutral" id="demoStatusBadge">READY</span>
-                    </div>
-                    <p class="assistant-intro">{{ tr('dashboard.demo_intro', 'Run deterministic backend scenarios and inspect the resulting NOC, SOC, arbiter, and explanation outputs.') }}</p>
-                    <form id="demoRunForm" class="assistant-form">
-                        <label for="demoScenarioSelect">Scenario</label>
-                        <select id="demoScenarioSelect" class="demo-select">
-                            <option value="">Loading scenarios...</option>
-                        </select>
-                        <div id="demoScenarioDescription" class="demo-description">-</div>
-                        <div class="assistant-shortcuts">
-                            <button type="submit" id="demoRunSubmit" class="assistant-submit">{{ tr('dashboard.run_demo', 'Run Demo') }}</button>
-                            <button type="button" id="demoClearOverlayBtn" class="shortcut-btn">{{ tr('dashboard.clear_demo', 'Clear Demo Overlay') }}</button>
-                        </div>
-                    </form>
-                    <div class="demo-boundary-banner" id="demoBoundaryBanner">
-                        <strong id="demoBoundaryMode">DETERMINISTIC REPLAY</strong>
-                        <span id="demoBoundarySummary">{{ tr('dashboard.demo_boundary_summary', 'Deterministic replay path. This does not replace the live Tactical first-pass path, and AI is not used in the core demo decision loop.') }}</span>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Scenario Result</div>
-                        <div class="fact-list compact-list">
-                            <div class="fact-item"><span>Scenario</span><strong id="demoScenarioId">-</strong></div>
-                            <div class="fact-item"><span>Events</span><strong id="demoEventCount">-</strong></div>
-                            <div class="fact-item"><span>Execution</span><strong id="demoExecutionMode">-</strong></div>
-                            <div class="fact-item"><span>AI Core</span><strong id="demoAiCore">-</strong></div>
-                            <div class="fact-item"><span>NOC</span><strong id="demoNocStatus">-</strong></div>
-                            <div class="fact-item"><span>SOC</span><strong id="demoSocStatus">-</strong></div>
-                            <div class="fact-item"><span>Action</span><strong id="demoAction">-</strong></div>
-                            <div class="fact-item"><span>Reason</span><strong id="demoReason">-</strong></div>
-                        </div>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Action Safety</div>
-                        <div class="fact-list compact-list">
-                            <div class="fact-item"><span>Reversible</span><strong id="demoSafetyReversible">-</strong></div>
-                            <div class="fact-item"><span>Approval</span><strong id="demoSafetyApproval">-</strong></div>
-                            <div class="fact-item"><span>Audited</span><strong id="demoSafetyAudited">-</strong></div>
-                            <div class="fact-item"><span>Effect</span><strong id="demoSafetyEffect">-</strong></div>
-                        </div>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Arbiter Trace</div>
-                        <div class="fact-list compact-list">
-                            <div class="fact-item"><span>NOC Fragile</span><strong id="demoTraceNocFragile">-</strong></div>
-                            <div class="fact-item"><span>Strong SOC</span><strong id="demoTraceStrongSoc">-</strong></div>
-                            <div class="fact-item"><span>Blast / Confidence</span><strong id="demoTraceBlastConfidence">-</strong></div>
-                            <div class="fact-item"><span>Client Impact</span><strong id="demoTraceClientImpact">-</strong></div>
-                        </div>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Operator Wording</div>
-                        <div id="demoOperatorWording">{{ tr('dashboard.no_demo', 'No demo overlay is active.') }}</div>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Next Checks</div>
-                        <ul class="action-list" id="demoNextChecks">
-                            <li>{{ tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.') }}</li>
-                        </ul>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Chosen Evidence</div>
-                        <ul class="action-list" id="demoEvidenceIds">
-                            <li>{{ tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.') }}</li>
-                        </ul>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Rejected Alternatives</div>
-                        <ul class="action-list" id="demoRejectedAlternatives">
-                            <li>{{ tr('dashboard.no_demo_overlay_active', 'No demo overlay is active.') }}</li>
-                        </ul>
-                    </div>
-                    <details class="demo-raw-panel">
-                        <summary>Raw JSON</summary>
-                        <pre class="assistant-response demo-raw-response" id="demoResponse">{{ tr('dashboard.no_demo_response', 'Run a scenario to preview the deterministic pipeline.') }}</pre>
-                    </details>
-                </section>
-
-                <section class="panel assistant-panel review-panel" id="reviewPanel">
-                    <div class="panel-heading assistant-heading">
-                        <div>
-                            <div class="panel-kicker">Review Readiness</div>
-                            <h2>Capability Boundary and Resource Guard</h2>
-                        </div>
-                        <span class="assistant-status status-neutral" id="reviewStatusBadge">READY</span>
-                    </div>
-                    <p class="assistant-intro">Compact proof that the deterministic path is bounded, local-first, and running within visible resource limits.</p>
-                    <div class="demo-boundary-banner">
-                        <strong id="reviewSummary">Deterministic edge pipeline, bounded controls, local-first operation, auditable outputs.</strong>
-                        <span id="reviewSummaryDetail">Waiting for capability and health data.</span>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Capability Boundary</div>
-                        <div class="fact-list compact-list">
-                            <div class="fact-item"><span>Execution</span><strong id="reviewExecutionMode">-</strong></div>
-                            <div class="fact-item"><span>AI Core</span><strong id="reviewAiCore">-</strong></div>
-                            <div class="fact-item"><span>Local Only</span><strong id="reviewLocalOnly">-</strong></div>
-                            <div class="fact-item"><span>Live Telemetry</span><strong id="reviewLiveTelemetry">-</strong></div>
-                            <div class="fact-item"><span>Demo State</span><strong id="reviewDemoState">-</strong></div>
-                            <div class="fact-item"><span>Implemented / Experimental</span><strong id="reviewBoundaryCounts">-</strong></div>
-                        </div>
-                        <div class="assistant-shortcuts">
-                            <button type="button" class="shortcut-btn" id="reviewOpenCapabilitiesBtn">Open Capability JSON</button>
-                            <button type="button" class="shortcut-btn" id="reviewOpenExplanationBtn">Open Latest Explanation</button>
-                        </div>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Implemented Now</div>
-                        <ul class="action-list" id="reviewImplementedList">
-                            <li>No data</li>
-                        </ul>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Experimental / Non-goals</div>
-                        <ul class="action-list" id="reviewExperimentalList">
-                            <li>No data</li>
-                        </ul>
-                        <ul class="action-list" id="reviewNonGoalsList">
-                            <li>No data</li>
-                        </ul>
-                    </div>
-                    <div class="assistant-block">
-                        <div class="assistant-label">Resource Guard</div>
-                        <div class="fact-list compact-list">
-                            <div class="fact-item"><span>Queue</span><strong id="reviewQueueDepth">-</strong></div>
-                            <div class="fact-item"><span>Deferred</span><strong id="reviewDeferredCount">-</strong></div>
-                            <div class="fact-item"><span>Fallback</span><strong id="reviewFallbackRate">-</strong></div>
-                            <div class="fact-item"><span>Policy</span><strong id="reviewPolicyMode">-</strong></div>
-                            <div class="fact-item"><span>Latency</span><strong id="reviewLatency">-</strong></div>
-                            <div class="fact-item"><span>Stale</span><strong id="reviewStaleFlags">-</strong></div>
-                        </div>
-                    </div>
-                </section>
             </aside>
         </div>
 

--- a/azazel_edge_web/templates/ops_comm.html
+++ b/azazel_edge_web/templates/ops_comm.html
@@ -21,6 +21,7 @@
             <button id="langJaBtn" class="audience-btn{% if ui_lang == 'ja' %} active lang-active-ja{% endif %}" data-lang="ja">{{ tr('lang.ja', '日本語') }}</button>
             <button id="langEnBtn" class="audience-btn{% if ui_lang == 'en' %} active lang-active-en{% endif %}" data-lang="en">{{ tr('lang.en', 'English') }}</button>
             <a class="topbar-link" href="/">{{ tr('ops.dashboard', 'Dashboard') }}</a>
+            <a class="topbar-link" href="/demo">Demo</a>
             <a class="topbar-link" id="mattermostLink" href="{{ mattermost_open_url or '#' }}" target="_blank" rel="noopener noreferrer">{{ tr('ops.open_mattermost', 'Open Mattermost') }}</a>
         </div>
     </header>

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -420,15 +420,8 @@ class DashboardDataContractTests(unittest.TestCase):
         self.assertIn("Background History", text)
         self.assertIn("Triage Audit", text)
         self.assertIn("Supporting history and audit trail", text)
-        self.assertIn("Demo Runner", text)
-        self.assertIn("Scenario Replay", text)
-        self.assertIn("Run Demo", text)
+        self.assertIn("Open Demo Page", text)
         self.assertIn("temporaryOpsCommLink", text)
-        self.assertIn("Next Checks", text)
-        self.assertIn("Chosen Evidence", text)
-        self.assertIn("Rejected Alternatives", text)
-        self.assertIn("Raw JSON", text)
-        self.assertIn("Clear Demo Overlay", text)
         self.assertIn("Ask M.I.O.", text)
         self.assertIn("Why now", text)
         self.assertIn("Do not do", text)
@@ -436,6 +429,19 @@ class DashboardDataContractTests(unittest.TestCase):
         self.assertIn("Reconnect", text)
         self.assertIn("Onboarding", text)
         self.assertIn("Portal", text)
+        self.assertNotIn('id="demoRunForm"', text)
+        self.assertNotIn('id="reviewPanel"', text)
+
+    def test_demo_page_renders_replay_and_review_sections(self) -> None:
+        response = self.client.get("/demo?lang=en")
+        self.assertEqual(response.status_code, 200)
+        text = response.get_data(as_text=True)
+        self.assertIn("Demo Runner", text)
+        self.assertIn("Scenario Replay", text)
+        self.assertIn("Run Demo", text)
+        self.assertIn("Review Readiness", text)
+        self.assertIn("Capability Boundary and Resource Guard", text)
+        self.assertIn("Open Latest Explanation", text)
 
     def test_manual_ai_ask_enriches_rationale_and_handoff(self) -> None:
         webapp._send_ai_manual_query = lambda **_: {


### PR DESCRIPTION
## Summary
- split demo replay and reviewer-facing controls out of the live dashboard into a dedicated `/demo` page
- keep the operational dashboard focused on live NOC/SOC workflow, with only a small overlay warning banner when demo state is active
- improve the dedicated demo page layout so the replay controls, result summary, arbiter context, and capability boundary are easier to scan

## Verification
- `PYTHONPATH=/home/azazel/Azazel-Edge ./.venv/bin/pytest -q` -> `155 passed`
- `git diff --check`

## Deployment note
- synced the changed web files into `/opt/azazel-edge` and restarted `azazel-edge-web.service` so the running environment reflects this split