### PR TITLE
feat(integration): disaster demos and shift handoff summary api

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -5757,6 +5757,82 @@ def api_dashboard_handoff():
     return jsonify({"ok": True, "handoff_brief_pack": pack}), 200
 
 
+@app.route("/api/handoff/summary", methods=["GET"])
+@require_token()
+def api_handoff_summary():
+    lang = _request_lang()
+    output_format = str(request.args.get("format") or "").strip().lower()
+    sot_payload, _target = _read_sot_payload()
+    rows = _tail_first_existing_jsonl([TRIAGE_AUDIT_LOG, TRIAGE_AUDIT_FALLBACK_LOG], limit=20)
+
+    user_state = str((sot_payload.get("risk") or {}).get("user_state") or sot_payload.get("user_state") or "").strip().upper()
+    if user_state in {"CRITICAL", "ALERT", "LIMITED", "DANGER"}:
+        posture = "attention"
+    elif user_state in {"WATCH", "ELEVATED", "SUSPECTED"}:
+        posture = "watch"
+    else:
+        posture = "normal"
+
+    primary_concern = str(sot_payload.get("recommendation") or "")
+    if not primary_concern:
+        for item in reversed(rows):
+            message = str(item.get("message") or item.get("detail") or item.get("title") or "").strip()
+            if message:
+                primary_concern = message
+                break
+    if not primary_concern:
+        primary_concern = (
+            "現在の主要懸念は記録されていません。"
+            if lang == "ja"
+            else "No primary concern is currently recorded."
+        )
+
+    actions_taken: List[str] = []
+    for item in reversed(rows):
+        action = str(item.get("action") or "")
+        decision = str(item.get("decision") or "")
+        if action:
+            actions_taken.append(action)
+        elif decision:
+            actions_taken.append(decision)
+        if len(actions_taken) >= 5:
+            break
+
+    latest_ai = _tail_jsonl(AI_LLM_LOG, limit=5)
+    do_now = ""
+    do_not_do = ""
+    if latest_ai:
+        candidate = latest_ai[-1]
+        response = candidate.get("response") if isinstance(candidate.get("response"), dict) else {}
+        do_now = str(response.get("answer") or response.get("user_message") or "").strip()
+        do_not_do = str(response.get("operator_note") or "").strip()
+
+    payload = {
+        "ok": True,
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "posture": posture,
+        "primary_concern": primary_concern,
+        "actions_taken": actions_taken,
+        "do_now": do_now,
+        "do_not_do": do_not_do,
+        "next_shift_notes": "",
+    }
+
+    if output_format == "print":
+        lines = [
+            "Azazel-Edge Shift Handoff Summary",
+            f"generated_at: {payload['generated_at']}",
+            f"posture: {payload['posture']}",
+            f"primary_concern: {payload['primary_concern']}",
+            f"actions_taken: {', '.join(payload['actions_taken']) if payload['actions_taken'] else '-'}",
+            f"do_now: {payload['do_now'] or '-'}",
+            f"do_not_do: {payload['do_not_do'] or '-'}",
+            "next_shift_notes:",
+        ]
+        return Response("\n".join(lines) + "\n", mimetype="text/plain")
+    return jsonify(payload), 200
+
+
 @app.route("/api/dashboard/evidence", methods=["GET"])
 @require_token()
 def api_dashboard_evidence():

--- a/py/azazel_edge/demo/scenarios.py
+++ b/py/azazel_edge/demo/scenarios.py
@@ -159,6 +159,78 @@ class DemoScenarioPack:
                     {'event_id': 'syslog-2', 'source': 'syslog_min', 'kind': 'syslog_line', 'subject': '10.0.0.5->192.168.40.10:22/TCP', 'severity': 60, 'confidence': 0.75, 'attrs': {'message': 'failed ssh auth burst', 'host': 'edge', 'tag': 'sshd'}},
                 ],
             },
