### PR TITLE
[#173] Default NOC monitoring scope to internal network

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ Install result (default scripts):
 - AI agent: `AZAZEL_OLLAMA_ENDPOINT`, `AZAZEL_LLM_MODEL_PRIMARY`, `AZAZEL_LLM_MODEL_DEGRADED`
 - Mattermost command trigger/token: `AZAZEL_MATTERMOST_COMMAND_TRIGGER`, `AZAZEL_MATTERMOST_COMMAND_TOKEN_FILE`
 - Runbook controlled execution gate: `AZAZEL_RUNBOOK_ENABLE_CONTROLLED_EXEC`
+- Topo-Lite/NOC monitor scope:
+  - `AZAZEL_NOC_MONITOR_SCOPE` (`internal` default, or `external`)
+  - `AZAZEL_INTERNAL_BRIDGE_IF` (`br0` default)
+  - `AZAZEL_MANAGED_CLIENT_CIDRS` (`172.16.0.0/24` default)
+  - `AZAZEL_INTERNAL_MONITOR_TARGET` (`172.16.0.254` default)
+  - `AZAZEL_NOC_EXTRA_INTERFACES` (optional CSV for multi-segment probes)
 
 ### Token auth
 - API token can be supplied by header `X-AZAZEL-TOKEN` (or `X-Auth-Token`) or `?token=`.

--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -2196,6 +2196,7 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
     noc_blast_radius = state.get("noc_blast_radius") if isinstance(state.get("noc_blast_radius"), dict) else {}
     noc_config_drift = state.get("noc_config_drift") if isinstance(state.get("noc_config_drift"), dict) else {}
     noc_incident_summary = state.get("noc_incident_summary") if isinstance(state.get("noc_incident_summary"), dict) else {}
+    monitor_scope = state.get("monitor_scope") if isinstance(state.get("monitor_scope"), dict) else {}
     client_identity_view = _client_identity_view_payload(state)
     remote_peer_view = _remote_peer_view_payload(state)
     soc_attack_candidates = (
@@ -2280,6 +2281,12 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
                 "captive_portal": str(connection.get("captive_portal") or ""),
                 "internet_check": str(connection.get("internet_check") or ""),
                 "signals": network_health.get("signals") if isinstance(network_health.get("signals"), list) else [],
+                "monitor_scope": {
+                    "mode": str(monitor_scope.get("mode") or "internal"),
+                    "label": str(monitor_scope.get("label") or "internal:br0 (172.16.0.0/24)"),
+                    "interface": str(monitor_scope.get("up_if") or "br0"),
+                    "cidr": str(monitor_scope.get("cidr") or "172.16.0.0/24"),
+                },
             },
             "service_health": service_summary,
         },

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -1085,6 +1085,7 @@ function applyDemoOverlay(result) {
     updateElement('networkGateway', 'demo-target');
     updateElement('networkInternet', action === 'notify' ? 'CHECK' : 'CONTROL');
     updateElement('networkPortal', 'N/A');
+    updateElement('networkScope', 'demo:synthetic');
     updateElement('networkDnsMismatch', '0');
     updateElement('networkSignals', joinList(result.noc?.summary?.reasons || []));
     updateElement('socThreatLevel', String(socStatus || 'quiet').toUpperCase());
@@ -2032,6 +2033,7 @@ function updateSituationBoard(summary, state, health, mattermost) {
     updateElement('networkGateway', summary.gateway || '-');
     updateElement('networkInternet', summary.uplink?.internet_check || '-');
     updateElement('networkPortal', summary.situation_board?.network_health?.captive_portal || '-');
+    updateElement('networkScope', summary.situation_board?.network_health?.monitor_scope?.label || '-');
     updateElement('networkDnsMismatch', String(summary.situation_board?.network_health?.dns_mismatch ?? 0));
     updateElement('networkSignals', joinList(summary.situation_board?.network_health?.signals));
 

--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -341,6 +341,7 @@
                                 <div class="fact-item"><span>{{ tr('dashboard.gateway', 'Gateway') }}</span><strong id="networkGateway">-</strong></div>
                                 <div class="fact-item"><span>{{ tr('dashboard.internet', 'Internet') }}</span><strong id="networkInternet">-</strong></div>
                                 <div class="fact-item"><span>{{ tr('dashboard.captive_portal', 'Captive Portal') }}</span><strong id="networkPortal">-</strong></div>
+                                <div class="fact-item"><span>Monitoring Scope</span><strong id="networkScope">-</strong></div>
                                 <div class="fact-item pro-only"><span>{{ tr('dashboard.dns_mismatch', 'DNS Mismatch') }}</span><strong id="networkDnsMismatch">0</strong></div>
                                 <div class="fact-item pro-only"><span>{{ tr('dashboard.signals', 'Signals') }}</span><strong id="networkSignals">-</strong></div>
                             </div>

--- a/py/azazel_edge/evidence_plane/noc_probe.py
+++ b/py/azazel_edge/evidence_plane/noc_probe.py
@@ -69,7 +69,13 @@ def _window_severity(state: str) -> int:
 
 
 class NocProbeAdapter:
-    def __init__(self, up_interface: str = 'eth1', down_interface: str = 'usb0', gateway_ip: str = ''):
+    def __init__(
+        self,
+        up_interface: str = 'eth1',
+        down_interface: str = 'usb0',
+        gateway_ip: str = '',
+        extra_interfaces: Optional[List[str]] = None,
+    ):
         self.up_interface = up_interface
         self.down_interface = down_interface
         self.gateway_ip = gateway_ip
@@ -77,6 +83,7 @@ class NocProbeAdapter:
             up_interface=up_interface,
             down_interface=down_interface,
             gateway_ip=gateway_ip,
+            extra_interfaces=extra_interfaces,
         )
 
     def collect_snapshot(self) -> Dict[str, Any]:

--- a/py/azazel_edge_control/daemon.py
+++ b/py/azazel_edge_control/daemon.py
@@ -126,6 +126,43 @@ def _default_sot_payload() -> dict[str, Any]:
     }
 
 
