### PR TITLE
feat(integration): vector and wazuh agent installer integration

### DIFF
--- a/docs/RELEASE_VERIFICATION_GUIDE.md
+++ b/docs/RELEASE_VERIFICATION_GUIDE.md
@@ -32,3 +32,21 @@ Review both artifacts before promoting a release to field deployment.
 ## Scope note
 
 This project currently uses a practical baseline and is not claiming full SLSA or enterprise signing compliance.
+
+## Optional integration smoke checks
+
+When `ENABLE_VECTOR=1` is used during installation:
+
+```bash
+systemctl is-active azazel-edge-vector
+vector --version
+test -f /etc/azazel-edge/vector/vector.toml
+```
+
+When Wazuh Agent is installed via `installer/internal/install_wazuh_agent.sh`:
+
+```bash
+systemctl is-active wazuh-agent
+test -x /var/ossec/active-response/bin/azazel-block.sh
+grep -q "/etc/azazel-edge/vector" /var/ossec/etc/ossec.conf
+```

--- a/installer/internal/install_all.sh
+++ b/installer/internal/install_all.sh
@@ -8,6 +8,7 @@ ENABLE_APP_STACK="${ENABLE_APP_STACK:-1}"
 ENABLE_AI_RUNTIME="${ENABLE_AI_RUNTIME:-1}"
 ENABLE_DEV_REMOTE_ACCESS="${ENABLE_DEV_REMOTE_ACCESS:-0}"
 ENABLE_RUST_CORE="${ENABLE_RUST_CORE:-1}"
+ENABLE_VECTOR="${ENABLE_VECTOR:-0}"
 
 # MODE=open|close (used only when ENABLE_DEV_REMOTE_ACCESS=1)
 DEV_REMOTE_MODE="${DEV_REMOTE_MODE:-open}"
@@ -24,6 +25,7 @@ echo "ENABLE_APP_STACK=${ENABLE_APP_STACK}"
 echo "ENABLE_AI_RUNTIME=${ENABLE_AI_RUNTIME}"
 echo "ENABLE_DEV_REMOTE_ACCESS=${ENABLE_DEV_REMOTE_ACCESS}"
 echo "ENABLE_RUST_CORE=${ENABLE_RUST_CORE}"
+echo "ENABLE_VECTOR=${ENABLE_VECTOR}"
 echo "DEV_REMOTE_MODE=${DEV_REMOTE_MODE}"
 
 if [[ "${ENABLE_INTERNAL_NETWORK}" == "1" ]]; then
@@ -52,6 +54,13 @@ if [[ "${ENABLE_DEV_REMOTE_ACCESS}" == "1" ]]; then
   MODE="${DEV_REMOTE_MODE}" "${REPO_ROOT}/installer/internal/set_dev_remote_access.sh"
 else
   echo "[all/5] Skip dev remote access setup"
+fi
+
+if [[ "${ENABLE_VECTOR}" == "1" ]]; then
+  echo "[all/6] Install Vector log aggregator"
+  VECTOR_MODE="${VECTOR_MODE:-local}" "${REPO_ROOT}/installer/internal/install_vector.sh"
+else
+  echo "[all/6] Skip Vector (set ENABLE_VECTOR=1 to enable)"
 fi
 
 echo "Unified installation completed."