+            'disaster_phishing_demo': {
+                'description': 'Disaster shelter phishing attack with fake government domain indicators.',
+                'demo': {
+                    'title': 'Disaster phishing triage',
+                    'summary': 'A fake relief/government portal pattern is detected and routed to bounded SOC response.',
+                    'attack_label': 'Disaster Phishing',
+                    'default_hold_sec': 8,
+                    'talk_track': 'The replay highlights social-engineering signals and keeps action bounded for operator review.',
+                    'decision_path': {
+                        'first_pass': {
+                            'headline': 'SOC SIGNAL: SOCIAL ENGINEERING',
+                            'detail': 'Suricata phishing indicators and DNS anomaly support align on the same source.',
+                        },
+                        'second_pass': {
+                            'headline': 'ATT&CK SUPPORT: T1566',
+                            'detail': 'Mapping and category support reinforce phishing triage confidence.',
+                        },
+                        'final_policy': {
+                            'headline': 'FINAL POLICY: REDIRECT OR NOTIFY',
+                            'detail': 'The deterministic path keeps response reversible and operator-auditable.',
+                        },
+                    },
+                },
+                'events': [
+                    {'event_id': 'soc-p1', 'source': 'suricata_eve', 'kind': 'alert', 'subject': '10.0.0.23->192.168.40.12:80/TCP', 'severity': 82, 'confidence': 0.88, 'attrs': {'sid': 9901201, 'attack_type': 'phishing/social-engineering', 'category': 'social-engineering', 'target_port': 80, 'risk_score': 82, 'confidence_raw': 88, 'src_ip': '10.0.0.23', 'dst_ip': '192.168.40.12'}},
+                    {'event_id': 'dns-p1', 'source': 'syslog_min', 'kind': 'dns_query', 'subject': 'gov-login.example', 'severity': 60, 'confidence': 0.70, 'attrs': {'query': 'gov-login.example', 'result': 'resolved'}},
+                    {'event_id': 'flow-p1', 'source': 'flow_min', 'kind': 'flow_summary', 'subject': '10.0.0.23->192.168.40.12:80/TCP', 'severity': 45, 'confidence': 0.65, 'attrs': {'src_ip': '10.0.0.23', 'dst_ip': '192.168.40.12', 'dst_port': 80, 'flow_state': 'suspicious', 'app_proto': 'http'}},
+                ],
+                'scoring': {
+                    'scenario_id': 'disaster_phishing_demo',
+                    'response_time_sec': None,
+                    'correct_action': None,
+                    'runbook_proposed': None,
+                    'drills_completed': 0,
+                },
+            },
+            'evacuation_network_demo': {
+                'description': 'Shelter entry network degradation with DHCP stress and ARP spoof indicators.',
+                'demo': {
+                    'title': 'Evacuation network stress drill',
+                    'summary': 'NOC degradation and ARP threat indicators are correlated before bounded control is selected.',
+                    'attack_label': 'ARP Spoof + DHCP Degradation',
+                    'default_hold_sec': 9,
+                    'talk_track': 'The replay demonstrates NOC/SOC split handling under evacuation-time network instability.',
+                    'decision_path': {
+                        'first_pass': {
+                            'headline': 'NOC HEALTH: DEGRADED',
+                            'detail': 'Path health and lease behavior degrade during high client churn.',
+                        },
+                        'second_pass': {
+                            'headline': 'SOC SIGNAL: ARP SPOOF',
+                            'detail': 'Gateway impersonation pattern increases suspicion on a specific source.',
+                        },
+                        'final_policy': {
+                            'headline': 'FINAL POLICY: THROTTLE THEN ISOLATE REVIEW',
+                            'detail': 'Deterministic response starts reversible and escalates only with sustained evidence.',
+                        },
+                    },
+                },
+                'events': [
+                    {'event_id': 'noc-e1', 'source': 'noc_probe', 'kind': 'service_health', 'subject': 'dhcp', 'severity': 75, 'confidence': 0.90, 'attrs': {'service': 'dhcp', 'state': 'degraded'}},
+                    {'event_id': 'soc-e1', 'source': 'suricata_eve', 'kind': 'alert', 'subject': 'arp-gateway', 'severity': 80, 'confidence': 0.86, 'attrs': {'sid': 9901211, 'attack_type': 'arp spoof', 'category': 'bad-unknown', 'target_port': 0, 'risk_score': 80, 'confidence_raw': 86, 'src_ip': '10.0.0.77', 'dst_ip': '192.168.40.1'}},
+                    {'event_id': 'noc-e2', 'source': 'noc_probe', 'kind': 'dhcp_leases', 'subject': 'lease-pool', 'severity': 68, 'confidence': 0.82, 'attrs': {'lease_failures': 15, 'pool_utilization': 95}},
+                ],
+                'scoring': {
+                    'scenario_id': 'evacuation_network_demo',
+                    'response_time_sec': None,
+                    'correct_action': None,
+                    'runbook_proposed': None,
+                    'drills_completed': 0,
+                },
+            },
         }
 
     def stage_order(self) -> List[str]:

