### PR TITLE
docs(license): add MIT license and align README metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Azazel-Edge contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Latest verified result (2026-03-15): **183 passed in 3.57s**
   - `maybe_enforce()` in Rust core contains placeholder comment.
 - `python3 py/azazel_edge_epd.py --help` currently fails with `ValueError: incomplete format`.
 - CI workflow files are not present (`.github/workflows` not found in repository tree).
-- `LICENSE` file is not present at repository root.
+- `LICENSE` file is present at repository root (MIT).
 
 ## Known Issues (as of 2026-03-15)
 
@@ -356,4 +356,4 @@ Verified on 2026-03-15:
 
 ## License
 
-No top-level `LICENSE` file is present in this repository (status: unknown).
+This repository is licensed under the MIT License. See [LICENSE](LICENSE).

--- a/README_ja.md
+++ b/README_ja.md
@@ -327,7 +327,7 @@ PYTHONPATH=. .venv/bin/pytest -q
   - Rust の `maybe_enforce()` はフックのみ
 - `python3 py/azazel_edge_epd.py --help` は現時点で `ValueError: incomplete format` で失敗
 - CI workflow は未配置（`.github/workflows` が見つからない）
-- ルート `LICENSE` ファイルは未配置
+- ルート `LICENSE` ファイルを配置済み（MIT）
 
 ## 既知の問題（2026-03-15 時点）
 
@@ -357,4 +357,4 @@ GitHub の open issue 例:
 
 ## ライセンス
 
-このリポジトリのルートには `LICENSE` ファイルが存在しません（status: unknown）。
+このリポジトリは MIT License で公開されています。詳細は [LICENSE](LICENSE) を参照してください。


### PR DESCRIPTION
## Summary
- Add top-level `LICENSE` (MIT)
- Update `README.md` and `README_ja.md` license metadata to match repository state

## Why
Implements issue #159 and removes legal metadata ambiguity for contributors and downstream users.

## Validation
- `. .venv/bin/activate && PYTHONPATH=py:. pytest -q` -> `217 passed`

Closes #159
