### PR TITLE
feat: add webhook/smtp notification fallback with ack audit

### DIFF
--- a/py/azazel_edge/notify/__init__.py
+++ b/py/azazel_edge/notify/__init__.py
@@ -1,3 +1,17 @@
-from .delivery import DecisionNotifier, MattermostNotifier, NtfyNotifier, NotificationError
+from .delivery import (
+    DecisionNotifier,
+    MattermostNotifier,
+    NtfyNotifier,
+    NotificationError,
+    SmtpNotifier,
+    WebhookNotifier,
+)
 
-__all__ = ['DecisionNotifier', 'MattermostNotifier', 'NtfyNotifier', 'NotificationError']
+__all__ = [
+    'DecisionNotifier',
+    'MattermostNotifier',
+    'NtfyNotifier',
+    'WebhookNotifier',
+    'SmtpNotifier',
+    'NotificationError',
+]

--- a/py/azazel_edge/notify/delivery.py
+++ b/py/azazel_edge/notify/delivery.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import smtplib
 from typing import Any, Dict, List
 from urllib.request import Request, urlopen
+from email.message import EmailMessage
 
 from azazel_edge.audit import P0AuditLogger
 
@@ -59,6 +61,60 @@ class MattermostNotifier:
         return {'ok': True, 'adapter': 'mattermost', 'status': status}
 
 
+class WebhookNotifier:
+    def __init__(self, webhook_url: str):
+        self.webhook_url = str(webhook_url or '').strip()
+
+    def send(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.webhook_url:
+            raise NotificationError('webhook_send_failed:missing_url')
+        req = Request(
+            self.webhook_url,
+            data=json.dumps(payload).encode('utf-8'),
+            headers={'Content-Type': 'application/json'},
+            method='POST',
+        )
+        try:
+            with urlopen(req, timeout=5) as resp:
+                status = getattr(resp, 'status', 200)
+        except Exception as exc:
+            raise NotificationError(f'webhook_send_failed:{exc}') from exc
+        if status >= 400:
+            raise NotificationError(f'webhook_send_failed_status:{status}')
+        return {'ok': True, 'adapter': 'webhook', 'status': status}
+
+
+class SmtpNotifier:
+    def __init__(self, host: str, port: int, sender: str, recipient: str, *, timeout: float = 5.0):
+        self.host = str(host or '').strip()
+        self.port = int(port)
+        self.sender = str(sender or '').strip()
+        self.recipient = str(recipient or '').strip()
+        self.timeout = float(timeout)
+
+    def send(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.host or not self.sender or not self.recipient:
+            raise NotificationError('smtp_send_failed:missing_config')
+        msg = EmailMessage()
+        msg['From'] = self.sender
+        msg['To'] = self.recipient
+        msg['Subject'] = f"[Azazel-Edge] {payload.get('level', 'info').upper()} {payload.get('action', '-')}"
+        msg.set_content(
+            f"target={payload.get('target')}\n"
+            f"reason={payload.get('reason')}\n"
+            f"evidence={','.join(payload.get('evidence_ids', []))}\n"
+            f"incident_id={payload.get('incident_id')}\n"
+            f"runbook_candidate_id={payload.get('runbook_candidate_id')}\n"
+            f"operator_wording={payload.get('operator_wording')}\n"
+        )
+        try:
+            with smtplib.SMTP(self.host, self.port, timeout=self.timeout) as client:
+                client.send_message(msg)
+        except Exception as exc:
+            raise NotificationError(f'smtp_send_failed:{exc}') from exc
+        return {'ok': True, 'adapter': 'smtp', 'status': 250}
+
+
 class DecisionNotifier:
     def __init__(self, notifiers: List[Any], audit_logger: P0AuditLogger):
         self.notifiers = list(notifiers)
@@ -83,15 +139,39 @@ class DecisionNotifier:
         }
 
         errors: List[str] = []
+        attempts: List[Dict[str, Any]] = []
         for notifier in self.notifiers:
+            adapter = self._adapter_name(notifier)
             try:
                 result = notifier.send(payload)
-                audit_result = {'ok': True, 'adapter': result.get('adapter'), 'payload': payload}
+                ack = result.get('status')
+                attempts.append({'adapter': adapter, 'ok': True, 'ack': ack})
+                audit_result = {
+                    'ok': True,
+                    'adapter': result.get('adapter') or adapter,
+                    'ack': ack,
+                    'attempts': attempts,
+                    'payload': payload,
+                }
                 self.audit.log('notification', trace_id=target, source='decision_notifier', decision='sent', payload=audit_result)
                 return audit_result
             except Exception as exc:
                 errors.append(str(exc))
+                attempts.append({'adapter': adapter, 'ok': False, 'error': str(exc)})
 
-        failed = {'ok': False, 'errors': errors, 'payload': payload}
+        failed = {'ok': False, 'errors': errors, 'attempts': attempts, 'payload': payload}
         self.audit.log('notification', trace_id=target, source='decision_notifier', decision='failed', payload=failed)
         return failed
+
+    @staticmethod
+    def _adapter_name(notifier: Any) -> str:
+        name = notifier.__class__.__name__.lower()
+        if 'mattermost' in name:
+            return 'mattermost'
+        if 'ntfy' in name:
+            return 'ntfy'
+        if 'webhook' in name:
+            return 'webhook'
+        if 'smtp' in name:
+            return 'smtp'
+        return name

--- a/tests/test_notification_v1.py
+++ b/tests/test_notification_v1.py
@@ -13,7 +13,7 @@ if str(PY_ROOT) not in sys.path:
     sys.path.insert(0, str(PY_ROOT))
 
 from azazel_edge.audit import P0AuditLogger
-from azazel_edge.notify import DecisionNotifier, NtfyNotifier
+from azazel_edge.notify import DecisionNotifier, MattermostNotifier, NtfyNotifier, SmtpNotifier, WebhookNotifier
 
 
 class _DummyResponse:
@@ -67,6 +67,67 @@ class NotificationV1Tests(unittest.TestCase):
             )
         self.assertFalse(result['ok'])
         self.assertTrue(result['errors'])