--- a/tests/test_demo_runner_v1.py
+++ b/tests/test_demo_runner_v1.py
@@ -84,9 +84,9 @@ class DemoRunnerV1Tests(unittest.TestCase):
             )
             payload = json.loads(result.stdout)
             self.assertTrue(payload['ok'])
-            self.assertEqual(len(payload['scenarios']), 3)
+            self.assertGreaterEqual(len(payload['scenarios']), 3)
             overlay = json.loads(overlay_path.read_text(encoding='utf-8'))
-            self.assertEqual(overlay['scenario_id'], 'mixed_correlation_demo')
+            self.assertEqual(overlay['scenario_id'], payload['scenarios'][-1]['scenario_id'])
 
 
 if __name__ == '__main__':

--- a/tests/test_demo_scenario_pack_v1.py
+++ b/tests/test_demo_scenario_pack_v1.py
@@ -19,10 +19,23 @@ class DemoScenarioPackV1Tests(unittest.TestCase):
         self.assertIn('soc_redirect_demo', scenarios)
         self.assertIn('noc_degraded_demo', scenarios)
         self.assertIn('mixed_correlation_demo', scenarios)
+        self.assertIn('disaster_phishing_demo', scenarios)
+        self.assertIn('evacuation_network_demo', scenarios)
         items = pack.list_items()
         self.assertEqual(items[0]['scenario_id'], 'soc_redirect_demo')
         self.assertEqual(items[0]['title'], 'High-confidence SOC path')
         self.assertEqual(items[2]['attack_label'], 'SSH Brute Force')
+        for scenario_id in ('disaster_phishing_demo', 'evacuation_network_demo'):
+            self.assertIn('description', scenarios[scenario_id])
+            self.assertIn('demo', scenarios[scenario_id])
+            self.assertIn('events', scenarios[scenario_id])
+            self.assertIn('scoring', scenarios[scenario_id])
+            scoring = scenarios[scenario_id]['scoring']
+            self.assertIn('scenario_id', scoring)
+            self.assertIn('response_time_sec', scoring)
+            self.assertIn('correct_action', scoring)
+            self.assertIn('runbook_proposed', scoring)
+            self.assertIn('drills_completed', scoring)
 
     def test_runner_executes_pipeline(self) -> None:
         result = DemoScenarioRunner().run('mixed_correlation_demo')

