### PR TITLE
chore(ci): add baseline GitHub Actions for Python and Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "feature/**"
+      - "docs/**"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements/runtime.txt
+          pip install pytest
+
+      - name: Run tests
+        run: PYTHONPATH=py:. pytest -q
+
+  rust-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run cargo tests
+        working-directory: rust/azazel-edge-core
+        run: cargo test --locked


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml`
- Introduce baseline CI jobs:
  - Python: install runtime deps + `PYTHONPATH=py:. pytest -q`
  - Rust: `cargo test --locked` in `rust/azazel-edge-core`

## Why
Implements the P1 CI baseline so regression checks run automatically on push/PR.

## Validation
- Local Python test run: `PYTHONPATH=py:. pytest -q` -> `217 passed`
- Local Rust test run was not possible in this environment because `cargo` is not installed; CI rust job provides verification.

## AGENTS.md alignment
- Single-purpose PR (CI only)
- Deterministic runtime path unchanged
- No installer/systemd/security modifications

Closes #151
