### PR TITLE
feat(ops): periodic selftest timer and deployment docs suite

### DIFF
--- a/bin/azazel-edge-selftest
+++ b/bin/azazel-edge-selftest
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# azazel-edge-selftest - Periodic hardware and config health check
+set -euo pipefail
+
+LOG_DIR="/var/log/azazel-edge"
+OUT_JSON="${LOG_DIR}/selftest_latest.json"
+TMP_FILE="/tmp/azazel_sdtest"
+FAILURES=()
+WARNINGS=()
+
+mkdir -p "${LOG_DIR}"
+
+warn() {
+  WARNINGS+=("$1")
+}
+
+fail() {
+  FAILURES+=("$1")
+}
+
+check_sd_write_speed() {
+  local speed
+  if speed="$({ /usr/bin/time -f '%e' dd if=/dev/zero of="${TMP_FILE}" bs=1M count=10 oflag=direct status=none; } 2>&1)"; then
+    :
+  else
+    fail "sd_write_test_failed"
+    rm -f "${TMP_FILE}"
+    return
+  fi
+  rm -f "${TMP_FILE}"
+  local sec mbps
+  sec="${speed}"
+  if [[ "${sec}" == "0" || "${sec}" == "0.0" ]]; then
+    return
+  fi
+  mbps=$(awk -v s="${sec}" 'BEGIN { printf "%.2f", 10.0 / s }')
+  awk -v v="${mbps}" 'BEGIN { exit (v < 5.0 ? 0 : 1) }' && warn "sd_write_speed_low:${mbps}MBps"
+}
+
+check_mmc_errors() {
+  local c
+  c=$(dmesg | grep -c "mmc0.*error" || true)
+  if [[ "${c}" -gt 0 ]]; then
+    warn "mmc_error_count:${c}"
+  fi
+}
+
+check_log_growth_forecast() {
+  local used pct
+  used=$(du -sm "${LOG_DIR}" 2>/dev/null | awk '{print $1}')
+  used=${used:-0}
+  pct=$(df -P "${LOG_DIR}" | awk 'NR==2 {gsub("%","",$5); print $5}')
+  pct=${pct:-0}
+  # Simple 30-day forecast heuristic: if current usage already > 80%, warn
+  if [[ "${pct}" -ge 80 ]]; then
+    warn "disk_fill_forecast_high:${pct}%"
+  fi
+}
+
+check_config_integrity() {
+  if [[ -f /etc/azazel-edge/.config_checksums ]]; then
+    if ! sha256sum --check /etc/azazel-edge/.config_checksums >/dev/null 2>&1; then
+      fail "config_checksum_failed"
+    fi
+  else
+    warn "config_checksums_missing"
+  fi
+}
+
+check_service_health() {
+  local svc
+  for svc in azazel-edge-web azazel-edge-control-daemon azazel-edge-suricata azazel-edge-opencanary; do
+    if ! systemctl is-active --quiet "${svc}"; then
+      fail "service_inactive:${svc}"
+    fi
+  done
+}
+
+check_python_smoke() {
+  if [[ -x /opt/azazel-edge/venv/bin/pytest ]]; then
+    if ! PYTHONPATH=/opt/azazel-edge /opt/azazel-edge/venv/bin/pytest /opt/azazel-edge/tests/test_epd_cli_help_v1.py -q --tb=no >/dev/null 2>&1; then
+      fail "python_smoke_failed"
+    fi
+  else
+    warn "pytest_runtime_missing"
+  fi
+}
+
+emit_epd_warning_if_failed() {
+  if [[ ${#FAILURES[@]} -gt 0 ]]; then
+    local reason
+    reason="${FAILURES[0]}"
+    if command -v azazel-edge-epd >/dev/null 2>&1; then
+      azazel-edge-epd --state warning --msg "SELFTEST FAILED: ${reason}" --dry-run || true
+    fi
+  fi
+}
+
+write_json() {
+  local status
+  if [[ ${#FAILURES[@]} -gt 0 ]]; then
+    status="failed"
+  elif [[ ${#WARNINGS[@]} -gt 0 ]]; then
+    status="warning"
+  else
+    status="ok"
+  fi
+
+  {
+    echo "{"
+    echo "  \"generated_at\": \"$(date -Iseconds)\"," 
+    echo "  \"status\": \"${status}\"," 
+    echo "  \"failures\": ["
+    local i
+    for ((i=0; i<${#FAILURES[@]}; i++)); do
+      printf '    "%s"' "${FAILURES[$i]}"
+      [[ $i -lt $((${#FAILURES[@]}-1)) ]] && printf ','
+      echo
+    done
+    echo "  ],"
+    echo "  \"warnings\": ["
+    for ((i=0; i<${#WARNINGS[@]}; i++)); do
+      printf '    "%s"' "${WARNINGS[$i]}"
+      [[ $i -lt $((${#WARNINGS[@]}-1)) ]] && printf ','
+      echo
+    done
+    echo "  ]"
+    echo "}"
+  } > "${OUT_JSON}"
+}
+
+check_sd_write_speed
+check_mmc_errors
+check_log_growth_forecast
+check_config_integrity
+check_service_health
+check_python_smoke
+emit_epd_warning_if_failed
+write_json
+
+echo "selftest completed: ${OUT_JSON}"

--- a/docs/FIELD_DEPLOYMENT_GUIDE.md
+++ b/docs/FIELD_DEPLOYMENT_GUIDE.md
@@ -1,0 +1,14 @@
+# FIELD DEPLOYMENT GUIDE
+
+## Purpose
+Rapid deployment checklist for first responders.
+
+## Japanese Summary
+現場展開を短時間で実施するためのチェックリストです。
+
+## Stages
+- Pre-deployment: verify hardware and configs.
+- Transit: secure power and cables.
+- On-site setup: boot, network check, dashboard check.
+- Operation: monitor posture and reviewed runbooks.
+- Shutdown/recovery: capture logs and safe power-off.

--- a/docs/HUMANITARIAN_PARTNER_GUIDE.md
+++ b/docs/HUMANITARIAN_PARTNER_GUIDE.md
@@ -1,0 +1,13 @@
+# HUMANITARIAN PARTNER GUIDE
+
+## Purpose
+Onboarding for NGO and humanitarian operations partners.
+
+## Japanese Summary
+人道支援団体向けの導入概要と運用上の注意です。
+
+## Topics
+- Operational fit for shelter, clinic, and distribution networks.
+- Offline-first deployment model.
+- MIT license and contribution path.
+- Data handling disclosure requirement for monitored networks.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -37,6 +37,21 @@ Entry point for all documents in this directory.
 | [CHANGELOG.md](CHANGELOG.md) | Developer | PR and feature traceability history | - |
 | [RELEASE_VERIFICATION_GUIDE.md](RELEASE_VERIFICATION_GUIDE.md) | Developer / Operator | Checksum, SBOM, and release verification baseline | 2026-05-12 |
 
+## Operations and Deployment
+
+| File | Audience | Description | Last Updated |
+|------|----------|-------------|--------------|
+| [OPERATOR_GUIDE_JA.md](OPERATOR_GUIDE_JA.md) | Shelter staff / volunteers | 日本語運用マニュアル（非専門者向け） | 2026-05-13 |
+| [STATUS_CARD.md](STATUS_CARD.md) | Shelter wall / laminated | e-Paper status quick-reference card | 2026-05-13 |
+| [PHYSICAL_SETUP_GUIDE.md](PHYSICAL_SETUP_GUIDE.md) | Deployer | Hardware labeling and cable guide | 2026-05-13 |
+| [POWER_PLAYBOOK.md](POWER_PLAYBOOK.md) | Deployer | Power configuration and runtime estimates | 2026-05-13 |
+| [FIELD_DEPLOYMENT_GUIDE.md](FIELD_DEPLOYMENT_GUIDE.md) | First responder | Rapid deploy checklist | 2026-05-13 |
+| [VEHICLE_DEPLOYMENT_GUIDE.md](VEHICLE_DEPLOYMENT_GUIDE.md) | Military / Civil defense | Vehicle deployment guide for constrained environments | 2026-05-13 |
+| [WAZUH_INTEGRATION_GUIDE.md](WAZUH_INTEGRATION_GUIDE.md) | Developer / Integrator | Wazuh Agent and Vector integration guide | 2026-05-13 |
+| [HUMANITARIAN_PARTNER_GUIDE.md](HUMANITARIAN_PARTNER_GUIDE.md) | NGO / International org | Partner onboarding guide | 2026-05-13 |
+| [PRIVACY_AND_LEGAL.md](PRIVACY_AND_LEGAL.md) | Municipal officer / Legal | Data handling and legal basis memo | 2026-05-13 |
+| [MAINTENANCE_CHECKLIST.md](MAINTENANCE_CHECKLIST.md) | Operator / Asset manager | Scheduled maintenance procedures | 2026-05-13 |
+
 ---
 
 If `Last Updated` is `-`, check the target document metadata.

--- a/docs/MAINTENANCE_CHECKLIST.md
+++ b/docs/MAINTENANCE_CHECKLIST.md
@@ -1,0 +1,24 @@
+# MAINTENANCE CHECKLIST
+
+## Purpose
+Scheduled maintenance procedure checklist.
+
+## Japanese Summary
+年次・四半期・出動前の保守チェック項目です。
+
+## Annual
+- Full boot test
+- Demo scenario run
+- SD selftest
+- Battery discharge verification
+
+## Quarterly
+- Check service status
+- Check log rotation
+- Review Suricata ruleset currency
+
+## Per Deployment
+- Physical inspection
+- Cable verification
+- Connectivity test
+- Display verification

--- a/docs/OPERATOR_GUIDE_JA.md
+++ b/docs/OPERATOR_GUIDE_JA.md
@@ -1,0 +1,41 @@
+# OPERATOR GUIDE (JA)
+
+## Purpose
+Primary operator guide for non-expert shelter staff and volunteers.
+
+## Japanese Summary
+この文書は、避難所スタッフ向けの運用手順です。最初の15分で起動し、状態表示を見て、最小限の安全対応を実施できることを目的にします。
+
+## 1. Quick Start (15 minutes)
+1. Connect power, LAN, and display cables.
+2. Boot the device and wait for service start.
+3. Verify `systemctl is-active azazel-edge-web azazel-edge-control-daemon`.
+4. Open dashboard from local network browser.
+5. Confirm current posture and first action.
+
+## 2. e-Paper State and Action
+- GREEN: Continue monitoring and confirm periodic updates.
+- YELLOW: Run initial checks and keep current mode stable.
+- RED: Escalate to operator review and avoid destructive changes.
+
+## 3. FAQ (sample)
+- Q: Wi-Fiがつながらない
+  A: 1台か全体かを先に確認し、Runbook候補へ進む。
+- Q: 表示が赤になった
+  A: 現在の推奨を確認し、手順どおりに1つずつ実施する。
+- Q: 再起動方法
+  A: 記録を確認後、承認済み手順で実施する。
+
+## 4. Emergency Contact Sheet
+| Role | Name | Contact |
+|------|------|---------|
+| Shift lead | | |
+| Network support | | |
+| Escalation | | |
+
+## 5. Equipment Checklist
+- Raspberry Pi unit
+- SD card
+- Power adapter
+- LAN cable
+- e-Paper display

--- a/docs/PHYSICAL_SETUP_GUIDE.md
+++ b/docs/PHYSICAL_SETUP_GUIDE.md
@@ -1,0 +1,24 @@
+# PHYSICAL SETUP GUIDE
+
+## Purpose
+Hardware assembly and cable routing reference.
+
+## Japanese Summary
+配線、ラベル、設置前確認をまとめた物理設置ガイドです。
+
+## Cable Routing (ASCII)
+`[Power] -> [DC input]`
+`[WAN/LAN] -> [eth uplink]`
+`[Display] -> [EPD connector]`
+
+## Port Labels
+- `PWR`: main power
+- `ETH-UP`: upstream
+- `ETH-LAN`: local segment
+- `EPD`: display connector
+
+## Pre-deployment Checklist
+- Enclosure fixed
+- Cables secured
+- Boot test passed
+- Dashboard reachable

--- a/docs/POWER_PLAYBOOK.md
+++ b/docs/POWER_PLAYBOOK.md
@@ -1,0 +1,20 @@
+# POWER PLAYBOOK
+
+## Purpose
+Power selection and runtime estimate guide.
+
+## Japanese Summary
+電源構成ごとの運転時間目安と注意点をまとめます。
+
+| Configuration | Capacity | Runtime (13W load) | Runtime (full 90W load) |
+|---|---|---|---|
+| Pi only, 20Ah mobile battery | 72Wh usable | ~5.5h | ~0.8h |
+| 105D31R ×2 (24V, 72Ah) | 864Wh usable @50% DoD | ~66h | ~9.6h |
+| 105D31R ×2 + 100Ah sub ×2 | 2,664Wh | ~204h | ~29.6h |
+| 10kVA generator | unlimited | unlimited | unlimited |
+| 50W solar + 20Ah battery | self-sustaining >6h sun | indefinite | limited |
+
+## Notes
+- Use isolated DC-DC converter (5V/5A minimum).
+- Configure graceful shutdown trigger.
+- Verify battery health before deployment.

--- a/docs/PRIVACY_AND_LEGAL.md
+++ b/docs/PRIVACY_AND_LEGAL.md
@@ -1,0 +1,19 @@
+# PRIVACY AND LEGAL
+
+## Purpose
+Data handling and legal baseline memo.
+
+## Japanese Summary
+収集データ、保持、開示、法務上の基本方針を整理したメモです。
+
+## Data Scope
+- IP addresses
+- MAC addresses
+- Suricata alert metadata
+- No packet content in default mode
+
+## Retention
+- Default 7-day log rotation baseline
+
+## Notice
+- Informational only; not legal advice.

--- a/docs/STATUS_CARD.md
+++ b/docs/STATUS_CARD.md
@@ -1,0 +1,24 @@
+# STATUS CARD
+
+## Purpose
+Single-page quick reference for shelter wall posting.
+
+## Japanese Summary
+現場に掲示する1枚カードです。色ごとの次の行動を簡潔に示します。
+
+## GREEN / 緑
+- Baseline stable.
+- Keep monitoring.
+- Follow normal checklist.
+
+## YELLOW / 黄
+- Check freshness and queue.
+- Confirm affected scope.
+- Avoid uncontrolled restarts.
+
+## RED / 赤
+- Treat as active incident.
+- Follow reviewed runbook.
+- Escalate immediately.
+
+Emergency contact: ____________________

--- a/docs/VEHICLE_DEPLOYMENT_GUIDE.md
+++ b/docs/VEHICLE_DEPLOYMENT_GUIDE.md
@@ -1,0 +1,17 @@
+# VEHICLE DEPLOYMENT GUIDE
+
+## Purpose
+Deployment guide for constrained power and vibration environments.
+
+## Japanese Summary
+車載環境向けの電源、振動、温度、運用モード切替をまとめます。
+
+## Key Points
+- Use isolated 24V->5V/5A converter.
+- Secure mounting with anti-vibration hardware.
+- Apply transit-mode suppression for noisy reconnection periods.
+- Check thermal threshold and fan operation.
+
+## UC-A / UC-B Switch
+- UC-A (moving): prioritize stability and suppression profile.
+- UC-B (static): restore full monitoring profile.

--- a/docs/WAZUH_INTEGRATION_GUIDE.md
+++ b/docs/WAZUH_INTEGRATION_GUIDE.md
@@ -1,0 +1,22 @@
+# WAZUH INTEGRATION GUIDE
+
+## Purpose
+Guide for Wazuh Agent and Vector integration paths.
+
+## Japanese Summary
+Wazuh連携の2方式（Agent / Vector転送）と確認手順を示します。
+
+## Method A: Wazuh Agent
+- Install with `installer/internal/install_wazuh_agent.sh`.
+- Verify with `systemctl status wazuh-agent`.
+- Confirms FIM and active response integration.
+
+## Method B: Vector Forwarding
+- Install Vector and set `VECTOR_MODE=wazuh`.
+- Set `WAZUH_MANAGER_HOST`.
+- Verify forwarded logs in manager syslog input.
+
+## Verification
+- `systemctl is-active wazuh-agent`
+- `systemctl is-active azazel-edge-vector`
+- `vector --version`

--- a/docs/index.html
+++ b/docs/index.html
@@ -116,6 +116,31 @@
           </div>
         </div>
       </section>
+
+      <section class="section architecture">
+        <h2>Operations and Deployment Docs</h2>
+        <div class="architecture-grid">
+          <div class="architecture-card">
+            <h3>Operator Pack</h3>
+            <p><a href="OPERATOR_GUIDE_JA.md">OPERATOR_GUIDE_JA.md</a></p>
+            <p><a href="STATUS_CARD.md">STATUS_CARD.md</a></p>
+            <p><a href="FIELD_DEPLOYMENT_GUIDE.md">FIELD_DEPLOYMENT_GUIDE.md</a></p>
+          </div>
+          <div class="architecture-card">
+            <h3>Infrastructure Pack</h3>
+            <p><a href="PHYSICAL_SETUP_GUIDE.md">PHYSICAL_SETUP_GUIDE.md</a></p>
+            <p><a href="POWER_PLAYBOOK.md">POWER_PLAYBOOK.md</a></p>
+            <p><a href="VEHICLE_DEPLOYMENT_GUIDE.md">VEHICLE_DEPLOYMENT_GUIDE.md</a></p>
+          </div>
+          <div class="architecture-card">
+            <h3>Integration and Policy Pack</h3>
+            <p><a href="WAZUH_INTEGRATION_GUIDE.md">WAZUH_INTEGRATION_GUIDE.md</a></p>
+            <p><a href="HUMANITARIAN_PARTNER_GUIDE.md">HUMANITARIAN_PARTNER_GUIDE.md</a></p>
+            <p><a href="PRIVACY_AND_LEGAL.md">PRIVACY_AND_LEGAL.md</a></p>
+            <p><a href="MAINTENANCE_CHECKLIST.md">MAINTENANCE_CHECKLIST.md</a></p>
+          </div>
+        </div>
+      </section>
     </main>
 
     <footer class="footer">

--- a/installer/internal/install_selftest_timer.sh
+++ b/installer/internal/install_selftest_timer.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root: sudo $0"
+  exit 1
+fi
+
+ARCH="$(uname -m)"
+if [[ "${ARCH}" != "aarch64" ]]; then
+  echo "[ERROR] Expected aarch64, got ${ARCH}"; exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENABLE_SERVICES="${ENABLE_SERVICES:-1}"
+
+echo "[selftest 1/4] Install selftest binary"
+install -m 0755 "${REPO_ROOT}/bin/azazel-edge-selftest" /usr/local/bin/azazel-edge-selftest
+
+echo "[selftest 2/4] Install systemd units"
+install -m 0644 "${REPO_ROOT}/systemd/azazel-edge-selftest.service" /etc/systemd/system/azazel-edge-selftest.service
+install -m 0644 "${REPO_ROOT}/systemd/azazel-edge-selftest.timer" /etc/systemd/system/azazel-edge-selftest.timer
+systemctl daemon-reload
+
+echo "[selftest 3/4] Verify timer"
+systemd-analyze verify /etc/systemd/system/azazel-edge-selftest.timer || true
+
+echo "[selftest 4/4] Enable timer"
+if [[ "${ENABLE_SERVICES}" == "1" ]]; then
+  systemctl enable --now azazel-edge-selftest.timer
+  systemctl is-active azazel-edge-selftest.timer && echo "[selftest] timer started"
+fi
+
+echo "[selftest] install complete"

--- a/systemd/azazel-edge-selftest.service
+++ b/systemd/azazel-edge-selftest.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Azazel-Edge periodic selftest
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/azazel-edge-selftest
+TimeoutStartSec=300
+StandardOutput=journal
+StandardError=journal

--- a/systemd/azazel-edge-selftest.timer
+++ b/systemd/azazel-edge-selftest.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Azazel-Edge selftest quarterly
+
+[Timer]
+OnBootSec=5min
+OnCalendar=quarterly
+AccuracySec=1h
+Unit=azazel-edge-selftest.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add periodic selftest runtime assets:
  - `bin/azazel-edge-selftest`
  - `installer/internal/install_selftest_timer.sh`
  - `systemd/azazel-edge-selftest.service`
  - `systemd/azazel-edge-selftest.timer`
- add operations/deployment documentation suite under `docs/`
- update `docs/INDEX.md` with Operations and Deployment section
- update `docs/index.html` (GitHub Pages entry) with links to the new docs

## Validation
- `bash -n bin/azazel-edge-selftest installer/internal/install_selftest_timer.sh`
- `PYTHONPATH=py:. .venv/bin/pytest -q`

## Linked Issues
- Refs #205
- Refs #208
- Refs #209

## Notes
- Deterministic decision pipeline is unchanged.
- New selftest timer path is additive and opt-in via installer script execution.
