### PR TITLE
[#172] Add Topo-Lite synthetic seed mode with strict evidence separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ Install result (default scripts):
   - `AZAZEL_MANAGED_CLIENT_CIDRS` (`172.16.0.0/24` default)
   - `AZAZEL_INTERNAL_MONITOR_TARGET` (`172.16.0.254` default)
   - `AZAZEL_NOC_EXTRA_INTERFACES` (optional CSV for multi-segment probes)
+- Topo-Lite synthetic seed mode:
+  - `AZAZEL_TOPOLITE_SEED_MODE_PATH` (mode state file, default `/run/azazel-edge/topolite_seed_mode.json`)
+  - API: `POST /api/topolite/seed-mode` with `mode=live|synthetic` and optional `seed_id`
 
 ### Token auth
 - API token can be supplied by header `X-AZAZEL-TOKEN` (or `X-Auth-Token`) or `?token=`.

--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -139,6 +139,7 @@ AI_LLM_LOG = Path(os.environ.get("AZAZEL_AI_LLM_LOG", "/var/log/azazel-edge/ai-l
 RUNBOOK_EVENT_LOG = Path(os.environ.get("AZAZEL_RUNBOOK_EVENT_LOG", "/var/log/azazel-edge/runbook-events.jsonl"))
 TRIAGE_AUDIT_LOG = Path(os.environ.get("AZAZEL_TRIAGE_AUDIT_PATH", "/var/log/azazel-edge/triage-audit.jsonl"))
 TRIAGE_AUDIT_FALLBACK_LOG = Path("/tmp/azazel-edge-triage-audit.jsonl")
+TOPOLITE_SEED_MODE_PATH = Path(os.environ.get("AZAZEL_TOPOLITE_SEED_MODE_PATH", "/run/azazel-edge/topolite_seed_mode.json"))
 SOT_AUDIT_LOG = Path(os.environ.get("AZAZEL_SOT_AUDIT_LOG", "/var/log/azazel-edge/sot-events.jsonl"))
 TRIAGE_SESSION_DIR = Path(os.environ.get("AZAZEL_TRIAGE_SESSION_DIR", "/run/azazel-edge/triage-sessions"))
 OPERATOR_PROGRESS_PATH = Path(os.environ.get("AZAZEL_OPERATOR_PROGRESS_PATH", "/run/azazel-edge/operator-progress.json"))
@@ -2031,6 +2032,12 @@ def _dashboard_noc_runbook_support(state: Dict[str, Any], lang: str) -> Dict[str
     noc_blast_radius = state.get("noc_blast_radius") if isinstance(state.get("noc_blast_radius"), dict) else {}
     noc_config_drift = state.get("noc_config_drift") if isinstance(state.get("noc_config_drift"), dict) else {}
     noc_incident_summary = state.get("noc_incident_summary") if isinstance(state.get("noc_incident_summary"), dict) else {}
+    topolite_mode = _read_topolite_seed_mode()
+    synthetic_story = (
+        _build_topolite_synthetic_story(str(topolite_mode.get("seed_id") or "topolite-default"))
+        if str(topolite_mode.get("mode") or "live") == "synthetic"
+        else {}
+    )
     return select_noc_runbook_support(
         {
             "summary": {
@@ -2128,6 +2135,64 @@ def _recent_mode_changes(mode_runtime: Dict[str, Any]) -> List[Dict[str, Any]]:
     ]
 
 
+def _read_topolite_seed_mode() -> Dict[str, Any]:
+    fallback = {"mode": "live", "seed_id": "topolite-default", "updated_at": time.time(), "updated_by": "system"}
+    try:
+        if TOPOLITE_SEED_MODE_PATH.exists():
+            data = json.loads(TOPOLITE_SEED_MODE_PATH.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                mode = str(data.get("mode") or "live").strip().lower()
+                if mode not in {"live", "synthetic"}:
+                    mode = "live"
+                return {
+                    "mode": mode,
+                    "seed_id": str(data.get("seed_id") or "topolite-default"),
+                    "updated_at": _as_float(data.get("updated_at"), time.time()),
+                    "updated_by": str(data.get("updated_by") or "unknown"),
+                }
+    except Exception:
+        pass
+    return fallback
+
+
+def _write_topolite_seed_mode(mode: str, seed_id: str, updated_by: str) -> Dict[str, Any]:
+    payload = {
+        "mode": "synthetic" if str(mode).lower() == "synthetic" else "live",
+        "seed_id": str(seed_id or "topolite-default"),
+        "updated_at": time.time(),
+        "updated_by": str(updated_by or "unknown"),
+    }
+    TOPOLITE_SEED_MODE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    TOPOLITE_SEED_MODE_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return payload
+
+
+def _build_topolite_synthetic_story(seed_id: str) -> Dict[str, Any]:
+    digest = hashlib.sha256(str(seed_id).encode("utf-8")).hexdigest()
+    n1 = int(digest[0:2], 16)
+    n2 = int(digest[2:4], 16)
+    n3 = int(digest[4:6], 16)
+    base_latency = 40 + (n1 % 35)
+    drop_pct = 2 + (n2 % 8)
+    impacted = 1 + (n3 % 5)
+    topology = [
+        {"id": "gw-br0", "kind": "gateway", "label": "Azazel Gateway (br0)", "state": "watch"},
+        {"id": "dns-resolver", "kind": "service", "label": "Resolver", "state": "degraded"},
+        {"id": "client-segment-a", "kind": "segment", "label": f"Clients {impacted}", "state": "affected"},
+    ]
+    timeline = [
+        {"ts_iso": "synthetic", "title": "Gateway jitter observed", "detail": f"latency={base_latency}ms", "kind": "topolite_synthetic"},
+        {"ts_iso": "synthetic", "title": "Resolver instability", "detail": f"packet_loss={drop_pct}%", "kind": "topolite_synthetic"},
+        {"ts_iso": "synthetic", "title": "Segment impact estimated", "detail": f"affected_clients={impacted}", "kind": "topolite_synthetic"},
+    ]
+    return {
+        "seed_id": str(seed_id),
+        "topology": topology,
+        "timeline": timeline,
+        "story_id": f"seed:{seed_id}",
+    }
+
+
 def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], advisory: Dict[str, Any]) -> Dict[str, Any]:
     lang = _request_lang()
     monitoring = get_monitoring_state()
@@ -2197,6 +2262,12 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
     noc_config_drift = state.get("noc_config_drift") if isinstance(state.get("noc_config_drift"), dict) else {}
     noc_incident_summary = state.get("noc_incident_summary") if isinstance(state.get("noc_incident_summary"), dict) else {}
     monitor_scope = state.get("monitor_scope") if isinstance(state.get("monitor_scope"), dict) else {}
+    topolite_mode = _read_topolite_seed_mode()
+    synthetic_story = (
+        _build_topolite_synthetic_story(str(topolite_mode.get("seed_id") or "topolite-default"))
+        if str(topolite_mode.get("mode") or "live") == "synthetic"
+        else {}
+    )
     client_identity_view = _client_identity_view_payload(state)
     remote_peer_view = _remote_peer_view_payload(state)
     soc_attack_candidates = (
@@ -2245,6 +2316,13 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
             "internet_check": str(connection.get("internet_check") or ""),
         },
         "gateway": str(state.get("gateway_ip") or ""),
+        "topolite": {
+            "mode": str(topolite_mode.get("mode") or "live"),
+            "seed_id": str(topolite_mode.get("seed_id") or "topolite-default"),
+            "data_source": "synthetic" if str(topolite_mode.get("mode") or "live") == "synthetic" else "live",
+            "watermark": "SYNTHETIC DATA - NOT LIVE EVIDENCE" if str(topolite_mode.get("mode") or "live") == "synthetic" else "",
+            "story": synthetic_story if isinstance(synthetic_story, dict) else {},
+        },
         "service_health_summary": service_summary,
         "current_recommendation": str(state.get("recommendation") or advisory.get("recommendation") or ""),
         "normal_assurance": _normal_assurance_payload(
@@ -2912,10 +2990,26 @@ def _dashboard_evidence_payload(
     ai_activity = [_normalize_ai_activity(item) for item in llm_rows[-10:]]
     runbook_events = [_normalize_runbook_event(item) for item in runbook_rows[-10:]]
     triage_audit = [_normalize_triage_audit_event(item) for item in triage_rows[-10:]]
+    topolite_mode = _read_topolite_seed_mode()
+    is_synthetic = str(topolite_mode.get("mode") or "live") == "synthetic"
+    synthetic_story = _build_topolite_synthetic_story(str(topolite_mode.get("seed_id") or "topolite-default")) if is_synthetic else {}
     mode_runtime = get_mode_state()
     sections = _dashboard_evidence_sections(state, advisory, ai_activity, runbook_events, triage_audit, mode_runtime)
+    if is_synthetic and isinstance(synthetic_story.get("timeline"), list):
+        sections["current_triggers"] = [
+            {
+                "ts_iso": "synthetic",
+                "title": "Synthetic seed mode active",
+                "detail": f"seed_id={topolite_mode.get('seed_id')}",
+                "kind": "topolite_synthetic",
+            },
+            *[item for item in synthetic_story.get("timeline", []) if isinstance(item, dict)],
+        ][:6]
     return {
         "ok": True,
+        "data_source": "synthetic" if is_synthetic else "live",
+        "watermark": "SYNTHETIC DATA - NOT LIVE EVIDENCE" if is_synthetic else "",
+        "synthetic_story": synthetic_story if isinstance(synthetic_story, dict) else {},
         "recent_alerts": recent_alerts,
         "recent_ai_activity": ai_activity,
         "recent_runbook_events": runbook_events,
@@ -4908,6 +5002,38 @@ def api_demo_flow():
         cmd.append("--refresh-epd")
     payload, code = _run_demo_runner(*cmd)
     return jsonify(payload), code
+
+
+@app.route("/api/topolite/seed-mode", methods=["GET", "POST"])
+@require_token()
+def api_topolite_seed_mode():
+    if request.method == "GET":
+        payload = _read_topolite_seed_mode()
+        mode = str(payload.get("mode") or "live")
+        response = dict(payload)
+        if mode == "synthetic":
+            response["story"] = _build_topolite_synthetic_story(str(payload.get("seed_id") or "topolite-default"))
+            response["watermark"] = "SYNTHETIC DATA - NOT LIVE EVIDENCE"
+        else:
+            response["story"] = {}
+            response["watermark"] = ""
+        return jsonify({"ok": True, "topolite_seed_mode": response}), 200
+
+    body = request.get_json(silent=True) or {}
+    mode = str(body.get("mode") or "").strip().lower()
+    if mode not in {"live", "synthetic"}:
+        return jsonify({"ok": False, "error": "mode must be live or synthetic"}), 400
+    seed_id = str(body.get("seed_id") or "topolite-default").strip() or "topolite-default"
+    updated_by = str(body.get("updated_by") or request.remote_addr or "webui")
+    payload = _write_topolite_seed_mode(mode=mode, seed_id=seed_id, updated_by=updated_by)
+    response = dict(payload)
+    if mode == "synthetic":
+        response["story"] = _build_topolite_synthetic_story(seed_id)
+        response["watermark"] = "SYNTHETIC DATA - NOT LIVE EVIDENCE"
+    else:
+        response["story"] = {}
+        response["watermark"] = ""
+    return jsonify({"ok": True, "topolite_seed_mode": response}), 200
 
 
 @app.route("/api/dashboard/summary", methods=["GET"])

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -195,6 +195,22 @@ function updateDemoModeBanner(result) {
     }
 }
 
+function updateSyntheticModeBanner(summary, evidence) {
+    const banner = document.getElementById('syntheticModeBanner');
+    const text = document.getElementById('syntheticModeBannerText');
+    if (!banner || !text) return;
+    const mode = String(summary?.topolite?.mode || 'live').toLowerCase();
+    const isSynthetic = mode === 'synthetic' || String(evidence?.data_source || 'live') === 'synthetic';
+    banner.hidden = !isSynthetic;
+    if (isSynthetic) {
+        text.textContent = String(summary?.topolite?.watermark || evidence?.watermark || 'SYNTHETIC DATA - NOT LIVE EVIDENCE');
+    }
+    const toggle = document.getElementById('topoliteSyntheticToggleBtn');
+    if (toggle) {
+        toggle.textContent = isSynthetic ? 'Switch to Live' : 'Switch to Synthetic';
+    }
+}
+
 const shortcutQuestions = {
     wifi: tr('dashboard.question_wifi_trouble', 'How should I guide a user who cannot connect to Wi-Fi?'),
     reconnect: tr('dashboard.question_reconnect', 'How should I guide a user who cannot reconnect?'),
@@ -393,6 +409,7 @@ function bindStaticHandlers() {
     document.getElementById('modePortalBtn')?.addEventListener('click', () => switchMode('portal'));
     document.getElementById('modeShieldBtn')?.addEventListener('click', () => switchMode('shield'));
     document.getElementById('modeScapegoatBtn')?.addEventListener('click', () => switchMode('scapegoat'));
+    document.getElementById('topoliteSyntheticToggleBtn')?.addEventListener('click', toggleTopoliteSyntheticMode);
     document.getElementById('portalAssistBtn')?.addEventListener('click', openPortalViewer);
     document.getElementById('containBtn')?.addEventListener('click', () => executeAction('contain'));
     document.getElementById('releaseBtn')?.addEventListener('click', () => executeAction('release'));
@@ -565,6 +582,25 @@ function bindStaticHandlers() {
     });
 
     loadDemoScenarios();
+}
+
+async function toggleTopoliteSyntheticMode() {
+    const currentMode = String(latestSummary?.topolite?.mode || 'live').toLowerCase();
+    const nextMode = currentMode === 'synthetic' ? 'live' : 'synthetic';
+    try {
+        await fetchJson('/api/topolite/seed-mode', {
+            method: 'POST',
+            body: JSON.stringify({
+                mode: nextMode,
+                seed_id: String(latestSummary?.topolite?.seed_id || 'topolite-default'),
+                updated_by: 'dashboard',
+            }),
+        });
+        await refreshDashboard();
+        showToast(`Topo-Lite mode changed to ${nextMode.toUpperCase()}`, 'success');
+    } catch (error) {
+        showToast(`Topo-Lite mode change failed: ${error.message}`, 'error');
+    }
 }
 
 function buildOpsCommTriageUrl(intentId = '', question = '') {
@@ -779,6 +815,7 @@ async function refreshDashboard() {
     handoffUrl.searchParams.set('session_id', progressSessionId);
     const requests = [
         ['summary', '/api/dashboard/summary', true],
+        ['topoliteMode', '/api/topolite/seed-mode', false],
         ['actions', actionsUrl.pathname + actionsUrl.search, false],
         ['progress', progressUrl.pathname + progressUrl.search, false],
         ['handoff', handoffUrl.pathname + handoffUrl.search, false],
@@ -827,15 +864,26 @@ async function refreshDashboard() {
     const capabilities = resultMap.capabilities?.data || { mattermost_triggers: [] };
     const demoCapabilities = resultMap.demoCapabilities?.data || { boundary: {}, execution_mode: 'deterministic_replay' };
     const demoOverlay = resultMap.demoOverlay?.data?.overlay || {};
+    const topoliteMode = resultMap.topoliteMode?.data?.topolite_seed_mode || {};
 
     latestState = state || {};
     latestSummary = summary || {};
+    if (!latestSummary.topolite && topoliteMode && typeof topoliteMode === 'object') {
+        latestSummary.topolite = {
+            mode: topoliteMode.mode || 'live',
+            seed_id: topoliteMode.seed_id || 'topolite-default',
+            data_source: topoliteMode.mode === 'synthetic' ? 'synthetic' : 'live',
+            watermark: topoliteMode.watermark || '',
+            story: topoliteMode.story || {},
+        };
+    }
     latestMattermost = mattermost || {};
     currentProgress = progress || {};
     currentHandoff = handoff || {};
     demoOverlayResult = demoOverlay && demoOverlay.active ? demoOverlay : null;
     setDemoOverlayVisualState(!!demoOverlayResult);
     updateDemoModeBanner(demoOverlayResult);
+    updateSyntheticModeBanner(summary, resultMap.evidence?.data || {});
     if (!demoOverlayResult) {
         resetDemoOverlayPresentation();
     }
@@ -2481,6 +2529,13 @@ function updateEvidenceBoard(evidence, health) {
         metaRight: item.kind || '-',
         title: item.title || '-',
         detail: item.detail || '-',
+    }));
+    const syntheticTopology = Array.isArray(evidence.synthetic_story?.topology) ? evidence.synthetic_story.topology : [];
+    renderTimeline('topoliteSyntheticTopology', syntheticTopology, (item) => ({
+        metaLeft: evidence.data_source === 'synthetic' ? 'synthetic' : '-',
+        metaRight: item.kind || '-',
+        title: item.label || item.id || '-',
+        detail: `state=${item.state || '-'}`,
     }));
 
     const stale = health.stale_flags || {};

--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -57,6 +57,15 @@
             </div>
             <p class="panel-note" id="demoModeBannerText">{{ tr('dashboard.demo_banner_default', 'A demo overlay is active. Review replay output on the dedicated demo page, not on the operational dashboard.') }}</p>
         </section>
+        <section class="panel demo-mode-banner" id="syntheticModeBanner" hidden>
+            <div class="panel-heading">
+                <div>
+                    <div class="panel-kicker">Topo-Lite Synthetic Mode</div>
+                    <h2>Synthetic evidence is active</h2>
+                </div>
+            </div>
+            <p class="panel-note" id="syntheticModeBannerText">SYNTHETIC DATA - NOT LIVE EVIDENCE</p>
+        </section>
         <section class="onboarding-banner" id="beginnerOnboarding">
             <div class="onboarding-copy">
                 <div class="panel-kicker">{{ tr('dashboard.beginner_onboarding_kicker', 'Beginner Guide') }}</div>
@@ -889,12 +898,17 @@
                 </div>
                 <div class="panel-heading-actions">
                     <div class="panel-note" id="healthSummaryLine">-</div>
+                    <button type="button" class="context-ask-btn pro-only" id="topoliteSyntheticToggleBtn">Toggle Synthetic</button>
                     <button type="button" class="context-ask-btn pro-only" data-question="{{ tr('dashboard.question_evidence_timeline_summary', 'Summarize the current evidence and timeline, and explain what to verify in live telemetry.') }}">{{ tr('dashboard.ask_about_this', 'Ask about this') }}</button>
                 </div>
             </div>
             <details class="panel-fold-details" id="evidenceTimelineDetails">
                 <summary id="evidenceTimelineDetailsToggle">{{ tr('dashboard.evidence_timeline_details_show', 'Show evidence and history') }}</summary>
                 <div class="evidence-grid">
+                    <article class="evidence-card">
+                        <div class="card-kicker">Topo-Lite Topology (Synthetic)</div>
+                        <ul class="timeline-list" id="topoliteSyntheticTopology"></ul>
+                    </article>
                     <article class="evidence-card">
                                 <div class="card-kicker">{{ tr('dashboard.current_triggers', 'Current Triggers') }}</div>
                         <ul class="timeline-list" id="currentTriggersTimeline"></ul>

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -37,6 +37,7 @@ class DashboardDataContractTests(unittest.TestCase):
             "read_demo_overlay": webapp.read_demo_overlay,
             "send_control_command_with_params": webapp.send_control_command_with_params,
             "_mattermost_send_message": webapp._mattermost_send_message,
+            "TOPOLITE_SEED_MODE_PATH": webapp.TOPOLITE_SEED_MODE_PATH,
         }
 
         webapp.STATE_PATH = root / "ui_snapshot.json"
@@ -49,6 +50,7 @@ class DashboardDataContractTests(unittest.TestCase):
         webapp.RUNBOOK_EVENT_LOG = root / "runbook-events.jsonl"
         webapp.TRIAGE_AUDIT_LOG = root / "triage-audit.jsonl"
         webapp.TRIAGE_AUDIT_FALLBACK_LOG = root / "triage-audit-fallback.jsonl"
+        webapp.TOPOLITE_SEED_MODE_PATH = root / "topolite_seed_mode.json"
         webapp.cp_read_snapshot_payload = None
         webapp.load_token = lambda: None
         webapp.AUTH_FAIL_OPEN = True
@@ -327,6 +329,7 @@ class DashboardDataContractTests(unittest.TestCase):
         webapp.send_control_command_with_params = self._orig["send_control_command_with_params"]
         webapp.OPERATOR_PROGRESS_PATH = self._orig["OPERATOR_PROGRESS_PATH"]
         webapp._mattermost_send_message = self._orig["_mattermost_send_message"]
+        webapp.TOPOLITE_SEED_MODE_PATH = self._orig["TOPOLITE_SEED_MODE_PATH"]
         self.tmp.cleanup()
 
     def test_dashboard_summary_contract(self) -> None:
@@ -802,6 +805,45 @@ class DashboardDataContractTests(unittest.TestCase):
         self.assertEqual(payload["recent_ai_activity"][0]["runbook_id"], "rb.noc.dns.failure.check")
         self.assertEqual(payload["recent_runbook_events"][0]["action"], "preview")
         self.assertEqual(payload["recent_mode_changes"][0]["current_mode"], "shield")
+
+    def test_topolite_seed_mode_toggle_and_summary_reflection(self) -> None:
+        get_before = self.client.get("/api/topolite/seed-mode")
+        self.assertEqual(get_before.status_code, 200)
+        before_payload = get_before.get_json()
+        self.assertEqual(before_payload["topolite_seed_mode"]["mode"], "live")
+
+        update = self.client.post(
+            "/api/topolite/seed-mode",
+            json={"mode": "synthetic", "seed_id": "seed-alpha", "updated_by": "test"},
+        )
+        self.assertEqual(update.status_code, 200)
+        update_payload = update.get_json()
+        self.assertEqual(update_payload["topolite_seed_mode"]["mode"], "synthetic")
+        self.assertEqual(update_payload["topolite_seed_mode"]["seed_id"], "seed-alpha")
+        self.assertIn("story", update_payload["topolite_seed_mode"])
+
+        summary = self.client.get("/api/dashboard/summary")
+        self.assertEqual(summary.status_code, 200)
+        summary_payload = summary.get_json()
+        self.assertEqual(summary_payload["topolite"]["mode"], "synthetic")
+        self.assertEqual(summary_payload["topolite"]["data_source"], "synthetic")
+        self.assertTrue(summary_payload["topolite"]["watermark"])
+
+    def test_synthetic_mode_keeps_live_audit_sources_unchanged(self) -> None:
+        self.client.post(
+            "/api/topolite/seed-mode",
+            json={"mode": "synthetic", "seed_id": "seed-bravo", "updated_by": "test"},
+        )
+        evidence = self.client.get("/api/dashboard/evidence")
+        self.assertEqual(evidence.status_code, 200)
+        payload = evidence.get_json()
+        self.assertEqual(payload["data_source"], "synthetic")
+        self.assertTrue(payload["watermark"])
+        self.assertIn("synthetic_story", payload)
+
+        triage_rows = payload.get("recent_triage_audit") or []
+        if triage_rows:
+            self.assertTrue(all(str(item.get("source") or "") != "topolite_synthetic" for item in triage_rows))
         self.assertTrue(payload["current_triggers"])
         self.assertTrue(payload["decision_changes"])
         self.assertTrue(payload["operator_interactions"])


### PR DESCRIPTION
## Summary
Implements #172 by adding a deterministic Topo-Lite synthetic seed mode that is explicitly toggled and visibly watermarked, while keeping live evidence/audit stores separate.

## Changes
- Added Topo-Lite seed mode API:
  - `GET /api/topolite/seed-mode`
  - `POST /api/topolite/seed-mode` (`mode=live|synthetic`, optional `seed_id`)
- Added deterministic synthetic story builder (seeded topology + timeline correlation).
- Extended dashboard summary/evidence payloads with Topo-Lite source metadata:
  - `topolite.mode`, `topolite.data_source`, `topolite.watermark`, `topolite.story`
  - evidence `data_source`, `watermark`, `synthetic_story`
- Added persistent UI labeling:
  - synthetic mode banner
  - synthetic topology card
  - toggle button in evidence panel
- Kept live export/audit paths unchanged; synthetic output is response-layer only and not written into triage audit logs.
- Added tests for mode toggle, summary reflection, and separation guarantee.

## Validation
- `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_dashboard_data_contract.py`
- `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_noc_runtime_integration_v1.py tests/test_evidence_plane_v1.py`

## Risk
Low to medium. Changes are additive and scoped to dashboard/API presentation path with explicit mode toggle.

## Rollback
- Set mode back to live:
  - `POST /api/topolite/seed-mode {"mode":"live"}`
- Or revert this PR.

Closes #172
