### PR TITLE
feat(installer): add optional SNMP and NetFlow sensor install path

### DIFF
--- a/installer/internal/install_all.sh
+++ b/installer/internal/install_all.sh
@@ -9,6 +9,8 @@ ENABLE_AI_RUNTIME="${ENABLE_AI_RUNTIME:-1}"
 ENABLE_DEV_REMOTE_ACCESS="${ENABLE_DEV_REMOTE_ACCESS:-0}"
 ENABLE_RUST_CORE="${ENABLE_RUST_CORE:-1}"
 ENABLE_VECTOR="${ENABLE_VECTOR:-0}"
+ENABLE_SNMP="${ENABLE_SNMP:-0}"
+ENABLE_NETFLOW="${ENABLE_NETFLOW:-0}"
 
 # MODE=open|close (used only when ENABLE_DEV_REMOTE_ACCESS=1)
 DEV_REMOTE_MODE="${DEV_REMOTE_MODE:-open}"
@@ -26,6 +28,8 @@ echo "ENABLE_AI_RUNTIME=${ENABLE_AI_RUNTIME}"
 echo "ENABLE_DEV_REMOTE_ACCESS=${ENABLE_DEV_REMOTE_ACCESS}"
 echo "ENABLE_RUST_CORE=${ENABLE_RUST_CORE}"
 echo "ENABLE_VECTOR=${ENABLE_VECTOR}"
+echo "ENABLE_SNMP=${ENABLE_SNMP}"
+echo "ENABLE_NETFLOW=${ENABLE_NETFLOW}"
 echo "DEV_REMOTE_MODE=${DEV_REMOTE_MODE}"
 
 if [[ "${ENABLE_INTERNAL_NETWORK}" == "1" ]]; then
@@ -61,6 +65,17 @@ if [[ "${ENABLE_VECTOR}" == "1" ]]; then
   VECTOR_MODE="${VECTOR_MODE:-local}" "${REPO_ROOT}/installer/internal/install_vector.sh"
 else
   echo "[all/6] Skip Vector (set ENABLE_VECTOR=1 to enable)"
+fi
+
+if [[ "${ENABLE_SNMP}" == "1" || "${ENABLE_NETFLOW}" == "1" ]]; then
+  echo "[all/7] Install optional sensors (SNMP/NetFlow)"
+  ENABLE_SNMP="${ENABLE_SNMP}" \
+  ENABLE_NETFLOW="${ENABLE_NETFLOW}" \
+  NETFLOW_PORT="${NETFLOW_PORT:-2055}" \
+  SNMP_TARGETS="${SNMP_TARGETS:-}" \
+  "${REPO_ROOT}/installer/internal/install_sensors.sh"
+else
+  echo "[all/7] Skip optional sensors (set ENABLE_SNMP=1 and/or ENABLE_NETFLOW=1)"
 fi
 
 echo "Unified installation completed."

--- a/installer/internal/install_sensors.sh
+++ b/installer/internal/install_sensors.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# install_sensors.sh — Install optional SNMP/NetFlow sensor components
+# Sensors feed existing Evidence Plane via dispatch_syslog_line()
+# Both sensors are OPTIONAL (ENABLE_SNMP, ENABLE_NETFLOW env flags)
+set -euo pipefail
+
+ENABLE_SNMP="${ENABLE_SNMP:-0}"
+ENABLE_NETFLOW="${ENABLE_NETFLOW:-0}"
+NETFLOW_PORT="${NETFLOW_PORT:-2055}"
+SNMP_TARGETS="${SNMP_TARGETS:-}"
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root: sudo $0"
+  exit 1
+fi
+
+echo "[sensors] ENABLE_SNMP=${ENABLE_SNMP}"
+echo "[sensors] ENABLE_NETFLOW=${ENABLE_NETFLOW}"
+echo "[sensors] NETFLOW_PORT=${NETFLOW_PORT}"
+
+if [[ "${ENABLE_SNMP}" == "1" ]]; then
+  apt-get update -y
+  apt-get install -y --no-install-recommends snmp
+  echo "[sensors] SNMP tools installed"
+  if [[ -n "${SNMP_TARGETS}" ]]; then
+    echo "[sensors] SNMP targets provided via SNMP_TARGETS"
+  else
+    echo "[sensors] SNMP targets not set (set SNMP_TARGETS JSON when enabling poller runtime)"
+  fi
+fi
+
+if [[ "${ENABLE_NETFLOW}" == "1" ]]; then
+  echo "[sensors] NetFlow receiver uses stdlib only — no extra packages needed"
+  echo "[sensors] Listening port: ${NETFLOW_PORT}"
+fi
+
+echo "[sensors] Done. Enable via ENABLE_SNMP=1 or ENABLE_NETFLOW=1"


### PR DESCRIPTION
## Summary
- add optional install path for SNMP and NetFlow sensors
- update installer flow/config to support sensor enablement
- implement issue #223 scope with explicit optional behavior

## Why
- provide controlled setup path for additional telemetry collectors

## Deterministic First impact
- no change to deterministic decision pipeline order
- deployment/install path enhancement only

## Validation
- [x] local diff reviewed
- [ ] PYTHONPATH=. .venv/bin/pytest -q

Closes #223