--- a/installer/internal/install_vector.sh
+++ b/installer/internal/install_vector.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# install_vector.sh - Install Vector log aggregator for Azazel-Edge
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root: sudo $0"; exit 1
+fi
+
+ARCH="$(uname -m)"
+if [[ "${ARCH}" != "aarch64" ]]; then
+  echo "[ERROR] Expected aarch64, got ${ARCH}. Vector install skipped."; exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VECTOR_MODE="${VECTOR_MODE:-local}"   # local | wazuh | aggregator
+WAZUH_MANAGER_HOST="${WAZUH_MANAGER_HOST:-}"
+ENABLE_SERVICES="${ENABLE_SERVICES:-1}"
+
+echo "[vector 1/5] Install Vector via official script"
+curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash -s -- --prefix /usr
+
+echo "[vector 2/5] Verify binary"
+vector --version || { echo "ERROR: vector not found after install"; exit 1; }
+
+echo "[vector 3/5] Install configuration"
+install -d /etc/azazel-edge/vector /var/log/azazel-edge/vector
+
+if [[ "${VECTOR_MODE}" == "wazuh" ]]; then
+  if [[ -z "${WAZUH_MANAGER_HOST}" ]]; then
+    echo "ERROR: WAZUH_MANAGER_HOST must be set for wazuh mode"; exit 1
+  fi
+  install -m 0644 "${REPO_ROOT}/security/vector/vector-wazuh.toml" /etc/azazel-edge/vector/vector.toml
+  printf "WAZUH_MANAGER_HOST=%s\n" "${WAZUH_MANAGER_HOST}" > /etc/default/azazel-edge-vector
+elif [[ "${VECTOR_MODE}" == "aggregator" ]]; then
+  install -m 0644 "${REPO_ROOT}/security/vector/vector-aggregator.toml" /etc/azazel-edge/vector/vector.toml
+  : > /etc/default/azazel-edge-vector
+else
+  install -m 0644 "${REPO_ROOT}/security/vector/vector-local.toml" /etc/azazel-edge/vector/vector.toml
+  : > /etc/default/azazel-edge-vector
+fi
+
+echo "[vector 4/5] Install systemd service"
+install -m 0644 "${REPO_ROOT}/systemd/azazel-edge-vector.service" /etc/systemd/system/azazel-edge-vector.service
+systemd-analyze verify /etc/systemd/system/azazel-edge-vector.service || true
+systemctl daemon-reload
+
+echo "[vector 5/5] Enable service"
+if [[ "${ENABLE_SERVICES}" == "1" ]]; then
+  systemctl enable --now azazel-edge-vector.service
+  systemctl is-active azazel-edge-vector.service && echo "[vector] Service started OK"
+fi
+
+echo "[vector] Install complete. Mode: ${VECTOR_MODE}"
+echo "  Config: /etc/azazel-edge/vector/vector.toml"
+echo "  Logs:   /var/log/azazel-edge/vector/"
+echo "  Toggle: VECTOR_MODE=wazuh WAZUH_MANAGER_HOST=<IP> sudo ${BASH_SOURCE[0]}"