--- a/tests/test_handoff_api_v1.py
+++ b/tests/test_handoff_api_v1.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+import azazel_edge_web.app as webapp
+
+
+class HandoffApiV1Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        now = time.time()
+
+        self._orig = {
+            "STATE_PATH": webapp.STATE_PATH,
+            "AI_LLM_LOG": webapp.AI_LLM_LOG,
+            "TRIAGE_AUDIT_LOG": webapp.TRIAGE_AUDIT_LOG,
+            "TRIAGE_AUDIT_FALLBACK_LOG": webapp.TRIAGE_AUDIT_FALLBACK_LOG,
+            "AUTH_FAIL_OPEN": webapp.AUTH_FAIL_OPEN,
+            "load_token": webapp.load_token,
+            "_sot_candidates": webapp._sot_candidates,
+        }
+
+        webapp.STATE_PATH = root / "ui_snapshot.json"
+        webapp.AI_LLM_LOG = root / "ai-llm.jsonl"
+        webapp.TRIAGE_AUDIT_LOG = root / "triage-audit.jsonl"
+        webapp.TRIAGE_AUDIT_FALLBACK_LOG = root / "triage-audit-fallback.jsonl"
+        webapp.AUTH_FAIL_OPEN = True
+        webapp.load_token = lambda: None
+
+        sot_path = root / "sot.json"
+        sot_path.write_text(
+            json.dumps(
+                {
+                    "user_state": "WATCH",
+                    "recommendation": "Check suspicious DNS behavior and verify path health.",
+                }
+            ),
+            encoding="utf-8",
+        )
+        webapp._sot_candidates = lambda: [sot_path]
+
+        webapp.TRIAGE_AUDIT_LOG.write_text(
+            "\n".join(
+                [
+                    json.dumps({"ts": now - 10, "action": "notify", "detail": "initial action"}),
+                    json.dumps({"ts": now - 8, "action": "throttle", "detail": "bounded control"}),
+                    json.dumps({"ts": now - 6, "action": "observe", "detail": "tracking"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        webapp.AI_LLM_LOG.write_text(
+            json.dumps(
+                {
+                    "ts": now - 1,
+                    "response": {
+                        "answer": "Confirm affected segment and preserve current mode.",
+                        "operator_note": "Do not restart network services without evidence refresh.",
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        self.client = webapp.app.test_client()
+
+    def tearDown(self) -> None:
+        webapp.STATE_PATH = self._orig["STATE_PATH"]
+        webapp.AI_LLM_LOG = self._orig["AI_LLM_LOG"]
+        webapp.TRIAGE_AUDIT_LOG = self._orig["TRIAGE_AUDIT_LOG"]
+        webapp.TRIAGE_AUDIT_FALLBACK_LOG = self._orig["TRIAGE_AUDIT_FALLBACK_LOG"]
+        webapp.AUTH_FAIL_OPEN = self._orig["AUTH_FAIL_OPEN"]
+        webapp.load_token = self._orig["load_token"]
+        webapp._sot_candidates = self._orig["_sot_candidates"]
+        self.tmp.cleanup()
+
+    def test_handoff_summary_returns_required_keys(self) -> None:
+        response = self.client.get("/api/handoff/summary")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["ok"])
+        for key in ("generated_at", "posture", "primary_concern", "actions_taken", "do_now", "do_not_do", "next_shift_notes"):
+            self.assertIn(key, payload)
+        self.assertEqual(payload["posture"], "watch")
+
+    def test_handoff_summary_lang_ja(self) -> None:
+        response = self.client.get("/api/handoff/summary?lang=ja")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["ok"])
+        self.assertIn("primary_concern", payload)
+
+    def test_handoff_summary_format_print_is_text(self) -> None:
+        response = self.client.get("/api/handoff/summary?format=print")
+        self.assertEqual(response.status_code, 200)
+        text = response.get_data(as_text=True)
+        self.assertIn("Azazel-Edge Shift Handoff Summary", text)
+        self.assertEqual(response.mimetype, "text/plain")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add disaster demo scenarios to `DemoScenarioPack`:
  - `disaster_phishing_demo`
  - `evacuation_network_demo`
- add required `scoring` contract blocks for new scenarios
- add `/api/handoff/summary` endpoint with:
  - JSON output (default)
  - print-friendly text output via `?format=print`
  - language selection support via request language handling
- update demo runner test expectation to support expanded scenario set

## Validation
- `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_demo_scenario_pack_v1.py tests/test_demo_runner_v1.py tests/test_handoff_api_v1.py`
- `PYTHONPATH=py:. .venv/bin/pytest -q`

## Linked Issues
- Refs #203
- Refs #204

## Notes
- Deterministic-first pipeline remains unchanged.
- No new external dependencies introduced.
