### PR TITLE
docs(core): align README and docs with completed implementation cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Azazel-Edge is a Raspberry Pi-oriented edge operations stack that combines:
 - Web UI + API + runbook workflow for operators
 - optional local AI assist (Ollama + Mattermost integration)
 
-This README is based on verified repository contents (code, scripts, tests, git history, GitHub issue/PR metadata) as of **2026-05-11**.
+This README is based on verified repository contents (code, scripts, tests, git history, GitHub issue/PR metadata) as of **2026-05-13**.
 
 ## What is Azazel-Edge?
 
@@ -142,6 +142,7 @@ flowchart LR
 ## Changelog
 
 See [`docs/CHANGELOG.md`](docs/CHANGELOG.md) for the full implementation history and PR traceability.
+See [`docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md`](docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md) for the current execution cycle feature inventory.
 
 ## Requirements
 
@@ -252,7 +253,7 @@ Install result (default scripts):
 
 ### Token auth
 - API token can be supplied by header `X-AZAZEL-TOKEN` (or `X-Auth-Token`) or `?token=`.
-- If no token file exists, protected endpoints become effectively open.
+- Default runtime posture is fail-closed (`AZAZEL_AUTH_FAIL_OPEN=0`): missing token material must not open protected endpoints.
 
 ## Usage
 
@@ -401,6 +402,7 @@ Latest verified result (2026-05-11): **224 passed, 16 subtests passed**
 | [AGENTS.md](AGENTS.md) | AI agent working charter — read before making any change |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Human contributor guide (branch, PR, test rules) |
 | [Changelog](docs/CHANGELOG.md) | PR and feature traceability history |
+| [Implementation Cycle Feature Inventory](docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md) | Verified feature inventory for Epic #196 implementation cycle |
 | [Release Verification Guide](docs/RELEASE_VERIFICATION_GUIDE.md) | Checksum/SBOM/dependency scan verification workflow |
 
 ## Limitations and Known Issues
