### PR TITLE
feat(probe): add NetFlow v5 UDP receiver for evidence bridge

### DIFF
--- a/py/azazel_edge/sensors/netflow_receiver.py
+++ b/py/azazel_edge/sensors/netflow_receiver.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import logging
+import socket
+import struct
+import threading
+from typing import Any, Callable, Dict, List
+
+from azazel_edge.evidence_plane import EvidenceBus, EvidencePlaneService
+
+
+class NetFlowParseError(RuntimeError):
+    pass
+
+
+NETFLOW_V5_HEADER = struct.Struct("!HHIIIIBBH")
+NETFLOW_V5_RECORD = struct.Struct("!4s4s4sHHIIIIHHxBBBHHBBH")
+
+_DEFAULT_SERVICE: EvidencePlaneService | None = None
+
+
+def _default_dispatch_syslog_line(line: str) -> None:
+    global _DEFAULT_SERVICE
+    if _DEFAULT_SERVICE is None:
+        _DEFAULT_SERVICE = EvidencePlaneService(EvidenceBus())
+    _DEFAULT_SERVICE.dispatch_syslog_line(line)
+
+
+def _ipv4(raw: bytes) -> str:
+    return ".".join(str(b) for b in raw)
+
+
+class NetFlowV5Receiver:
+    def __init__(
+        self,
+        listen_host: str = "0.0.0.0",
+        listen_port: int = 2055,
+        dispatch_fn: Callable[[str], None] | None = None,
+        top_talker_threshold: int = 1000,
+    ):
+        self.listen_host = str(listen_host or "0.0.0.0")
+        self.listen_port = int(listen_port)
+        self.dispatch_fn = dispatch_fn or _default_dispatch_syslog_line
+        self.top_talker_threshold = max(1, int(top_talker_threshold))
+        self.logger = logging.getLogger(__name__)
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def parse_packet(self, data: bytes) -> List[Dict[str, Any]]:
+        if not isinstance(data, (bytes, bytearray)) or len(data) < NETFLOW_V5_HEADER.size:
+            raise NetFlowParseError("netflow_packet_too_short")
+        header = NETFLOW_V5_HEADER.unpack_from(data, 0)
+        version = int(header[0])
+        count = int(header[1])
+        if version != 5:
+            raise NetFlowParseError("netflow_version_unsupported")
+        expected = NETFLOW_V5_HEADER.size + (count * NETFLOW_V5_RECORD.size)
+        if len(data) < expected:
+            raise NetFlowParseError("netflow_packet_truncated")
+
+        flows: List[Dict[str, Any]] = []
+        offset = NETFLOW_V5_HEADER.size
+        for _ in range(count):
+            rec = NETFLOW_V5_RECORD.unpack_from(data, offset)
+            offset += NETFLOW_V5_RECORD.size
+            flows.append(
+                {
+                    "src_ip": _ipv4(rec[0]),
+                    "dst_ip": _ipv4(rec[1]),
+                    "src_port": int(rec[9]),
+                    "dst_port": int(rec[10]),
+                    "packets": int(rec[5]),
+                    "bytes": int(rec[6]),
+                    "protocol": int(rec[12]),
+                    "tcp_flags": int(rec[11]),
+                }
+            )
+        return flows
+
+    def to_syslog_lines(self, flows: List[Dict[str, Any]], exporter_ip: str) -> List[str]:
+        rows: List[str] = []
+        exp = str(exporter_ip or "").strip() or "unknown"
+        for flow in flows:
+            prefix = "NETFLOW_TOP_TALKER" if int(flow.get("packets") or 0) > self.top_talker_threshold else "NETFLOW_FLOW"
+            rows.append(
+                f"{prefix} exporter={exp} "
+                f"src={flow.get('src_ip','-')}:{int(flow.get('src_port') or 0)} "
+                f"dst={flow.get('dst_ip','-')}:{int(flow.get('dst_port') or 0)} "
+                f"proto={int(flow.get('protocol') or 0)} "
+                f"pkts={int(flow.get('packets') or 0)} "
+                f"bytes={int(flow.get('bytes') or 0)}"
+            )
+        return rows
+
+    def run_forever(self) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((self.listen_host, self.listen_port))
+            sock.settimeout(1.0)
+            while not self._stop_event.is_set():
+                try:
+                    data, addr = sock.recvfrom(65535)
+                except socket.timeout:
+                    continue
+                except Exception as exc:
+                    self.logger.warning("netflow receive failure: %s", exc)
+                    continue
+                try:
+                    flows = self.parse_packet(data)
+                    lines = self.to_syslog_lines(flows, addr[0] if isinstance(addr, tuple) and addr else "")
+                    for line in lines:
+                        self.dispatch_fn(line)
+                except NetFlowParseError as exc:
+                    self.logger.warning("netflow parse error: %s", exc)
+                    continue