--- a/installer/internal/install_wazuh_agent.sh
+++ b/installer/internal/install_wazuh_agent.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# install_wazuh_agent.sh - Install Wazuh Agent on Azazel-Edge (ARM64)
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root: sudo $0"; exit 1
+fi
+
+ARCH="$(uname -m)"
+if [[ "${ARCH}" != "aarch64" ]]; then
+  echo "[ERROR] Expected aarch64, got ${ARCH}"; exit 1
+fi
+
+WAZUH_MANAGER_HOST="${WAZUH_MANAGER_HOST:?'ERROR: Set WAZUH_MANAGER_HOST env var (Wazuh Manager IP)'}"
+WAZUH_MANAGER_PORT="${WAZUH_MANAGER_PORT:-1514}"
+WAZUH_AGENT_NAME="${WAZUH_AGENT_NAME:-azazel-edge-$(hostname -s)}"
+WAZUH_VERSION="${WAZUH_VERSION:-4.9.0}"
+ENABLE_SERVICES="${ENABLE_SERVICES:-1}"
+
+echo "[wazuh-agent 1/5] Add Wazuh APT repository (ARM64)"
+curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --dearmor -o /usr/share/keyrings/wazuh.gpg
+echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" > /etc/apt/sources.list.d/wazuh.list
+apt-get update
+
+echo "[wazuh-agent 2/5] Install wazuh-agent"
+WAZUH_MANAGER="${WAZUH_MANAGER_HOST}" \
+WAZUH_MANAGER_PORT="${WAZUH_MANAGER_PORT}" \
+WAZUH_AGENT_NAME="${WAZUH_AGENT_NAME}" \
+  apt-get install -y "wazuh-agent=${WAZUH_VERSION}-*"
+
+echo "[wazuh-agent 3/5] Configure FIM for Azazel-Edge critical paths"
+python3 - <<'PYEOF'
+import xml.etree.ElementTree as ET
+
+tree = ET.parse('/var/ossec/etc/ossec.conf')
+root = tree.getroot()
+syscheck = root.find('syscheck')
+if syscheck is None:
+    syscheck = ET.SubElement(root, 'syscheck')
+
+azazel_dirs = [
+    '/etc/azazel-edge',
+    '/opt/azazel-edge',
+    '/var/log/azazel-edge',
+    '/etc/suricata/rules',
+    '/etc/azazel-edge/vector',
+]
+existing = {d.text for d in syscheck.findall('directories')}
+for path in azazel_dirs:
+    if path not in existing:
+        el = ET.SubElement(syscheck, 'directories')
+        el.set('check_all', 'yes')
+        el.set('report_changes', 'yes')
+        el.set('realtime', 'yes')
+        el.text = path
+
+tree.write('/var/ossec/etc/ossec.conf', encoding='utf-8', xml_declaration=True)
+print('[wazuh-agent] FIM directories configured.')
+PYEOF
+
+echo "[wazuh-agent 4/5] Enable active response hook (iptables block)"
+cat > /var/ossec/active-response/bin/azazel-block.sh <<'AREOF'
+#!/usr/bin/env bash
+set -euo pipefail
+ACTION="${1:-add}"
+IP="${3:-}"
+[[ -z "${IP}" ]] && exit 0
+if [[ "${ACTION}" == "add" ]]; then
+  iptables -I FORWARD -s "${IP}" -j DROP
+  iptables -I INPUT -s "${IP}" -j DROP
+  logger -t azazel-wazuh "BLOCKED: ${IP}"
+elif [[ "${ACTION}" == "delete" ]]; then
+  iptables -D FORWARD -s "${IP}" -j DROP 2>/dev/null || true
+  iptables -D INPUT -s "${IP}" -j DROP 2>/dev/null || true
+  logger -t azazel-wazuh "UNBLOCKED: ${IP}"
+fi
+AREOF
+chmod 0750 /var/ossec/active-response/bin/azazel-block.sh
+chown root:wazuh /var/ossec/active-response/bin/azazel-block.sh
+
+echo "[wazuh-agent 5/5] Enable and start wazuh-agent"
+systemctl daemon-reload
+if [[ "${ENABLE_SERVICES}" == "1" ]]; then
+  systemctl enable --now wazuh-agent
+  systemctl is-active wazuh-agent && echo "[wazuh-agent] Service started OK"
+fi
+
+echo "[wazuh-agent] Install complete."
+echo "  Manager:    ${WAZUH_MANAGER_HOST}:${WAZUH_MANAGER_PORT}"
+echo "  Agent name: ${WAZUH_AGENT_NAME}"
+echo "  FIM paths:  /etc/azazel-edge, /opt/azazel-edge, /etc/suricata/rules"
+echo "  Active response: /var/ossec/active-response/bin/azazel-block.sh"
+echo ""
+echo "NEXT: Register agent on Wazuh Manager:"
+echo "  manager$ /var/ossec/bin/manage_agents -a  (or use Wazuh Dashboard)"

--- a/security/vector/vector-aggregator.toml
+++ b/security/vector/vector-aggregator.toml
@@ -1,0 +1,20 @@
+# Azazel-Edge Vector configuration - aggregator mode
+# Receives log lines from multiple nodes and archives locally.
+
+[sources.edge_udp]
+type = "socket"
+mode = "udp"
+address = "0.0.0.0:5514"
+
+[transforms.tag_node]
+type = "remap"
+inputs = ["edge_udp"]
+source = '''
+  .ingest = "azazel-aggregator"
+'''
+
+[sinks.aggregate_archive]
+type = "file"
+inputs = ["tag_node"]
+path = "/var/log/azazel-edge/vector/aggregate-%Y-%m-%d.jsonl"
+encoding.codec = "json"

