### PR TITLE
security: expand disaster suricata rules and ATT&CK mapping

### DIFF
--- a/config/attack_mapping.yaml
+++ b/config/attack_mapping.yaml
@@ -20,3 +20,35 @@ rules:
     tactic: reconnaissance
     confidence: 70
     attack_type_contains: ["scan", "probe", "recon"]
+
+  - technique_id: T1566
+    technique_name: Phishing
+    tactic: initial-access
+    confidence: 75
+    sid: [9901201, 9901202, 9901203]
+    attack_type_contains: ["phish", "social-engineering", "fake"]
+    category_contains: ["social-engineering"]
+
+  - technique_id: T1557
+    technique_name: Adversary-in-the-Middle
+    tactic: credential-access
+    confidence: 80
+    sid: [9901211]
+    attack_type_contains: ["arp", "spoof", "mitm"]
+    category_contains: ["bad-unknown"]
+
+  - technique_id: T1046
+    technique_name: Network Service Discovery
+    tactic: discovery
+    confidence: 70
+    sid: [9901221, 9901222]
+    attack_type_contains: ["scan", "probe"]
+    category_contains: ["network-scan"]
+
+  - technique_id: T1048
+    technique_name: Exfiltration Over Alternative Protocol
+    tactic: exfiltration
+    confidence: 65
+    sid: [9901231, 9901232]
+    attack_type_contains: ["dns", "tunnel", "exfil"]
+    category_contains: ["policy-violation"]

--- a/security/suricata/azazel-lite.rules
+++ b/security/suricata/azazel-lite.rules
@@ -1,3 +1,32 @@
 alert tcp any any -> $HOME_NET 12222 (msg:"AZAZEL OPENCANARY SSH probe"; flags:S; flow:to_server; classtype:attempted-recon; sid:9901101; rev:1;)
 alert tcp any any -> $HOME_NET 18080 (msg:"AZAZEL OPENCANARY HTTP probe"; flags:S; flow:to_server; classtype:attempted-recon; sid:9901102; rev:1;)
 alert tcp any any -> $HOME_NET [12222,18080] (msg:"AZAZEL OPENCANARY repeated access"; flags:S; flow:to_server; threshold:type both, track by_src, count 8, seconds 60; classtype:attempted-recon; sid:9901103; rev:1;)
+
+# ============================================================
+# AZAZEL-EDGE DISASTER SHELTER THREAT RULES
+# SID range: 9901201-9901299
+# Context: Emergency shelter Wi-Fi, 100-person scale
+# Covers: disaster phishing, fake AP, ARP spoofing, port scan
+# ============================================================
+
+# --- Fake captive portal / phishing ---
+alert http any any -> $HOME_NET any (msg:"AZAZEL DISASTER phishing - fake government domain"; content:"gov."; http_host; nocase; content:"login"; http_uri; nocase; flow:to_client; classtype:social-engineering; sid:9901201; rev:1;)
+alert http any any -> $HOME_NET any (msg:"AZAZEL DISASTER phishing - fake MyNumber portal"; content:"mynumber"; http_host; nocase; flow:to_client; classtype:social-engineering; sid:9901202; rev:1;)
+alert http any any -> $HOME_NET any (msg:"AZAZEL DISASTER phishing - fake disaster relief site"; content:"saigai"; http_host; nocase; flow:to_client; classtype:social-engineering; sid:9901203; rev:1;)
+
+# --- ARP spoofing / gateway impersonation ---
+alert arp any any -> any any (msg:"AZAZEL ARP spoof - gateway impersonation detected"; arp.opcode:2; arp.spa:!$HOME_NET; classtype:bad-unknown; sid:9901211; rev:1;)
+
+# --- Rapid port scanning from internal ---
+alert tcp $HOME_NET any -> any any (msg:"AZAZEL SCAN internal host rapid port scan"; flags:S; threshold:type both, track by_src, count 30, seconds 10; classtype:network-scan; sid:9901221; rev:1;)
+alert tcp any any -> $HOME_NET any (msg:"AZAZEL SCAN external rapid port scan on shelter network"; flags:S; threshold:type both, track by_src, count 30, seconds 10; classtype:network-scan; sid:9901222; rev:1;)
+
+# --- DNS exfiltration / suspicious DNS tunnel ---
+alert dns any any -> any any (msg:"AZAZEL DNS exfil - unusually long DNS query"; dns.query; content:"."; dsize:>100; classtype:policy-violation; sid:9901231; rev:1;)
+alert dns any any -> any any (msg:"AZAZEL DNS tunnel - high-frequency DNS queries"; dns.query; threshold:type both, track by_src, count 50, seconds 10; classtype:policy-violation; sid:9901232; rev:1;)
+
+# --- Credential harvesting patterns ---
+alert http any any -> $HOME_NET any (msg:"AZAZEL CREDENTIAL harvest - password field in GET request"; content:"password="; http_uri; nocase; flow:to_server; classtype:policy-violation; sid:9901241; rev:1;)
+
+# --- C2 beacon patterns (disaster APT) ---
+alert http $HOME_NET any -> any any (msg:"AZAZEL C2 beacon - periodic small HTTP POST"; content:"POST"; http_method; dsize:<200; threshold:type both, track by_src, count 10, seconds 60; classtype:trojan-activity; sid:9901251; rev:1;)


### PR DESCRIPTION
## Summary
- expand `security/suricata/azazel-lite.rules` with disaster-context detections in SID range `9901201+`
- keep existing OpenCanary rules untouched (`9901101-9901103`)
- add ATT&CK mapping entries in `config/attack_mapping.yaml` for:
  - `T1566` (phishing)
  - `T1557` (adversary-in-the-middle)
  - `T1046` (network service discovery)
  - `T1048` (exfiltration over alternative protocol)

## Validation
- `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_attack_mapping_v1.py`
- `PYTHONPATH=py:. .venv/bin/pytest -q`

## Linked Issue
- Refs #202

## Notes
- Deterministic evaluation pipeline unchanged.
- No new Python dependencies added.
