### PR TITLE
fix(ops): prevent argparse percent-format crash in EPD help

### DIFF
--- a/py/azazel_edge_epd.py
+++ b/py/azazel_edge_epd.py
@@ -839,10 +839,10 @@ Examples:
                        help='Display state')
     parser.add_argument('--ssid', help='Wi-Fi SSID (for normal state)')
     parser.add_argument('--mode-label', default='SHIELD', help='Gateway mode label shown above SSID (for normal state)')
-    parser.add_argument('--signal', type=int, help='Wi-Fi signal strength in dBm (negative, e.g., -55) or 0-100%')
+    parser.add_argument('--signal', type=int, help='Wi-Fi signal strength in dBm (negative, e.g., -55) or 0-100%%')
     parser.add_argument('--uplink-type', default='unknown', help='Uplink type for icon selection: wifi, ethernet, other')
     parser.add_argument('--risk-status', default='SAFE', help='Risk status (for normal state): SAFE, CHECKING, LIMITED, CONTAINED')
-    parser.add_argument('--suspicion', type=int, default=0, help='Suspicion score (for normal state, 0-100)')
+    parser.add_argument('--suspicion', type=int, default=0, help='Suspicion score (for normal state, 0-100%%)')
     parser.add_argument('--msg', help='Message (for warning/danger/stale states)')
     parser.add_argument('--dry-run', action='store_true',
                        help='Generate preview only, do not update EPD')

--- a/tests/test_epd_cli_help_v1.py
+++ b/tests/test_epd_cli_help_v1.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+class EpdCliHelpV1Tests(unittest.TestCase):
+    def test_epd_cli_help_returns_zero(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        script = repo_root / "py" / "azazel_edge_epd.py"
+        result = subprocess.run(
+            [sys.executable, str(script), "--help"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Azazel EPD Controller", result.stdout)
+        self.assertIn("--signal", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix argparse help formatting crash in `py/azazel_edge_epd.py`
- Escape literal percent signs in option help text (`0-100%%`)
- Add regression test for `--help` exit path

## Root Cause
`argparse` expands help text using `%` formatting semantics. Unescaped `%` in help strings caused `ValueError: incomplete format` during `--help`.

## Validation
- `. .venv/bin/activate && python py/azazel_edge_epd.py --help`
- `. .venv/bin/activate && PYTHONPATH=py:. pytest -q tests/test_epd_cli_help_v1.py`
- `. .venv/bin/activate && PYTHONPATH=py:. pytest -q` -> `218 passed`

## AGENTS.md alignment
- Deterministic path unchanged
- No installer/systemd/security changes
- Single-purpose PR

Closes #152