--- a/security/vector/vector-local.toml
+++ b/security/vector/vector-local.toml
@@ -1,0 +1,47 @@
+# Azazel-Edge Vector configuration - local mode
+# Suricata EVE JSON -> local JSONL archive
+# ARM64/Raspberry Pi 5 native; no cloud dependencies
+# Install: curl --proto '=https' --tlsv1.2 -sSfL https://sh.vector.dev | bash
+
+[sources.suricata_eve]
+type = "file"
+include = ["/var/log/suricata/eve.json"]
+read_from = "end"
+ignore_older_secs = 86400
+
+[sources.opencanary_log]
+type = "file"
+include = ["/var/log/azazel-edge/opencanary/*.log"]
+read_from = "end"
+ignore_older_secs = 86400
+
+[transforms.parse_suricata]
+type = "remap"
+inputs = ["suricata_eve"]
+source = '''
+  .source_type = "suricata"
+  parsed, err = parse_json(.message)
+  if err == null {
+    . = merge(., parsed)
+  }
+  del(.message)
+'''
+
+[transforms.parse_opencanary]
+type = "remap"
+inputs = ["opencanary_log"]
+source = '''
+  .source_type = "opencanary"
+'''
+
+[sinks.local_suricata_archive]
+type = "file"
+inputs = ["parse_suricata"]
+path = "/var/log/azazel-edge/vector/suricata-%Y-%m-%d.jsonl"
+encoding.codec = "json"
+
+[sinks.local_opencanary_archive]
+type = "file"
+inputs = ["parse_opencanary"]
+path = "/var/log/azazel-edge/vector/opencanary-%Y-%m-%d.jsonl"
+encoding.codec = "json"

--- a/security/vector/vector-wazuh.toml
+++ b/security/vector/vector-wazuh.toml
@@ -1,0 +1,37 @@
+# Azazel-Edge Vector configuration - Wazuh forwarding mode
+# Suricata EVE + OpenCanary -> Wazuh Manager syslog input
+# Set WAZUH_MANAGER_HOST env var before enabling this mode
+
+[sources.suricata_eve]
+type = "file"
+include = ["/var/log/suricata/eve.json"]
+read_from = "end"
+ignore_older_secs = 86400
+
+[transforms.to_cef]
+type = "remap"
+inputs = ["suricata_eve"]
+source = '''
+  parsed, err = parse_json(.message)
+  if err == null {
+    sig_id = to_string(get!(parsed, ["alert", "signature_id"])) ?? "0"
+    sig    = get(parsed, ["alert", "signature"]) ?? "unknown"
+    sev    = to_string(get!(parsed, ["alert", "severity"])) ?? "3"
+    src_ip = get(parsed, ["src_ip"]) ?? "-"
+    dst_ip = get(parsed, ["dest_ip"]) ?? "-"
+    .message = "CEF:0|Azazel-Edge|Suricata|1.0|" + sig_id + "|" + to_string!(sig) + "|" + sev + "|src=" + to_string!(src_ip) + " dst=" + to_string!(dst_ip)
+  }
+'''
+
+[sinks.wazuh_syslog]
+type = "socket"
+inputs = ["to_cef"]
+address = "${WAZUH_MANAGER_HOST}:514"
+mode = "udp"
+encoding.codec = "text"
+
+[sinks.local_archive_wazuh_mode]
+type = "file"
+inputs = ["to_cef"]
+path = "/var/log/azazel-edge/vector/suricata-forwarded-%Y-%m-%d.jsonl"
+encoding.codec = "json"

--- a/systemd/azazel-edge-vector.service
+++ b/systemd/azazel-edge-vector.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Azazel-Edge Vector log aggregator
+Documentation=https://vector.dev
+After=network.target azazel-edge-suricata.service
+Wants=azazel-edge-suricata.service
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/default/azazel-edge-vector
+ExecStart=/usr/bin/vector --config /etc/azazel-edge/vector/vector.toml
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=azazel-vector
+MemoryMax=64M
+CPUQuota=10%
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add Vector integration assets:
  - `security/vector/vector-local.toml`
  - `security/vector/vector-wazuh.toml`
  - `security/vector/vector-aggregator.toml`
  - `installer/internal/install_vector.sh`
  - `systemd/azazel-edge-vector.service`
- update unified installer with opt-in `ENABLE_VECTOR` flow in `installer/internal/install_all.sh`
- add Wazuh Agent installer path:
  - `installer/internal/install_wazuh_agent.sh`
  - includes ARM64 guard, repository setup, FIM path append, and active response hook
- add optional integration smoke checks to `docs/RELEASE_VERIFICATION_GUIDE.md`

## Validation
- `bash -n installer/internal/install_vector.sh installer/internal/install_wazuh_agent.sh installer/internal/install_all.sh`
- `PYTHONPATH=py:. .venv/bin/pytest -q`

## Linked Issues
- Refs #200
- Refs #201

## Notes
- No cloud-only runtime dependency was introduced.
- Deterministic decision pipeline remains unchanged.