+
+    def test_notifier_uses_failover_order_and_records_attempt_ack(self) -> None:
+        calls = []
+
+        def _fake_urlopen(req, timeout=5):
+            url = str(getattr(req, 'full_url', ''))
+            calls.append(url)
+            if 'mattermost.invalid' in url:
+                raise RuntimeError('mattermost down')
+            return _DummyResponse(202)
+
+        with tempfile.TemporaryDirectory() as tmp, patch('azazel_edge.notify.delivery.urlopen', side_effect=_fake_urlopen):
+            logger = P0AuditLogger(Path(tmp) / 'audit.jsonl')
+            notifier = DecisionNotifier(
+                [
+                    MattermostNotifier('http://mattermost.invalid/hook'),
+                    NtfyNotifier('http://127.0.0.1:8081', 'azazel-alerts'),
+                    WebhookNotifier('http://webhook.invalid/endpoint'),
+                ],
+                logger,
+            )
+            result = notifier.notify(
+                arbiter={'action': 'notify', 'reason': 'soc_high_but_noc_fragile', 'chosen_evidence_ids': ['ev-1']},
+                explanation={'operator_wording': 'Notify operator now.'},
+                target='edge-uplink',
+            )
+            rows = [json.loads(line) for line in (Path(tmp) / 'audit.jsonl').read_text(encoding='utf-8').splitlines()]
+
+        self.assertTrue(result['ok'])
+        self.assertEqual(result['adapter'], 'ntfy')
+        self.assertEqual(result['ack'], 202)
+        self.assertEqual(result['attempts'][0]['adapter'], 'mattermost')
+        self.assertFalse(result['attempts'][0]['ok'])
+        self.assertEqual(result['attempts'][1]['adapter'], 'ntfy')
+        self.assertTrue(result['attempts'][1]['ok'])
+        self.assertEqual(rows[-1]['payload']['attempts'][1]['ack'], 202)
+        self.assertEqual(len(calls), 2)
+
+    def test_smtp_notifier_reports_ack(self) -> None:
+        class _FakeSMTP:
+            def __init__(self, host, port, timeout=5):
+                self.host = host
+                self.port = port
+                self.timeout = timeout
+                self.sent = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def send_message(self, msg):
+                self.sent = True
+
+        with patch('azazel_edge.notify.delivery.smtplib.SMTP', _FakeSMTP):
+            notifier = SmtpNotifier('127.0.0.1', 25, 'azazel@example.local', 'ops@example.local')
+            result = notifier.send({'action': 'notify', 'target': 'edge-uplink', 'reason': 'test', 'evidence_ids': [], 'level': 'warning'})
+        self.assertTrue(result['ok'])
+        self.assertEqual(result['adapter'], 'smtp')
+        self.assertEqual(result['status'], 250)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add generic `WebhookNotifier` adapter for notification fallback
- add `SmtpNotifier` adapter for notification fallback
- extend `DecisionNotifier` delivery audit payload with:
  - per-adapter attempts list
  - success/failure per attempt
  - delivery ack/status on success
- keep deterministic failover behavior via notifier order (mattermost -> ntfy -> fallback adapters)
- export new adapters from `azazel_edge.notify`
- add tests for failover sequence and ack audit trail

## Test
- `PYTHONPATH=. .venv/bin/pytest -q tests/test_notification_v1.py`
- `PYTHONPATH=. .venv/bin/pytest -q`
  - `229 passed, 16 subtests passed`

## Related issues
Closes #158