--- a/tests/test_netflow_receiver_v1.py
+++ b/tests/test_netflow_receiver_v1.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import socket
+import struct
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from azazel_edge.sensors.netflow_receiver import (
+    NETFLOW_V5_HEADER,
+    NETFLOW_V5_RECORD,
+    NetFlowParseError,
+    NetFlowV5Receiver,
+)
+
+
+def _ip(a: int, b: int, c: int, d: int) -> bytes:
+    return bytes([a, b, c, d])
+
+
+def _record(src: bytes, dst: bytes, src_port: int, dst_port: int, packets: int, octets: int, proto: int, flags: int = 0) -> bytes:
+    return NETFLOW_V5_RECORD.pack(
+        src,            # srcaddr
+        dst,            # dstaddr
+        _ip(0, 0, 0, 0),  # nexthop
+        1,              # input
+        2,              # output
+        packets,        # dPkts
+        octets,         # dOctets
+        1000,           # First
+        2000,           # Last
+        src_port,       # srcport
+        dst_port,       # dstport
+        flags,          # tcp_flags
+        proto,          # prot
+        0,              # tos
+        65000,          # src_as
+        65001,          # dst_as
+        24,             # src_mask
+        24,             # dst_mask
+        0,              # pad2
+    )
+
+
+def _packet(flows: list[bytes]) -> bytes:
+    header = NETFLOW_V5_HEADER.pack(
+        5,              # version
+        len(flows),     # count
+        10000,          # sys_uptime
+        1715580000,     # unix_secs
+        0,              # unix_nsecs
+        10,             # flow_sequence
+        0,              # engine_type
+        0,              # engine_id
+        0,              # sampling
+    )
+    return header + b"".join(flows)
+
+
+class NetFlowReceiverV1Tests(unittest.TestCase):
+    def test_parse_packet_valid_v5(self) -> None:
+        receiver = NetFlowV5Receiver()
+        pkt = _packet(
+            [
+                _record(_ip(10, 0, 0, 1), _ip(192, 168, 1, 10), 12345, 443, 10, 1000, 6, 0x10),
+                _record(_ip(10, 0, 0, 2), _ip(192, 168, 1, 20), 53000, 53, 5, 500, 17, 0),
+            ]
+        )
+        flows = receiver.parse_packet(pkt)
+        self.assertEqual(len(flows), 2)
+        self.assertEqual(flows[0]["src_ip"], "10.0.0.1")
+        self.assertEqual(flows[0]["dst_port"], 443)
+        self.assertEqual(flows[1]["protocol"], 17)
+
+    def test_parse_packet_wrong_version_raises(self) -> None:
+        receiver = NetFlowV5Receiver()
+        header = NETFLOW_V5_HEADER.pack(9, 0, 0, 0, 0, 0, 0, 0, 0)
+        with self.assertRaises(NetFlowParseError):
+            receiver.parse_packet(header)
+
+    def test_to_syslog_lines_format(self) -> None:
+        receiver = NetFlowV5Receiver(top_talker_threshold=1000)
+        lines = receiver.to_syslog_lines(
+            [
+                {
+                    "src_ip": "10.0.0.1",
+                    "dst_ip": "192.168.1.10",
+                    "src_port": 1000,
+                    "dst_port": 443,
+                    "protocol": 6,
+                    "packets": 10,
+                    "bytes": 5000,
+                    "tcp_flags": 16,
+                }
+            ],
+            "172.16.0.1",
+        )
+        self.assertEqual(len(lines), 1)
+        self.assertTrue(lines[0].startswith("NETFLOW_FLOW exporter=172.16.0.1"))
+
+    def test_to_syslog_lines_top_talker_flagged(self) -> None:
+        receiver = NetFlowV5Receiver(top_talker_threshold=100)
+        lines = receiver.to_syslog_lines(
+            [
+                {
+                    "src_ip": "10.0.0.1",
+                    "dst_ip": "192.168.1.10",
+                    "src_port": 1000,
+                    "dst_port": 443,
+                    "protocol": 6,
+                    "packets": 200,
+                    "bytes": 5000,
+                    "tcp_flags": 16,
+                }
+            ],
+            "172.16.0.1",
+        )
+        self.assertTrue(lines[0].startswith("NETFLOW_TOP_TALKER"))
+
+    def test_run_forever_dispatches(self) -> None:
+        pkt = _packet([_record(_ip(10, 0, 0, 1), _ip(192, 168, 1, 10), 12345, 443, 10, 1000, 6)])
+        sent: list[str] = []
+
+        class _Sock:
+            def __init__(self):
+                self.sent = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def setsockopt(self, *_args):
+                return None
+
+            def bind(self, *_args):
+                return None
+
+            def settimeout(self, *_args):
+                return None
+
+            def recvfrom(self, _size):
+                if not self.sent:
+                    self.sent = True
+                    return pkt, ("127.0.0.1", 9999)
+                raise socket.timeout()
+
+        receiver = NetFlowV5Receiver(
+            dispatch_fn=lambda line: sent.append(line),
+            listen_port=2055,
+        )
+        with patch("azazel_edge.sensors.netflow_receiver.socket.socket", return_value=_Sock()):
+            t = threading.Thread(target=receiver.run_forever, daemon=True)
+            t.start()
+            time.sleep(0.05)
+            receiver.stop()
+            t.join(timeout=1)
+        self.assertTrue(sent)
+        self.assertTrue(sent[0].startswith("NETFLOW_FLOW exporter=127.0.0.1"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add NetFlow v5 UDP receiver implementation
- bridge received flow data into Evidence Plane path
- include issue #222 scoped integration updates

## Why
- expand deterministic telemetry ingestion from flow sources

## Deterministic First impact
- no change to deterministic pipeline sequence
- input/collector layer extension only

## Validation
- [x] local diff reviewed
- [ ] PYTHONPATH=. .venv/bin/pytest -q

Closes #222