### PR TITLE
feat: expand correlation engine for distributed and sequence patterns

### DIFF
--- a/py/azazel_edge/correlation/advanced.py
+++ b/py/azazel_edge/correlation/advanced.py
@@ -51,11 +51,13 @@ class AdvancedCorrelator:
         payloads = _to_payloads(events)
         pair_groups: DefaultDict[Tuple[str, str, int], List[Dict[str, Any]]] = defaultdict(list)
         ip_groups: DefaultDict[str, List[Dict[str, Any]]] = defaultdict(list)
+        target_groups: DefaultDict[str, List[Dict[str, Any]]] = defaultdict(list)
 
         for payload in payloads:
             src, dst, port = self._extract_endpoints(payload)
             if src and dst:
                 pair_groups[(src, dst, port)].append(payload)
+                target_groups[dst].append(payload)
             for ip in {src, dst} - {''}:
                 ip_groups[ip].append(payload)
 
@@ -66,6 +68,10 @@ class AdvancedCorrelator:
                 clusters.append(cluster)
         for ip, group in ip_groups.items():
             cluster = self._build_ip_cluster(ip, group)
+            if cluster:
+                clusters.append(cluster)
+        for dst, group in target_groups.items():
+            cluster = self._build_target_cluster(dst, group)
             if cluster:
                 clusters.append(cluster)
 
@@ -135,6 +141,9 @@ class AdvancedCorrelator:
         if self._within_window(group, 300):
             score += 4
             reasons.append('time_proximity')
+        seq_bonus, seq_reasons = self._sequence_bonus(group)
+        score += seq_bonus
+        reasons.extend(seq_reasons)
         return {
             'correlation_id': f'pair:{src}:{dst}:{port}',
             'scope': 'pair',
@@ -161,6 +170,9 @@ class AdvancedCorrelator:
         if 'syslog_min' in sources:
             score += 4
             reasons.append('syslog_same_ip')
+        seq_bonus, seq_reasons = self._sequence_bonus(group)
+        score += seq_bonus
+        reasons.extend(seq_reasons)
         return {
             'correlation_id': f'ip:{ip}',
             'scope': 'ip',
@@ -171,6 +183,72 @@ class AdvancedCorrelator:
             'reasons': reasons,
             'evidence_ids': sorted(dict.fromkeys(str(item.get('event_id') or '') for item in group if str(item.get('event_id') or ''))),
         }
+
+    def _build_target_cluster(self, dst: str, group: List[Dict[str, Any]]) -> Dict[str, Any] | None:
+        sources = {str(item.get('source') or '') for item in group if str(item.get('source') or '')}
+        src_ips: Set[str] = set()
+        for item in group:
+            attrs = item.get('attrs', {}) if isinstance(item.get('attrs'), dict) else {}
+            src = str(attrs.get('src_ip') or '')
+            if not src:
+                src, _subj_dst, _port = _parse_subject(str(item.get('subject') or ''))
+            if src:
+                src_ips.add(src)
+        if len(src_ips) < 3 or len(sources) < 2:
+            return None
+
+        score = 30 + (len(src_ips) * 8) + (len(sources) * 4)
+        reasons: List[str] = ['multi_source_single_target']
+        if self._within_window(group, 300):
+            score += 8
+            reasons.append('distributed_scan_window')
+        if 'suricata_eve' in sources and 'flow_min' in sources:
+            score += 10
+            reasons.append('suricata_flow_target_alignment')
+        if 'syslog_min' in sources:
+            score += 6
+            reasons.append('syslog_target_support')
+        seq_bonus, seq_reasons = self._sequence_bonus(group)
+        score += seq_bonus
+        reasons.extend(seq_reasons)
+        return {
+            'correlation_id': f'target:{dst}',
+            'scope': 'target',
+            'subject': dst,
+            'score': min(100, score),
+            'sources': sorted(sources),
+            'src_ip_count': len(src_ips),
+            'src_ips': sorted(src_ips)[:16],
+            'kinds': sorted({str(item.get('kind') or '') for item in group if str(item.get('kind') or '')}),
+            'reasons': reasons,
+            'evidence_ids': sorted(dict.fromkeys(str(item.get('event_id') or '') for item in group if str(item.get('event_id') or ''))),
+        }
+
+    @staticmethod
+    def _sequence_bonus(group: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
+        stage_rank = {'observe': 1, 'notify': 2, 'throttle': 3, 'redirect': 3, 'isolate': 4}
+        rows = sorted(group, key=lambda item: _parse_ts(str(item.get('ts') or '')))
+        stages: List[str] = []
+        for item in rows:
+            attrs = item.get('attrs', {}) if isinstance(item.get('attrs'), dict) else {}
+            raw = str(
+                attrs.get('recommended_action')
+                or attrs.get('action')
+                or item.get('action')
+                or ''
+            ).strip().lower()
+            if raw in stage_rank:
+                if not stages or stages[-1] != raw:
+                    stages.append(raw)
+        if len(stages) < 2:
+            return 0, []
+        ranks = [stage_rank[s] for s in stages]
+        if ranks == sorted(ranks) and len(set(ranks)) >= 3 and {'observe', 'notify'}.issubset(set(stages)):
+            if 'throttle' in stages or 'redirect' in stages:
+                return 15, ['sequence_escalation']
+        if ranks == sorted(ranks) and len(set(ranks)) >= 2:
+            return 6, ['sequence_progression']
+        return 0, []
 
     @staticmethod
     def _within_window(group: List[Dict[str, Any]], seconds: int) -> bool:

--- a/tests/test_advanced_correlation_v1.py
+++ b/tests/test_advanced_correlation_v1.py
@@ -69,6 +69,36 @@ def _syslog() -> EvidenceEvent:
     )
 
 
+def _event(
+    *,
+    ts: str,
+    source: str,
+    kind: str,
+    subject: str,
+    src_ip: str,
+    dst_ip: str,
+    port: int,
+    action: str = "",
+) -> EvidenceEvent:
+    attrs = {
+        'src_ip': src_ip,
+        'dst_ip': dst_ip,
+        'dst_port': port,
+    }
+    if action:
+        attrs['recommended_action'] = action
+    return EvidenceEvent.build(
+        ts=ts,
+        source=source,
+        kind=kind,
+        subject=subject,
+        severity=65,
+        confidence=0.75,
+        attrs=attrs,
+        status='warn',
+    )
+
+
 class AdvancedCorrelationV1Tests(unittest.TestCase):
     def test_correlator_builds_multi_source_cluster(self) -> None:
         result = AdvancedCorrelator().correlate([_suricata(), _flow(), _syslog()])
@@ -100,6 +130,30 @@ class AdvancedCorrelationV1Tests(unittest.TestCase):
         )
         self.assertIn('correlation', explanation['why_chosen'])
         self.assertIn('Correlation', explanation['operator_wording'])
