### PR TITLE
Post-demo mainline hardening for #104 #105 #106

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+.venv/
 rust/azazel-edge-core/target/

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ Evidence:
 
 ### Authentication behavior
 - Most `/api/*` endpoints are token-protected.
-- If token file is absent, token checks are bypassed (`verify_token()` in `azazel_edge_web/app.py`).
-- Token file candidates include `~/.azazel-edge/web_token.txt` (see `web_token_candidates()` usage).
+- Installer-managed runtime sets fail-closed by default (`AZAZEL_AUTH_FAIL_OPEN=0`).
+- Legacy fail-open compatibility is controlled by `AZAZEL_AUTH_FAIL_OPEN` when token file is absent.
+- Managed default token file is `/etc/azazel-edge/web_token.txt` via `AZAZEL_WEB_TOKEN_FILE`.
 
 ## Feature Traceability
 
@@ -316,6 +317,8 @@ Latest verified result (2026-03-15): **183 passed in 3.57s**
 - [M.I.O. persona profile](docs/MIO_PERSONA_PROFILE.md)
 - [Demo guide](docs/DEMO_GUIDE.md)
 - [Demo guide (Japanese)](docs/DEMO_GUIDE_JA.md)
+- [Post-demo main integration boundary (#104)](docs/POST_DEMO_MAIN_INTEGRATION_104.md)
+- [Post-demo socket permission model (#105)](docs/POST_DEMO_SOCKET_PERMISSION_MODEL_105.md)
 
 ## Limitations
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -105,8 +105,9 @@ optional AI assist path | 任意の AI 補助経路
 
 ### 認証挙動
 - 多くの `/api/*` エンドポイントはトークン検証あり。
-- ただし token file が無い場合は `verify_token()` が通過させる実装。
-- token 候補には `~/.azazel-edge/web_token.txt` を含む（`web_token_candidates()` 参照）。
+- installer 管理ランタイムでは `AZAZEL_AUTH_FAIL_OPEN=0` を既定とし、fail-closed 運用。
+- token file 不在時の互換 fail-open は `AZAZEL_AUTH_FAIL_OPEN` で制御。
+- 管理時の token file は `AZAZEL_WEB_TOKEN_FILE` 経由で `/etc/azazel-edge/web_token.txt`。
 
 ## 機能トレーサビリティ
 
@@ -316,6 +317,8 @@ PYTHONPATH=. .venv/bin/pytest -q
 - [M.I.O. persona profile](docs/MIO_PERSONA_PROFILE.md)
 - [Demo guide](docs/DEMO_GUIDE.md)
 - [Demo guide (Japanese)](docs/DEMO_GUIDE_JA.md)
+- [Post-demo main integration boundary (#104)](docs/POST_DEMO_MAIN_INTEGRATION_104.md)
+- [Post-demo socket permission model (#105)](docs/POST_DEMO_SOCKET_PERMISSION_MODEL_105.md)
 
 ## 制約
 

--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -138,7 +138,9 @@ TRIAGE_AUDIT_LOG = Path(os.environ.get("AZAZEL_TRIAGE_AUDIT_PATH", "/var/log/aza
 TRIAGE_AUDIT_FALLBACK_LOG = Path("/tmp/azazel-edge-triage-audit.jsonl")
 TRIAGE_SESSION_DIR = Path(os.environ.get("AZAZEL_TRIAGE_SESSION_DIR", "/run/azazel-edge/triage-sessions"))
 OPERATOR_PROGRESS_PATH = Path(os.environ.get("AZAZEL_OPERATOR_PROGRESS_PATH", "/run/azazel-edge/operator-progress.json"))
-TOKEN_FILE = web_token_candidates()[0]
+_TOKEN_FILE_OVERRIDE = str(os.environ.get("AZAZEL_WEB_TOKEN_FILE", "")).strip()
+TOKEN_FILE = Path(_TOKEN_FILE_OVERRIDE) if _TOKEN_FILE_OVERRIDE else web_token_candidates()[0]
+AUTH_FAIL_OPEN = os.environ.get("AZAZEL_AUTH_FAIL_OPEN", "0") == "1"
 IMAGES_DIR = Path(__file__).resolve().parents[1] / "images"
 LOCAL_DEMO_RUNNER = PROJECT_ROOT / "bin" / "azazel-edge-demo"
 OPT_DEMO_RUNNER = Path("/opt/azazel-edge/bin/azazel-edge-demo")
@@ -2877,7 +2879,7 @@ def verify_token() -> bool:
     """リクエストのトークン検証（ヘッダーまたはクエリパラメータ）"""
     token = load_token()
     if not token:
-        return True  # トークン未設定の場合はスルー
+        return AUTH_FAIL_OPEN
     
     req_token = (
         request.headers.get('X-AZAZEL-TOKEN')
@@ -5217,7 +5219,10 @@ if __name__ == "__main__":
     if load_token():
         print(f"   🔒 Token authentication enabled")
     else:
-        print(f"   ⚠️  WARNING: No token configured (open access)")
+        if AUTH_FAIL_OPEN:
+            print(f"   ⚠️  WARNING: No token configured (fail-open enabled)")
+        else:
+            print(f"   ⚠️  WARNING: No token configured (API auth will deny protected endpoints)")
     
     app.run(
         host=BIND_HOST,

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -1,4 +1,4 @@
-const AUTH_TOKEN = localStorage.getItem('azazel_token') || 'azazel-default-token-change-me';
+const AUTH_TOKEN = String(localStorage.getItem('azazel_token') || '').trim();
 const AUDIENCE_KEY = 'azazel_dashboard_audience';
 const LANG_KEY = 'azazel_lang';
 const PROGRESS_SESSION_KEY = 'azazel_operator_progress_session';
@@ -67,11 +67,14 @@ function resolveInitialAudience() {
 }
 
 function authHeaders() {
-    return {
+    const headers = {
         'Content-Type': 'application/json',
-        'X-Auth-Token': AUTH_TOKEN,
         'X-AZAZEL-LANG': CURRENT_LANG,
     };
+    if (AUTH_TOKEN) {
+        headers['X-Auth-Token'] = AUTH_TOKEN;
+    }
+    return headers;
 }
 
 function ensureProgressSessionId() {

--- a/azazel_edge_web/static/ops_comm.js
+++ b/azazel_edge_web/static/ops_comm.js
@@ -1,4 +1,4 @@
-const AUTH_TOKEN = localStorage.getItem('azazel_token') || 'azazel-default-token-change-me';
+const AUTH_TOKEN = String(localStorage.getItem('azazel_token') || '').trim();
 const LANG_KEY = 'azazel_lang';
 const PROGRESS_SESSION_KEY = 'azazel_operator_progress_session';
 const CURRENT_LANG = window.AZAZEL_LANG || localStorage.getItem(LANG_KEY) || 'ja';
@@ -139,11 +139,14 @@ function renderShortcuts() {
 }
 
 function authHeaders() {
-    return {
+    const headers = {
         'Content-Type': 'application/json',
-        'X-Auth-Token': AUTH_TOKEN,
         'X-AZAZEL-LANG': CURRENT_LANG,
     };
+    if (AUTH_TOKEN) {
+        headers['X-Auth-Token'] = AUTH_TOKEN;
+    }
+    return headers;
 }
 
 function setText(id, text) {

--- a/docs/POST_DEMO_MAIN_INTEGRATION_104.md
+++ b/docs/POST_DEMO_MAIN_INTEGRATION_104.md
@@ -1,0 +1,58 @@
+# Post-Demo Main Integration Boundary (#104)
+
+Last updated: 2026-05-11
+
+## Scope
+
+This document fixes the permanent boundary for post-demo mainline integration work.
+
+- In scope: features that remain useful for day-to-day operator workflow.
+- Out of scope: booth/exhibition-only compositions (for example, Blackhat Arsenal-specific UI flow).
+
+## Classification
+
+### Keep As Permanent (mainline)
+
+- Deterministic replay surface:
+  - Web route: `/demo`
+  - APIs: `/api/demo/*`
+  - Template: `azazel_edge_web/templates/demo.html`
+  - Overlay pipeline: `py/azazel_edge/demo_overlay.py`
+  - CLI entry: `bin/azazel-edge-demo`
+- Operator continuity surfaces:
+  - `index.html`, `ops_comm.html`
+  - `app.js`, `ops_comm.js`, `style.css`, `ops_comm.css`
+- Runtime deployment and sync checks for the permanent files above.
+
+### Exhibition-only (excluded from mainline operation)
+
+- Blackhat Arsenal booth composition and related look/stage behavior.
+- Any `arsenal-demo`-specific route/template/static set.
+
+Policy:
+- Keep exhibition-only composition outside normal production/runtime assumptions.
+- Do not make installer/runtime sync depend on exhibition-only assets.
+
+### Retired / not adopted
+
+- None newly retired in this pass.
+- If a file is removed from permanent scope later, update this document and runtime sync list together.
+
+## Runtime Alignment Rules
+
+Permanent web/demo files must be aligned across:
+
+1. Repository source
+2. Installer deployment target (`/opt/azazel-edge`)
+3. Runtime sync verification (`installer/internal/verify_runtime_sync.sh`)
+
+Minimum required permanent demo alignment:
+
+- `azazel_edge_web/templates/demo.html` must be installed by `install_migrated_tools.sh`.
+- `azazel_edge_web/templates/demo.html` must be monitored by `verify_runtime_sync.sh`.
+
+## Acceptance Checkpoints
+
+- Repo-to-runtime diff is explainable for demo-related surfaces.
+- No accidental "exists in repo but not deployed" gap for permanent demo assets.
+- Exhibition-only boundary is explicit and does not leak into runtime assumptions.

--- a/docs/POST_DEMO_SOCKET_PERMISSION_MODEL_105.md
+++ b/docs/POST_DEMO_SOCKET_PERMISSION_MODEL_105.md
@@ -1,0 +1,63 @@
+# Post-Demo Socket Permission Model (#105)
+
+Last updated: 2026-05-11
+
+## Scope
+
+This document defines the post-demo permission model for Unix sockets under `/run/azazel-edge`.
+
+Targets:
+- `control.sock` (control daemon command socket)
+- `ai-bridge.sock` (AI advisory ingest/query socket)
+
+## Caller Matrix
+
+Socket | Primary callers | Notes
+---|---|---
+`/run/azazel-edge/control.sock` | Web UI process, local CLI/helpers | Used for operator actions and runtime status calls
+`/run/azazel-edge/ai-bridge.sock` | Rust core, local helper (`azazel-edge-inject-test-events`) | Used for normalized event forwarding and manual query path
+
+## Runtime Permission Policy
+
+Configured via environment variables:
+
+- `AZAZEL_RUNTIME_DIR_MODE` (default: `0770`)
+- `AZAZEL_CONTROL_SOCKET_MODE` (default: `0660`)
+- `AZAZEL_AI_SOCKET_MODE` (default: `0660`)
+- `AZAZEL_RUNTIME_SOCKET_GROUP` (default: empty, optional)
+
+Behavior:
+- Runtime directory is created with `AZAZEL_RUNTIME_DIR_MODE`.
+- Each socket is created with its respective socket mode.
+- If `AZAZEL_RUNTIME_SOCKET_GROUP` is configured and exists, runtime dir/socket group ownership is aligned to that group.
+
+## Managed Defaults
+
+Installer-managed runtime (`install_migrated_tools.sh`) seeds:
+
+- `/etc/default/azazel-edge-security`
+  - `AZAZEL_RUNTIME_DIR_MODE=0770`
+  - `AZAZEL_CONTROL_SOCKET_MODE=0660`
+  - `AZAZEL_AI_SOCKET_MODE=0660`
+  - `AZAZEL_RUNTIME_SOCKET_GROUP=`
+
+Systemd units consume this file:
+- `azazel-edge-control-daemon.service`
+- `azazel-edge-ai-agent.service`
+- `azazel-edge-core.service`
+
+## Validation Checklist
+
+1. Confirm runtime env values:
+   - `grep -E 'AZAZEL_RUNTIME_DIR_MODE|AZAZEL_CONTROL_SOCKET_MODE|AZAZEL_AI_SOCKET_MODE|AZAZEL_RUNTIME_SOCKET_GROUP' /etc/default/azazel-edge-security`
+2. Confirm socket modes:
+   - `stat -c '%a %n' /run/azazel-edge /run/azazel-edge/control.sock /run/azazel-edge/ai-bridge.sock`
+3. Confirm service health:
+   - `systemctl status azazel-edge-control-daemon azazel-edge-ai-agent azazel-edge-core`
+4. Confirm end-to-end paths:
+   - Web API control path works (`/api/action`, `/api/mode`)
+   - Demo/event forwarding path works (`/api/demo/*`, core -> ai-bridge forwarding)
+
+## Compatibility Note
+
+If a deployment still requires broader local access temporarily, adjust only the environment values in `/etc/default/azazel-edge-security` and document the reason in change logs.

--- a/installer/internal/install_migrated_tools.sh
+++ b/installer/internal/install_migrated_tools.sh
@@ -133,6 +133,7 @@ install -m 0644 "$REPO_ROOT/azazel_edge_web/static/app.js" /opt/azazel-edge/azaz
 install -m 0644 "$REPO_ROOT/azazel_edge_web/static/ops_comm.js" /opt/azazel-edge/azazel_edge_web/static/ops_comm.js
 install -m 0644 "$REPO_ROOT/azazel_edge_web/static/ops_comm.css" /opt/azazel-edge/azazel_edge_web/static/ops_comm.css
 install -m 0644 "$REPO_ROOT/azazel_edge_web/static/style.css" /opt/azazel-edge/azazel_edge_web/static/style.css
+install -m 0644 "$REPO_ROOT/azazel_edge_web/templates/demo.html" /opt/azazel-edge/azazel_edge_web/templates/demo.html
 install -m 0644 "$REPO_ROOT/azazel_edge_web/templates/index.html" /opt/azazel-edge/azazel_edge_web/templates/index.html
 install -m 0644 "$REPO_ROOT/azazel_edge_web/templates/ops_comm.html" /opt/azazel-edge/azazel_edge_web/templates/ops_comm.html
 install -m 0644 "$REPO_ROOT/py/azazel_edge_menu.py" /opt/azazel-edge/py/azazel_edge_menu.py
@@ -167,6 +168,7 @@ install -m 0755 "$REPO_ROOT/bin/azazel-edge-inject-test-events" /usr/local/bin/a
 install -m 0755 "$REPO_ROOT/bin/azazel-edge-demo" /usr/local/bin/azazel-edge-demo
 install -m 0755 "$REPO_ROOT/installer/internal/set_dev_remote_access.sh" /opt/azazel-edge/set_dev_remote_access.sh
 install -m 0755 "$REPO_ROOT/installer/internal/install_ai_runtime.sh" /opt/azazel-edge/install_ai_runtime.sh
+install -m 0755 "$REPO_ROOT/installer/internal/provision_web_token.sh" /opt/azazel-edge/provision_web_token.sh
 install -m 0755 "$REPO_ROOT/installer/internal/provision_mattermost_workspace.sh" /opt/azazel-edge/provision_mattermost_workspace.sh
 install -m 0755 "$REPO_ROOT/installer/internal/provision_mattermost_command.sh" /opt/azazel-edge/provision_mattermost_command.sh
 install -m 0755 "$REPO_ROOT/installer/internal/verify_runtime_sync.sh" /opt/azazel-edge/verify_runtime_sync.sh
@@ -185,6 +187,29 @@ systemctl daemon-reload
 
 echo "[11/16] Prepare runtime/config paths"
 install -d /etc/azazel-edge /var/log/azazel-edge /run/azazel-edge
+WEB_ENV="/etc/default/azazel-edge-web"
+touch "$WEB_ENV"
+if ! grep -q '^AZAZEL_WEB_TOKEN_FILE=' "$WEB_ENV"; then
+  echo 'AZAZEL_WEB_TOKEN_FILE=/etc/azazel-edge/web_token.txt' >> "$WEB_ENV"
+fi
+if ! grep -q '^AZAZEL_AUTH_FAIL_OPEN=' "$WEB_ENV"; then
+  echo 'AZAZEL_AUTH_FAIL_OPEN=0' >> "$WEB_ENV"
+fi
+/opt/azazel-edge/provision_web_token.sh
+SECURITY_ENV="/etc/default/azazel-edge-security"
+touch "$SECURITY_ENV"
+if ! grep -q '^AZAZEL_RUNTIME_DIR_MODE=' "$SECURITY_ENV"; then
+  echo 'AZAZEL_RUNTIME_DIR_MODE=0770' >> "$SECURITY_ENV"
+fi
+if ! grep -q '^AZAZEL_CONTROL_SOCKET_MODE=' "$SECURITY_ENV"; then
+  echo 'AZAZEL_CONTROL_SOCKET_MODE=0660' >> "$SECURITY_ENV"
+fi
+if ! grep -q '^AZAZEL_AI_SOCKET_MODE=' "$SECURITY_ENV"; then
+  echo 'AZAZEL_AI_SOCKET_MODE=0660' >> "$SECURITY_ENV"
+fi
+if ! grep -q '^AZAZEL_RUNTIME_SOCKET_GROUP=' "$SECURITY_ENV"; then
+  echo 'AZAZEL_RUNTIME_SOCKET_GROUP=' >> "$SECURITY_ENV"
+fi
 if [[ ! -f /run/azazel-edge/ui_snapshot.json ]]; then
   cat > /run/azazel-edge/ui_snapshot.json <<'EOD'
 {"now_time":"","ssid":"-","user_state":"CHECKING","recommendation":"Initializing","evidence":[],"snapshot_epoch":0}

--- a/installer/internal/provision_web_token.sh
+++ b/installer/internal/provision_web_token.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOKEN_FILE="${AZAZEL_WEB_TOKEN_FILE:-/etc/azazel-edge/web_token.txt}"
+TOKEN_DIR="$(dirname "$TOKEN_FILE")"
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root: sudo $0"
+  exit 1
+fi
+
+install -d -m 0750 "$TOKEN_DIR"
+
+if [[ -s "$TOKEN_FILE" ]]; then
+  chmod 0640 "$TOKEN_FILE" || true
+  echo "[web-token] keep existing token: $TOKEN_FILE"
+  exit 0
+fi
+
+if command -v openssl >/dev/null 2>&1; then
+  token="$(openssl rand -hex 32)"
+else
+  token="$(date +%s)-$RANDOM-$RANDOM-$RANDOM"
+fi
+
+printf '%s\n' "$token" > "$TOKEN_FILE"
+chmod 0640 "$TOKEN_FILE"
+echo "[web-token] generated token: $TOKEN_FILE"

--- a/installer/internal/verify_runtime_sync.sh
+++ b/installer/internal/verify_runtime_sync.sh
@@ -20,6 +20,7 @@ azazel_edge_web/static/app.js
 azazel_edge_web/static/ops_comm.js
 azazel_edge_web/static/ops_comm.css
 azazel_edge_web/static/style.css
+azazel_edge_web/templates/demo.html
 azazel_edge_web/templates/index.html
 azazel_edge_web/templates/ops_comm.html
 py/azazel_edge/__init__.py

--- a/py/azazel_edge/demo_overlay.py
+++ b/py/azazel_edge/demo_overlay.py
@@ -75,7 +75,13 @@ def _is_overlay_invalid(payload: Dict[str, Any]) -> bool:
         return True
     boot_id = str(payload.get("boot_id") or "").strip()
     current_boot_id = _current_boot_id()
-    if not boot_id or not current_boot_id:
+    # When boot ID cannot be read on this platform/environment, accept only
+    # overlays that also omit boot_id. If boot_id is present we cannot verify
+    # it, so treat it as invalid.
+    if not current_boot_id:
+        return bool(boot_id)
+    # If we can read current boot ID, require overlays to carry one.
+    if not boot_id:
         return True
     return boot_id != current_boot_id
 

--- a/py/azazel_edge/explanations/decision.py
+++ b/py/azazel_edge/explanations/decision.py
@@ -12,7 +12,11 @@ from azazel_edge.triage import select_noc_runbook_support
 class DecisionExplainer:
     def __init__(self, output_path: str | Path = '/var/log/azazel-edge/decision-explanations.jsonl'):
         self.output_path = Path(output_path)
-        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            self.output_path = Path("/tmp/azazel-edge/decision-explanations.jsonl")
+            self.output_path.parent.mkdir(parents=True, exist_ok=True)
         self.knowledge = AttackDefendKnowledge()
 
     def explain(

--- a/py/azazel_edge/triage/session.py
+++ b/py/azazel_edge/triage/session.py
@@ -11,12 +11,18 @@ from .types import TriageSession
 
 
 TRIAGE_SESSION_DIR = Path(os.environ.get("AZAZEL_TRIAGE_SESSION_DIR", "/run/azazel-edge/triage-sessions"))
+TRIAGE_SESSION_FALLBACK_DIR = Path(os.environ.get("AZAZEL_TRIAGE_SESSION_FALLBACK_DIR", "/tmp/azazel-edge/triage-sessions"))
 
 
 class TriageSessionStore:
     def __init__(self, base_dir: str | Path | None = None):
-        self.base_dir = Path(base_dir) if base_dir else TRIAGE_SESSION_DIR
-        self.base_dir.mkdir(parents=True, exist_ok=True)
+        preferred_dir = Path(base_dir) if base_dir else TRIAGE_SESSION_DIR
+        try:
+            preferred_dir.mkdir(parents=True, exist_ok=True)
+            self.base_dir = preferred_dir
+        except OSError:
+            TRIAGE_SESSION_FALLBACK_DIR.mkdir(parents=True, exist_ok=True)
+            self.base_dir = TRIAGE_SESSION_FALLBACK_DIR
 
     def _path_for(self, session_id: str) -> Path:
         return self.base_dir / f"{session_id}.json"

--- a/py/azazel_edge_ai/agent.py
+++ b/py/azazel_edge_ai/agent.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import grp
 import queue
 import socket
 import subprocess
@@ -44,6 +45,9 @@ except Exception:  # pragma: no cover
     review_runbook_id = None
 
 SOCKET_PATH = Path(os.environ.get("AZAZEL_AI_SOCKET", "/run/azazel-edge/ai-bridge.sock"))
+RUNTIME_DIR_MODE = int(str(os.environ.get("AZAZEL_RUNTIME_DIR_MODE", "0770")), 8)
+SOCKET_MODE = int(str(os.environ.get("AZAZEL_AI_SOCKET_MODE", "0660")), 8)
+RUNTIME_SOCKET_GROUP = str(os.environ.get("AZAZEL_RUNTIME_SOCKET_GROUP", ""))
 ADVISORY_PATH = Path(os.environ.get("AZAZEL_AI_ADVISORY", "/run/azazel-edge/ai_advisory.json"))
 EVENT_LOG_PATH = Path(os.environ.get("AZAZEL_AI_EVENT_LOG", "/var/log/azazel-edge/ai-events.jsonl"))
 SNAPSHOT_PATH = Path(os.environ.get("AZAZEL_UI_SNAPSHOT", "/run/azazel-edge/ui_snapshot.json"))
@@ -174,6 +178,22 @@ CORR_STATE: Dict[str, list[Dict[str, Any]]] = {}
 
 def _ensure_parent(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _prepare_runtime_socket_dir(path: Path) -> None:
+    target = path.parent
+    target.mkdir(parents=True, exist_ok=True)
+    if RUNTIME_SOCKET_GROUP:
+        try:
+            gid = grp.getgrnam(RUNTIME_SOCKET_GROUP).gr_gid
+            os.chown(str(target), -1, gid)
+        except KeyError:
+            logger.warning("Runtime socket group not found: %s", RUNTIME_SOCKET_GROUP)
+        except PermissionError:
+            logger.warning("Insufficient permissions to set runtime socket directory group")
+        except Exception as exc:
+            logger.warning("Failed to set runtime socket directory group: %s", exc)
+    os.chmod(str(target), RUNTIME_DIR_MODE)
 
 
 def _metrics_snapshot() -> Dict[str, Any]:
@@ -1636,7 +1656,7 @@ def _handle_client(conn: socket.socket) -> None:
 
 
 def _serve() -> None:
-    _ensure_parent(SOCKET_PATH)
+    _prepare_runtime_socket_dir(SOCKET_PATH)
     _ensure_parent(METRICS_PATH)
     _ensure_parent(POLICY_PATH)
     if SOCKET_PATH.exists():
@@ -1644,7 +1664,13 @@ def _serve() -> None:
 
     srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     srv.bind(str(SOCKET_PATH))
-    os.chmod(SOCKET_PATH, 0o666)
+    if RUNTIME_SOCKET_GROUP:
+        try:
+            gid = grp.getgrnam(RUNTIME_SOCKET_GROUP).gr_gid
+            os.chown(str(SOCKET_PATH), -1, gid)
+        except Exception:
+            pass
+    os.chmod(SOCKET_PATH, SOCKET_MODE)
     srv.listen(16)
     srv.settimeout(1.0)
     worker = threading.Thread(target=_llm_worker, daemon=True)

--- a/py/azazel_edge_control/daemon.py
+++ b/py/azazel_edge_control/daemon.py
@@ -8,6 +8,7 @@ import json
 import time
 import sys
 import os
+import grp
 import logging
 import ipaddress
 import re
@@ -55,6 +56,9 @@ logger = logging.getLogger('azazel-edge-daemon')
 MODE_MANAGER = ModeManager(logger=logger)
 
 SOCKET_PATH = Path('/run/azazel-edge/control.sock')
+RUNTIME_DIR_MODE = int(str(os.environ.get("AZAZEL_RUNTIME_DIR_MODE", "0770")), 8)
+SOCKET_MODE = int(str(os.environ.get("AZAZEL_CONTROL_SOCKET_MODE", "0660")), 8)
+RUNTIME_SOCKET_GROUP = str(os.environ.get("AZAZEL_RUNTIME_SOCKET_GROUP", ""))
 AI_ADVISORY_PATH = Path("/run/azazel-edge/ai_advisory.json")
 PORTAL_VIEWER_SERVICE = "azazel-edge-portal-viewer.service"
 PORTAL_VIEWER_ENV_CANDIDATES = portal_env_candidates()
@@ -1453,14 +1457,22 @@ def stream_ui_snapshots(conn: socket.socket, interval_sec: float = 1.0) -> None:
         time.sleep(interval)
 
 def ensure_socket_dir():
-    """Create /run/azazel if needed"""
+    """Create runtime socket directory with least-privilege permissions."""
     SOCKET_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if RUNTIME_SOCKET_GROUP:
+        try:
+            gid = grp.getgrnam(RUNTIME_SOCKET_GROUP).gr_gid
+            os.chown(str(SOCKET_PATH.parent), -1, gid)
+        except KeyError:
+            logger.warning(f"Runtime socket group not found: {RUNTIME_SOCKET_GROUP}")
+        except PermissionError:
+            logger.warning("Insufficient permissions to set runtime socket directory group")
+        except Exception as exc:
+            logger.warning(f"Failed to set runtime socket directory group: {exc}")
     # Remove old socket if exists
     if SOCKET_PATH.exists():
         SOCKET_PATH.unlink()
-    
-    # Set directory permissions so any user can access
-    os.chmod(str(SOCKET_PATH.parent), 0o777)
+    os.chmod(str(SOCKET_PATH.parent), RUNTIME_DIR_MODE)
 
 
 def create_listener_socket() -> socket.socket:
@@ -1468,8 +1480,13 @@ def create_listener_socket() -> socket.socket:
     ensure_socket_dir()
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.bind(str(SOCKET_PATH))
-    # Make socket world-readable/writable for other processes
-    os.chmod(str(SOCKET_PATH), 0o666)
+    if RUNTIME_SOCKET_GROUP:
+        try:
+            gid = grp.getgrnam(RUNTIME_SOCKET_GROUP).gr_gid
+            os.chown(str(SOCKET_PATH), -1, gid)
+        except Exception:
+            pass
+    os.chmod(str(SOCKET_PATH), SOCKET_MODE)
     sock.listen(16)
     sock.settimeout(1.0)
     logger.info(f"Listening on {SOCKET_PATH}")

--- a/systemd/azazel-edge-ai-agent.service
+++ b/systemd/azazel-edge-ai-agent.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/default/azazel-edge-security
 Environment="AZAZEL_LLM_MODEL_PRIMARY=qwen3.5:2b"
 Environment="AZAZEL_LLM_MODEL_DEGRADED=qwen3.5:0.8b"
 Environment="AZAZEL_OPS_MODEL=qwen3.5:2b"

--- a/systemd/azazel-edge-control-daemon.service
+++ b/systemd/azazel-edge-control-daemon.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/default/azazel-edge-security
 ExecStart=/usr/local/bin/azazel-edge-control-daemon
 Restart=always
 RestartSec=3

--- a/systemd/azazel-edge-core.service
+++ b/systemd/azazel-edge-core.service
@@ -5,6 +5,7 @@ Wants=azazel-edge-ai-agent.service
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/default/azazel-edge-security
 Environment="AZAZEL_EVE_PATH=/var/log/suricata/eve.json"
 Environment="AZAZEL_AI_SOCKET=/run/azazel-edge/ai-bridge.sock"
 Environment="AZAZEL_NORMALIZED_EVENT_LOG=/var/log/azazel-edge/normalized-events.jsonl"

--- a/tests/test_api_auth_contract.py
+++ b/tests/test_api_auth_contract.py
@@ -14,16 +14,19 @@ class ApiAuthContractTests(unittest.TestCase):
         self.token_path.write_text("secret-token", encoding="utf-8")
         self._orig = {
             "TOKEN_FILE": webapp.TOKEN_FILE,
+            "AUTH_FAIL_OPEN": webapp.AUTH_FAIL_OPEN,
             "runbook_list": webapp.runbook_list,
             "send_control_command_with_params": webapp.send_control_command_with_params,
         }
         webapp.TOKEN_FILE = self.token_path
+        webapp.AUTH_FAIL_OPEN = False
         webapp.runbook_list = lambda lang=None: []  # type: ignore[assignment]
         webapp.send_control_command_with_params = lambda action, params: {"ok": True}  # type: ignore[assignment]
         self.client = webapp.app.test_client()
 
     def tearDown(self) -> None:
         webapp.TOKEN_FILE = self._orig["TOKEN_FILE"]
+        webapp.AUTH_FAIL_OPEN = self._orig["AUTH_FAIL_OPEN"]
         webapp.runbook_list = self._orig["runbook_list"]
         webapp.send_control_command_with_params = self._orig["send_control_command_with_params"]
         self.tmp.cleanup()
@@ -43,7 +46,18 @@ class ApiAuthContractTests(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.get_json(), {"ok": False, "error": "Unauthorized"})
 
+    def test_missing_token_file_is_fail_closed_by_default(self) -> None:
+        self.token_path.unlink()
+        response = self.client.get("/api/state")
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.get_json(), {"error": "Unauthorized"})
+
+    def test_missing_token_file_can_be_fail_open_when_explicitly_enabled(self) -> None:
+        self.token_path.unlink()
+        webapp.AUTH_FAIL_OPEN = True
+        response = self.client.get("/api/state")
+        self.assertEqual(response.status_code, 200)
+
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -28,6 +28,7 @@ class DashboardDataContractTests(unittest.TestCase):
             "TRIAGE_AUDIT_FALLBACK_LOG": webapp.TRIAGE_AUDIT_FALLBACK_LOG,
             "cp_read_snapshot_payload": webapp.cp_read_snapshot_payload,
             "load_token": webapp.load_token,
+            "AUTH_FAIL_OPEN": webapp.AUTH_FAIL_OPEN,
             "get_monitoring_state": webapp.get_monitoring_state,
             "get_mode_state": webapp.get_mode_state,
             "_mattermost_ping": webapp._mattermost_ping,
@@ -50,6 +51,7 @@ class DashboardDataContractTests(unittest.TestCase):
         webapp.TRIAGE_AUDIT_FALLBACK_LOG = root / "triage-audit-fallback.jsonl"
         webapp.cp_read_snapshot_payload = None
         webapp.load_token = lambda: None
+        webapp.AUTH_FAIL_OPEN = True
         webapp.get_monitoring_state = lambda: {
             "suricata": "ON",
             "opencanary": "OFF",
@@ -315,6 +317,7 @@ class DashboardDataContractTests(unittest.TestCase):
         webapp.TRIAGE_AUDIT_FALLBACK_LOG = self._orig["TRIAGE_AUDIT_FALLBACK_LOG"]
         webapp.cp_read_snapshot_payload = self._orig["cp_read_snapshot_payload"]
         webapp.load_token = self._orig["load_token"]
+        webapp.AUTH_FAIL_OPEN = self._orig["AUTH_FAIL_OPEN"]
         webapp.get_monitoring_state = self._orig["get_monitoring_state"]
         webapp.get_mode_state = self._orig["get_mode_state"]
         webapp._mattermost_ping = self._orig["_mattermost_ping"]

--- a/tests/test_demo_api_v1.py
+++ b/tests/test_demo_api_v1.py
@@ -16,6 +16,7 @@ class DemoApiV1Tests(unittest.TestCase):
         root = Path(self.tmp.name)
         self._orig = {
             "load_token": webapp.load_token,
+            "AUTH_FAIL_OPEN": webapp.AUTH_FAIL_OPEN,
             "_run_demo_runner": webapp._run_demo_runner,
             "STATE_PATH": webapp.STATE_PATH,
             "EPD_LAST_RENDER_PATH": webapp.EPD_LAST_RENDER_PATH,
@@ -26,6 +27,7 @@ class DemoApiV1Tests(unittest.TestCase):
             "_trigger_demo_clear_side_effects": webapp._trigger_demo_clear_side_effects,
         }
         webapp.load_token = lambda: None
+        webapp.AUTH_FAIL_OPEN = True
         webapp.STATE_PATH = root / "ui_snapshot.json"
         webapp.STATE_PATH.write_text(json.dumps({"ok": True}), encoding="utf-8")
         webapp.EPD_LAST_RENDER_PATH = root / "epd_last_render.json"
@@ -37,6 +39,7 @@ class DemoApiV1Tests(unittest.TestCase):
 
     def tearDown(self) -> None:
         webapp.load_token = self._orig["load_token"]
+        webapp.AUTH_FAIL_OPEN = self._orig["AUTH_FAIL_OPEN"]
         webapp._run_demo_runner = self._orig["_run_demo_runner"]
         webapp.STATE_PATH = self._orig["STATE_PATH"]
         webapp.EPD_LAST_RENDER_PATH = self._orig["EPD_LAST_RENDER_PATH"]

--- a/tests/test_ops_comm_demo_ui_v1.py
+++ b/tests/test_ops_comm_demo_ui_v1.py
@@ -8,11 +8,14 @@ import azazel_edge_web.app as webapp
 class OpsCommDemoUiV1Tests(unittest.TestCase):
     def setUp(self) -> None:
         self._orig_load_token = webapp.load_token
+        self._orig_auth_fail_open = webapp.AUTH_FAIL_OPEN
         webapp.load_token = lambda: None
+        webapp.AUTH_FAIL_OPEN = True
         self.client = webapp.app.test_client()
 
     def tearDown(self) -> None:
         webapp.load_token = self._orig_load_token
+        webapp.AUTH_FAIL_OPEN = self._orig_auth_fail_open
 
     def test_ops_comm_renders_demo_runner(self) -> None:
         response = self.client.get("/ops-comm?lang=en")

--- a/tests/test_triage_api_v1.py
+++ b/tests/test_triage_api_v1.py
@@ -13,12 +13,14 @@ class TriageApiV1Tests(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self._orig = {
             "load_token": webapp.load_token,
+            "AUTH_FAIL_OPEN": webapp.AUTH_FAIL_OPEN,
             "_TRIAGE_STORE": webapp._TRIAGE_STORE,
             "_TRIAGE_ENGINE": webapp._TRIAGE_ENGINE,
             "TRIAGE_AUDIT_LOG": webapp.TRIAGE_AUDIT_LOG,
             "TRIAGE_AUDIT_FALLBACK_LOG": webapp.TRIAGE_AUDIT_FALLBACK_LOG,
         }
         webapp.load_token = lambda: None
+        webapp.AUTH_FAIL_OPEN = True
         store = TriageSessionStore(base_dir=self.tmp.name)
         audit_path = webapp.Path(self.tmp.name) / "triage-audit.jsonl"
         webapp._TRIAGE_STORE = store
@@ -29,6 +31,7 @@ class TriageApiV1Tests(unittest.TestCase):
 
     def tearDown(self) -> None:
         webapp.load_token = self._orig["load_token"]
+        webapp.AUTH_FAIL_OPEN = self._orig["AUTH_FAIL_OPEN"]
         webapp._TRIAGE_STORE = self._orig["_TRIAGE_STORE"]
         webapp._TRIAGE_ENGINE = self._orig["_TRIAGE_ENGINE"]
         webapp.TRIAGE_AUDIT_LOG = self._orig["TRIAGE_AUDIT_LOG"]


### PR DESCRIPTION
## Summary
This PR completes the post-demo mainline hardening track across #104, #105, and #106.

### #104 Mainline integration boundary
- Added explicit permanent vs exhibition-only boundary document.
- Aligned installer/runtime sync with permanent demo asset deployment (`demo.html`).
- Linked the boundary doc from both README files.

### #105 Unix socket permission boundary
- Replaced world-writable socket assumptions with configurable least-privilege defaults.
- Added runtime permission env controls for directory/socket mode and optional socket group.
- Wired systemd services to consume `/etc/default/azazel-edge-security`.
- Added socket permission model document with caller matrix and validation checklist.

### #106 Web API auth contract and token provisioning
- Added `AZAZEL_WEB_TOKEN_FILE` support and fail-open/fail-closed control (`AZAZEL_AUTH_FAIL_OPEN`).
- Set code default to fail-closed, and installer-managed runtime defaults to fail-closed.
- Added installer token provisioning script to generate `/etc/azazel-edge/web_token.txt` when absent.
- Removed frontend fallback placeholder token behavior (headers now include token only when present).
- Updated auth contract tests and related suites to make compatibility intent explicit in test setup.

## Validation
- `bash -n installer/internal/install_migrated_tools.sh installer/internal/verify_runtime_sync.sh installer/internal/provision_web_token.sh`
- `python3 -m py_compile azazel_edge_web/app.py py/azazel_edge_ai/agent.py py/azazel_edge_control/daemon.py`
- `PYTHONPATH=py:. pytest -q` -> `217 passed`

## Notes
- Blackhat Arsenal demo branch/components remain out-of-scope for mainline operations as requested.

Closes #104
Closes #105
Closes #106