+def _env_list(name: str) -> list[str]:
+    raw = str(os.environ.get(name, "")).strip()
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _resolve_monitor_scope(route: dict[str, Any], snapshot: dict[str, Any]) -> dict[str, str]:
+    scope_mode = str(os.environ.get("AZAZEL_NOC_MONITOR_SCOPE", "internal")).strip().lower()
+    if scope_mode not in {"internal", "external"}:
+        scope_mode = "internal"
+    internal_if = str(os.environ.get("AZAZEL_INTERNAL_BRIDGE_IF", "br0")).strip() or "br0"
+    internal_cidr = str(os.environ.get("AZAZEL_MANAGED_CLIENT_CIDRS", "172.16.0.0/24")).strip() or "172.16.0.0/24"
+    internal_target = str(os.environ.get("AZAZEL_INTERNAL_MONITOR_TARGET", "172.16.0.254")).strip() or "172.16.0.254"
+    external_if = str(route.get("up_if") or "eth1").strip() or "eth1"
+    down_if = str(snapshot.get("down_if") or os.environ.get("AZAZEL_NOC_DOWN_INTERFACE", "usb0")).strip() or "usb0"
+
+    if scope_mode == "internal":
+        return {
+            "mode": "internal",
+            "label": f"internal:{internal_if} ({internal_cidr})",
+            "up_if": internal_if,
+            "down_if": down_if,
+            "gateway_ip": internal_target,
+            "cidr": internal_cidr,
+        }
+
+    return {
+        "mode": "external",
+        "label": f"external:{external_if}",
+        "up_if": external_if,
+        "down_if": down_if,
+        "gateway_ip": str(route.get("gateway_ip") or "").strip(),
+        "cidr": "",
+    }
+
+
 def _sot_candidates() -> list[Path]:
     candidates: list[Path] = []
     env_path = str(os.environ.get("AZAZEL_SOT_PATH", "")).strip()
@@ -1068,6 +1105,7 @@ def _compute_live_noc_projection(up_if: str, down_if: str, gateway_ip: str) -> d
                 up_interface=str(up_if or "eth1"),
                 down_interface=str(down_if or "usb0"),
                 gateway_ip=str(gateway_ip or ""),
+                extra_interfaces=_env_list("AZAZEL_NOC_EXTRA_INTERFACES"),
             )
             _NOC_ADAPTER_KEY = key
 
@@ -1107,6 +1145,8 @@ def _enrich_snapshot(data: dict[str, Any]) -> dict[str, Any]:
     enriched["gateway_ip"] = gateway_ip
     enriched.setdefault("down_if", "usb0")
     enriched.setdefault("down_ip", "10.12.194.1")
+    monitor_scope = _resolve_monitor_scope(route, enriched)
+    enriched["monitor_scope"] = monitor_scope
     if uplink_type == "ethernet":
         enriched["ssid"] = f"ETH:{up_if}" if up_if != "-" else "ETH"
 