+
+    def test_correlator_detects_multi_source_single_target_pattern(self) -> None:
+        events = [
+            _event(ts='2026-03-10T00:00:00Z', source='suricata_eve', kind='alert', subject='10.0.0.5->192.168.40.10:22/TCP', src_ip='10.0.0.5', dst_ip='192.168.40.10', port=22),
+            _event(ts='2026-03-10T00:00:40Z', source='suricata_eve', kind='alert', subject='10.0.0.6->192.168.40.10:22/TCP', src_ip='10.0.0.6', dst_ip='192.168.40.10', port=22),
+            _event(ts='2026-03-10T00:01:10Z', source='flow_min', kind='flow_summary', subject='10.0.0.7->192.168.40.10:22/TCP', src_ip='10.0.0.7', dst_ip='192.168.40.10', port=22),
+            _event(ts='2026-03-10T00:01:30Z', source='syslog_min', kind='syslog_line', subject='10.0.0.8->192.168.40.10:22/TCP', src_ip='10.0.0.8', dst_ip='192.168.40.10', port=22),
+        ]
+        result = AdvancedCorrelator().correlate(events)
+        target_clusters = [c for c in result['clusters'] if c.get('scope') == 'target' and c.get('subject') == '192.168.40.10']
+        self.assertTrue(target_clusters)
+        self.assertIn('multi_source_single_target', target_clusters[0]['reasons'])
+        self.assertGreaterEqual(int(target_clusters[0].get('src_ip_count') or 0), 3)
+
+    def test_correlator_adds_sequence_escalation_reason(self) -> None:
+        events = [
+            _event(ts='2026-03-10T00:00:00Z', source='suricata_eve', kind='alert', subject='10.0.0.5->192.168.40.10:443/TCP', src_ip='10.0.0.5', dst_ip='192.168.40.10', port=443, action='observe'),
+            _event(ts='2026-03-10T00:00:20Z', source='flow_min', kind='flow_summary', subject='10.0.0.5->192.168.40.10:443/TCP', src_ip='10.0.0.5', dst_ip='192.168.40.10', port=443, action='notify'),
+            _event(ts='2026-03-10T00:00:50Z', source='syslog_min', kind='syslog_line', subject='10.0.0.5->192.168.40.10:443/TCP', src_ip='10.0.0.5', dst_ip='192.168.40.10', port=443, action='throttle'),
+        ]
+        result = AdvancedCorrelator().correlate(events)
+        pair = [c for c in result['clusters'] if c.get('scope') == 'pair'][0]
+        self.assertIn('sequence_escalation', pair['reasons'])
+        self.assertGreaterEqual(int(pair.get('score') or 0), 50)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- expand `AdvancedCorrelator` with distributed pattern detection (`multi_source_single_target`)
- add target-scoped correlation cluster output with distinct source-ip count and reason trail
- add sequence-aware scoring bonus for escalating decision paths (`observe -> notify -> throttle`)
- apply sequence bonus to pair/ip/target cluster scoring while keeping deterministic scoring rules
- add regression tests for distributed target detection and sequence escalation scoring

## Test
- `PYTHONPATH=. .venv/bin/pytest -q tests/test_advanced_correlation_v1.py tests/test_soc_evaluator_v1.py`
- `PYTHONPATH=. .venv/bin/pytest -q`
  - `226 passed, 16 subtests passed`

## Related issues
Closes #154