@@ -422,12 +424,7 @@ Latest verified result (2026-05-11): **224 passed, 16 subtests passed**
 ### Open work items
 
 See [GitHub Issues](https://github.com/01rabbit/Azazel-Edge/issues) for the current list.
-Priority items as of 2026-05-11:
-
-- #140 Epic: Azazel-Topo-Lite MVP *(P0)*
-- #173 [Topo-Lite] Default monitoring scope to internal network (br0/172.16.0.0/24) *(P0)*
-- #172 [Topo-Lite] Synthetic seed mode with strict live-evidence separation *(P0)*
-- #174 [Topo-Lite] Left-sidebar integration and single-screen visual triage UI *(P0)*
+Priority items are tracked in GitHub Issues and may change daily.
 
 ## Current Status
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,10 +53,25 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - lightweight Python static check job (`compileall`)
   - release checksum artifact generation (`release-checksums.sha256`)
   - release verification documentation (`docs/RELEASE_VERIFICATION_GUIDE.md`)
+- Notification transport hardening line:
+  - Syslog CEF notifier adapter (`SyslogCEFNotifier`)
+  - offline queue notifier with recovery flush (`OfflineQueueNotifier`)
+  - summary-only transfer mode in `DecisionNotifier`
+- Installer/runtime integration line:
+  - Vector installer + service/config baseline
+  - Wazuh ARM64 installer baseline
+  - periodic self-test timer/service and helper script
+  - encrypted storage default installer path (`SKIP_LUKS=1` opt-out)
+  - captive portal consent page and registration API baseline
+- Operations/deployment documentation pack:
+  - operator/deployment/legal/maintenance guides
+  - docs index and GitHub Pages docs landing refresh
+  - implementation cycle feature inventory (`docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md`)
 
 ### Changed
 - Dependency review CI job now runs only when repository variable `ENABLE_DEPENDENCY_REVIEW` is set to `true`.
   - This avoids false CI failures on repositories where Dependency Graph is disabled.
+- README refreshed to align with current runtime capabilities and fail-closed posture.
 
 ## [2026-05-12]
 

--- a/docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md
+++ b/docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md
@@ -1,0 +1,34 @@
+# Implementation Cycle Feature Inventory (2026Q2)
+
+Last updated: 2026-05-13
+Related epic: #196
+
+This inventory summarizes the implemented features completed in the current execution cycle and links each item to purpose, affected modules, operational impact, and verification commands.
+
+## Feature Inventory
+
+| Issue | Feature | Purpose | Affected modules | Operational impact | Verification |
+|---|---|---|---|---|---|
+| #197 | Syslog CEF notifier adapter | Add SIEM-friendly outbound notifier format for deterministic decisions | `py/azazel_edge/notify/delivery.py`, `py/azazel_edge/notify/__init__.py`, `tests/test_notification_syslog_cef_v1.py` | Enables forwarding decision notifications in CEF via syslog collectors | `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_notification_syslog_cef_v1.py` |
+| #198 | Offline queue notifier + recovery flush | Preserve outbound notifications during temporary network outages | `py/azazel_edge/notify/delivery.py`, `py/azazel_edge/notify/__init__.py`, `tests/test_notification_offline_queue_v1.py` | Fail-closed notification path with queue depth visibility and controlled replay | `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_notification_offline_queue_v1.py` |
+| #199 | Summary-only transfer mode in DecisionNotifier | Reduce sensitive transfer payload in degraded transport paths | `py/azazel_edge/notify/delivery.py`, `tests/test_notification_v1.py` | Strips `evidence_ids`, truncates `operator_wording` to 200 chars before adapter send | `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_notification_v1.py` |
+| #200 | Vector installer/config/service integration | Standardize local and aggregator log forwarding path | `installer/internal/install_vector.sh`, `security/vector/*`, `systemd/azazel-edge-vector.service`, `installer/internal/install_all.sh` | Operator can provision deterministic log pipeline by installer toggle | `bash -n installer/internal/install_vector.sh` |
+| #201 | Wazuh ARM64 installer | Add ARM64-compatible endpoint telemetry integration path | `installer/internal/install_wazuh_agent.sh`, `docs/WAZUH_INTEGRATION_GUIDE.md` | Optional host telemetry integration for field deployments | `bash -n installer/internal/install_wazuh_agent.sh` |
+| #202 | Suricata disaster threat rules + ATT&CK mappings | Improve SOC detection coverage for disaster context threats | `security/suricata/azazel-lite.rules`, `config/attack_mapping.yaml` | Increased deterministic SOC signal quality with mapped rationale | `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_soc_evaluator_v*.py` |
+| #203 | Disaster phishing / evacuation demo scenarios | Strengthen deterministic demonstration coverage for training | `py/azazel_edge/demo/scenarios.py`, `tests/test_demo_scenario_pack_v1.py` | Operators can replay scenario-specific triage behavior | `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_demo_scenario_pack_v1.py` |
+| #204 | Shift handoff summary API | Improve operator continuity during shift rotation | `azazel_edge_web/app.py`, `tests/test_handoff_api_v1.py` | Adds consistent summary endpoint for handoff briefing | `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_handoff_api_v1.py` |
+| #205 | Periodic self-test timer | Add routine runtime checks and predictable maintenance rhythm | `bin/azazel-edge-selftest`, `installer/internal/install_selftest_timer.sh`, `systemd/azazel-edge-selftest.{service,timer}` | Better early detection of drift/failure in unattended operation | `bash -n installer/internal/install_selftest_timer.sh` |
+| #206 | Encrypted storage default path | Enforce fail-closed secret handling at install baseline | `installer/internal/install_security_stack.sh`, `installer/internal/install_encrypted_storage.sh`, `docs/FIELD_DEPLOYMENT_GUIDE.md` | Secrets are moved under encrypted mount by default | `bash -n installer/internal/install_encrypted_storage.sh installer/internal/install_security_stack.sh` |
+| #207 | Captive portal consent + registration API | Add explicit user consent flow and local allowlist registration | `azazel_edge_web/app.py`, `azazel_edge_web/templates/captive_consent.html`, `py/azazel_edge/i18n.py`, `installer/internal/install_captive_portal.sh`, `tests/test_captive_portal_api_v1.py` | Field onboarding flow gains legal notice + consent trace | `PYTHONPATH=py:. .venv/bin/pytest -q tests/test_captive_portal_api_v1.py` |
+| #208 | Operations/deployment doc suite | Provide role-specific run and deployment guides | `docs/OPERATOR_GUIDE_JA.md`, `docs/STATUS_CARD.md`, `docs/PHYSICAL_SETUP_GUIDE.md`, `docs/POWER_PLAYBOOK.md`, `docs/FIELD_DEPLOYMENT_GUIDE.md`, `docs/VEHICLE_DEPLOYMENT_GUIDE.md`, `docs/WAZUH_INTEGRATION_GUIDE.md`, `docs/HUMANITARIAN_PARTNER_GUIDE.md`, `docs/PRIVACY_AND_LEGAL.md`, `docs/MAINTENANCE_CHECKLIST.md` | Operational onboarding speed and consistency improved | Link and doc consistency checks + repo test baseline |
+| #209 | Docs index/navigation refresh | Align docs discovery with latest runtime and ops content | `docs/INDEX.md`, `docs/index.html` | Public/internal documentation entrypoint reflects current state | Manual link check in `docs/` |
+
+## Cycle Baseline Validation
+
+```bash
+PYTHONPATH=py:. .venv/bin/pytest -q
+```
+
+Expected baseline at cycle close:
+- `305 passed, 62 subtests passed`
+

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@ Entry point for all documents in this directory.
 | File | Audience | Description | Last Updated |
 |------|----------|-------------|--------------|
 | [NEXT_DEVELOPMENT_EXECUTION_INDEX_2026Q2.md](NEXT_DEVELOPMENT_EXECUTION_INDEX_2026Q2.md) | Developer | 2026Q2 implementation plan index | - |
+| [IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md](IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md) | Developer / Operator | Verified feature inventory for Epic #196 delivery cycle | 2026-05-13 |
 | [CHANGELOG.md](CHANGELOG.md) | Developer | PR and feature traceability history | - |
 | [RELEASE_VERIFICATION_GUIDE.md](RELEASE_VERIFICATION_GUIDE.md) | Developer / Operator | Checksum, SBOM, and release verification baseline | 2026-05-12 |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,6 +141,23 @@
           </div>
         </div>
       </section>
+
+      <section class="section architecture">
+        <h2>Implementation Records</h2>
+        <div class="architecture-grid">
+          <div class="architecture-card">
+            <h3>Cycle delivery map</h3>
+            <p><a href="IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md">IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md</a></p>
+            <p>Verified mapping from implementation issues to modules, impact, and validation commands.</p>
+          </div>
+          <div class="architecture-card">
+            <h3>Change history</h3>
+            <p><a href="CHANGELOG.md">CHANGELOG.md</a></p>
+            <p><a href="INDEX.md">INDEX.md</a></p>
+            <p>Track feature evolution and current documentation entry points.</p>
+          </div>
+        </div>
+      </section>
     </main>
 
     <footer class="footer">


### PR DESCRIPTION
## Summary
- add verified implementation cycle inventory for Epic #196 (`docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md`)
- refresh README with latest date, fail-closed auth wording, and inventory link
- update docs index and GitHub Pages landing links for implementation records
- update changelog with notifier/integration/docs delivery highlights

## Validation
- `PYTHONPATH=py:. .venv/bin/pytest -q`

Refs #210