@@ -1157,9 +1197,9 @@ def _enrich_snapshot(data: dict[str, Any]) -> dict[str, Any]:
     )
     try:
         noc_projection = _compute_live_noc_projection(
-            up_if=up_if,
-            down_if=str(enriched.get("down_if") or "usb0"),
-            gateway_ip=gateway_ip,
+            up_if=str(monitor_scope.get("up_if") or up_if),
+            down_if=str(monitor_scope.get("down_if") or enriched.get("down_if") or "usb0"),
+            gateway_ip=str(monitor_scope.get("gateway_ip") or gateway_ip),
         )
         if isinstance(noc_projection, dict):
             enriched.update(noc_projection)

--- a/tests/test_noc_runtime_integration_v1.py
+++ b/tests/test_noc_runtime_integration_v1.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import unittest
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,6 +15,26 @@ from azazel_edge_control import daemon as control_daemon
 
 
 class NocRuntimeIntegrationV1Tests(unittest.TestCase):
+    def test_resolve_monitor_scope_defaults_to_internal(self) -> None:
+        with patch.dict(os.environ, {"AZAZEL_NOC_MONITOR_SCOPE": "internal"}, clear=False):
+            scope = control_daemon._resolve_monitor_scope(
+                {"up_if": "eth1", "gateway_ip": "192.168.40.1"},
+                {"down_if": "usb0"},
+            )
+        self.assertEqual(scope["mode"], "internal")
+        self.assertEqual(scope["up_if"], "br0")
+        self.assertEqual(scope["cidr"], "172.16.0.0/24")
+
+    def test_resolve_monitor_scope_supports_external_override(self) -> None:
+        with patch.dict(os.environ, {"AZAZEL_NOC_MONITOR_SCOPE": "external"}, clear=False):
+            scope = control_daemon._resolve_monitor_scope(
+                {"up_if": "eth1", "gateway_ip": "192.168.40.1"},
+                {"down_if": "usb0"},
+            )
+        self.assertEqual(scope["mode"], "external")
+        self.assertEqual(scope["up_if"], "eth1")
+        self.assertEqual(scope["gateway_ip"], "192.168.40.1")
+
     def test_build_noc_runtime_projection_maps_evaluation_into_dashboard_shape(self) -> None:
         evaluation = {
             "summary": {"status": "degraded", "degraded_mode": False, "reasons": ["capacity_health:degraded"]},
@@ -118,6 +139,8 @@ class NocRuntimeIntegrationV1Tests(unittest.TestCase):
         self.assertEqual(enriched["noc_capacity"]["state"], "elevated")
         self.assertEqual(enriched["noc_service_assurance"]["degraded_targets"], ["resolver-tcp"])
         self.assertEqual(enriched["noc_incident_summary"]["incident_id"], "incident:test")
+        self.assertEqual(enriched["monitor_scope"]["mode"], "internal")
+        self.assertIn("br0", enriched["monitor_scope"]["label"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Implements issue #173 by switching Topo-Lite/NOC runtime monitor scope defaults to internal network (`br0` / `172.16.0.0/24`) while preserving explicit runtime override for external scope.

## What changed
- Control daemon now resolves monitor scope from runtime policy:
  - default: `AZAZEL_NOC_MONITOR_SCOPE=internal`
  - internal defaults: `AZAZEL_INTERNAL_BRIDGE_IF=br0`, `AZAZEL_MANAGED_CLIENT_CIDRS=172.16.0.0/24`, `AZAZEL_INTERNAL_MONITOR_TARGET=172.16.0.254`
  - override: `AZAZEL_NOC_MONITOR_SCOPE=external`
- NOC adapter creation accepts optional `AZAZEL_NOC_EXTRA_INTERFACES` for multi-segment probing.
- Snapshot enrichment publishes `monitor_scope` in state.
- Dashboard summary API includes `situation_board.network_health.monitor_scope`.
- Web UI shows active monitoring scope in Network Health card.
- README documents the new scope-related runtime variables.
- Added tests for internal default + external override behavior.

## Validation
- `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_noc_runtime_integration_v1.py tests/test_dashboard_data_contract.py`
- `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_noc_monitor_v1.py tests/test_noc_monitor_v2.py tests/test_evidence_plane_v1.py`

## Risk
Low to medium: changes runtime monitoring target defaults. External-first operations can keep old behavior via env override.

## Rollback
Set `AZAZEL_NOC_MONITOR_SCOPE=external` (and restart `azazel-edge-control-daemon.service`) to restore external-uplink-first probing.

Closes #173
