### PR TITLE
feat(integration): add STIX exporter and TAXII 2.1 read-only API

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -34,6 +34,7 @@ from functools import wraps
 from collections import deque
 from pathlib import Path
 from datetime import datetime
+from datetime import timezone
 from typing import Dict, Any, Optional, Iterator, Tuple, List, Callable
 from urllib.request import Request, urlopen
 from urllib.parse import urlparse, quote
@@ -100,6 +101,7 @@ try:
         AEVT_INGEST_REJECT,
         AEVT_NODE_QUARANTINE,
     )
+    from azazel_edge.integrations import STIXExporter
 except Exception:
     cp_read_snapshot_payload = None
     cp_watch_snapshots = None
@@ -135,6 +137,7 @@ except Exception:
     SoTValidationError = ValueError  # type: ignore
     AggregatorRegistry = None  # type: ignore
     FreshnessPolicy = None  # type: ignore
+    STIXExporter = None  # type: ignore
 
 # Configuration
 _RUNTIME_STATE_PATHS = runtime_snapshot_path_candidates()
@@ -217,6 +220,7 @@ AGGREGATOR_AUDIT_LOG = Path(
     str(os.environ.get("AZAZEL_AGGREGATOR_AUDIT_LOG", "/var/log/azazel-edge/aggregator-events.jsonl")).strip()
     or "/var/log/azazel-edge/aggregator-events.jsonl"
 )
+TAXII_COLLECTION_ID = "azazel-edge-decisions"
 
 if AggregatorRegistry is not None and FreshnessPolicy is not None:
     _AGGREGATOR_REGISTRY = AggregatorRegistry(
@@ -797,6 +801,29 @@ def _tail_first_existing_jsonl(paths: List[Path], limit: int = 20) -> List[Dict[
         if rows:
             return rows
     return []
+
+
+def _taxii_response(payload: Dict[str, Any], status: int = 200) -> Response:
+    return Response(
+        json.dumps(payload, ensure_ascii=False),
+        status=status,
+        mimetype="application/taxii+json;version=2.1",
+    )
+
+
+def _added_after_epoch(value: str) -> Optional[float]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return float(dt.timestamp())
+    except Exception:
+        return None
 
 
 def _load_captive_registry() -> Dict[str, Any]:
@@ -5159,6 +5186,59 @@ def api_aggregator_nodes():
             "poll_interval_sec": AGGREGATOR_POLL_INTERVAL_SEC,
         }
     ), 200
+
+
+@app.route("/taxii2/", methods=["GET"])
+@require_token()
+def taxii_discovery():
+    payload = {
+        "title": "Azazel-Edge TAXII 2.1 Server",
+        "description": "Emergency shelter gateway threat intelligence",
+        "contact": "azazel-edge",
+        "api_roots": ["/taxii2/"],
+    }
+    return _taxii_response(payload)
+
+
+@app.route("/taxii2/collections/", methods=["GET"])
+@require_token()
+def taxii_collections():
+    payload = {
+        "collections": [
+            {
+                "id": TAXII_COLLECTION_ID,
+                "title": "Azazel-Edge Arbiter Decisions",
+                "description": "STIX 2.1 sightings and indicators from deterministic triage",
+                "can_read": True,
+                "can_write": False,
+                "media_types": ["application/stix+json;version=2.1"],
+            }
+        ]
+    }
+    return _taxii_response(payload)
+
+
+@app.route(f"/taxii2/collections/{TAXII_COLLECTION_ID}/objects/", methods=["GET"])
+@require_token()
+def taxii_collection_objects():
+    limit_raw = str(request.args.get("limit", "50")).strip()
+    try:
+        limit = int(limit_raw)
+    except Exception:
+        limit = 50
+    limit = max(1, min(200, limit))
+    added_after = _added_after_epoch(str(request.args.get("added_after", "") or ""))
+    exporter = STIXExporter() if STIXExporter is not None else None
+    if exporter is None:
+        return _taxii_response({"more": False, "next": None, "objects": []})
+    source = TRIAGE_AUDIT_LOG if TRIAGE_AUDIT_LOG.exists() else TRIAGE_AUDIT_FALLBACK_LOG
+    bundle = exporter.export_audit_window(source, max_entries=limit, since_epoch=added_after)
+    payload = {
+        "more": False,
+        "next": None,
+        "objects": list(bundle.get("objects") or []),
+    }
+    return _taxii_response(payload)
 
 
 @app.route("/api/state/stream")

--- a/py/azazel_edge/integrations/__init__.py
+++ b/py/azazel_edge/integrations/__init__.py
@@ -1,3 +1,11 @@
 from .upstream import JsonlMirrorSink, UpstreamEnvelopeBuilder, WebhookSink
+from .stix_export import STIXExporter, STIX_SPEC_VERSION, STIX_BUNDLE_TYPE
 
-__all__ = ['UpstreamEnvelopeBuilder', 'JsonlMirrorSink', 'WebhookSink']
+__all__ = [
+    'UpstreamEnvelopeBuilder',
+    'JsonlMirrorSink',
+    'WebhookSink',
+    'STIXExporter',
+    'STIX_SPEC_VERSION',
+    'STIX_BUNDLE_TYPE',
+]

--- a/py/azazel_edge/integrations/stix_export.py
+++ b/py/azazel_edge/integrations/stix_export.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import argparse
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+STIX_SPEC_VERSION = "2.1"
+STIX_BUNDLE_TYPE = "bundle"
+STIX_NAMESPACE = uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7")
+
+
+def _stix_id(obj_type: str, deterministic_key: str) -> str:
+    uid = uuid.uuid5(STIX_NAMESPACE, f"{obj_type}:{deterministic_key}")
+    return f"{obj_type}--{uid}"
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _to_iso(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    text = str(value or "").strip()
+    if not text:
+        return _iso_now()
+    if text.endswith("Z"):
+        return text
+    try:
+        dt = datetime.fromisoformat(text)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    except Exception:
+        return _iso_now()
+
+
+class STIXExporter:
+    def __init__(self, identity_name: str = "Azazel-Edge", identity_id: str | None = None):
+        self.identity_name = str(identity_name or "Azazel-Edge")
+        self.identity_id = identity_id or _stix_id("identity", self.identity_name)
+
+    def arbiter_to_sighting(self, decision: Dict[str, Any]) -> Dict[str, Any]:
+        action = str(decision.get("action") or "observe")
+        reason = str(decision.get("reason") or "")
+        evidence_ids = [str(x) for x in decision.get("evidence_ids", []) if str(x)]
+        trace_id = str(decision.get("trace_id") or "unknown")
+        level = str(decision.get("level") or "info")
+        ts = _to_iso(decision.get("ts") or decision.get("timestamp") or decision.get("created") or _iso_now())
+        indicator_ref = _stix_id("indicator", f"{reason}:{trace_id}")
+        sid = _stix_id("sighting", f"{trace_id}:{action}:{','.join(sorted(evidence_ids))}")
+        return {
+            "type": "sighting",
+            "spec_version": STIX_SPEC_VERSION,
+            "id": sid,
+            "created": ts,
+            "modified": ts,
+            "sighting_of_ref": indicator_ref,
+            "count": 1,
+            "where_sighted_refs": [self.identity_id],
+            "description": f"action={action} level={level} reason={reason} evidence={','.join(evidence_ids)}",
+            "x_azazel_trace_id": trace_id,
+        }
+
+    def suricata_alert_to_indicator(self, alert: Dict[str, Any], technique_id: str = "") -> Dict[str, Any]:
+        alert_obj = alert.get("alert") if isinstance(alert.get("alert"), dict) else {}
+        signature = str(alert_obj.get("signature") or alert.get("signature") or "suricata-alert")
+        signature_id = str(alert_obj.get("signature_id") or alert.get("signature_id") or "0")
+        src_ip = str(alert.get("src_ip") or "0.0.0.0")
+        dst_ip = str(alert.get("dest_ip") or alert.get("dst_ip") or "0.0.0.0")
+        created = _to_iso(alert.get("timestamp") or _iso_now())
+        indicator_id = _stix_id("indicator", f"{signature_id}:{signature}:{src_ip}:{dst_ip}:{technique_id}")
+        pattern = (
+            f"[network-traffic:src_ref.value = '{src_ip}' AND "
+            f"network-traffic:dst_ref.value = '{dst_ip}']"
+        )
+        name = signature if not technique_id else f"{signature} ({technique_id})"
+        return {
+            "type": "indicator",
+            "spec_version": STIX_SPEC_VERSION,
+            "id": indicator_id,
+            "created": created,
+            "modified": created,
+            "name": name,
+            "pattern": pattern,
+            "pattern_type": "stix",
+            "valid_from": created,
+            "labels": ["suricata", "azazel-edge"],
+            "x_azazel_signature_id": signature_id,
+            "x_azazel_attack_technique": str(technique_id or ""),
+        }
+
+    def action_to_course_of_action(self, action: str, rationale: str = "") -> Dict[str, Any]:
+        act = str(action or "observe")
+        coa_id = _stix_id("course-of-action", act)
+        created = _iso_now()
+        return {
+            "type": "course-of-action",
+            "spec_version": STIX_SPEC_VERSION,
+            "id": coa_id,
+            "created": created,
+            "modified": created,
+            "name": f"azazel-edge:{act}",
+            "description": str(rationale or f"Deterministic response action: {act}"),
+        }
+
+    def build_bundle(self, objects: List[Dict[str, Any]]) -> Dict[str, Any]:
+        ids = sorted(str(item.get("id") or "") for item in objects if isinstance(item, dict))
+        bundle_id = _stix_id(STIX_BUNDLE_TYPE, "|".join(ids))
+        return {
+            "type": STIX_BUNDLE_TYPE,
+            "id": bundle_id,
+            "spec_version": STIX_SPEC_VERSION,
+            "objects": list(objects),
+        }
+
+    def export_audit_window(
+        self,
+        audit_log_path: str | Path,
+        max_entries: int = 100,
+        since_epoch: float | None = None,
+    ) -> Dict[str, Any]:
+        path = Path(audit_log_path)
+        if not path.exists():
+            return self.build_bundle([])
+        lines = path.read_text(encoding="utf-8").splitlines()
+        rows = lines[-max(1, int(max_entries)) :]
+        objects: List[Dict[str, Any]] = []
+        for row in rows:
+            row = row.strip()
+            if not row:
+                continue
+            try:
+                payload = json.loads(row)
+            except Exception:
+                continue
+            ts_iso = _to_iso(payload.get("ts"))
+            try:
+                if since_epoch is not None:
+                    dt = datetime.fromisoformat(ts_iso.replace("Z", "+00:00"))
+                    if dt.timestamp() < float(since_epoch):
+                        continue
+            except Exception:
+                pass
+            kind = str(payload.get("kind") or "")
+            if kind != "action_decision":
+                continue
+            decision = {
+                "action": payload.get("action"),
+                "reason": payload.get("reason"),
+                "evidence_ids": payload.get("chosen_evidence_ids") or payload.get("evidence_ids") or [],
+                "trace_id": payload.get("trace_id") or "",
+                "level": payload.get("level") or "info",
+                "ts": payload.get("ts") or ts_iso,
+            }
+            objects.append(self.arbiter_to_sighting(decision))
+            objects.append(self.action_to_course_of_action(str(payload.get("action") or "observe"), str(payload.get("reason") or "")))
+        return self.build_bundle(objects)
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description="Export Azazel-Edge audit decisions as STIX 2.1 Bundle JSON")
+    parser.add_argument("--audit-log", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--max-entries", type=int, default=100)
+    args = parser.parse_args()
+    exporter = STIXExporter()
+    bundle = exporter.export_audit_window(args.audit_log, max_entries=args.max_entries)
+    Path(args.output).write_text(json.dumps(bundle, ensure_ascii=True, indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_stix_export_v1.py
+++ b/tests/test_stix_export_v1.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from azazel_edge.integrations.stix_export import STIXExporter, _stix_id
+
+
+class STIXExportV1Tests(unittest.TestCase):
+    def test_build_bundle_has_required_fields(self) -> None:
+        exporter = STIXExporter()
+        bundle = exporter.build_bundle([{"type": "indicator", "id": "indicator--x"}])
+        self.assertEqual(bundle["type"], "bundle")
+        self.assertIn("id", bundle)
+        self.assertEqual(bundle["spec_version"], "2.1")
+        self.assertIn("objects", bundle)
+
+    def test_arbiter_to_sighting_produces_valid_object(self) -> None:
+        exporter = STIXExporter()
+        sighting = exporter.arbiter_to_sighting(
+            {
+                "action": "notify",
+                "reason": "soc_high_but_noc_fragile",
+                "evidence_ids": ["ev-1"],
+                "trace_id": "trace-1",
+                "level": "warning",
+                "ts": "2026-05-13T00:00:00Z",
+            }
+        )
+        self.assertEqual(sighting["type"], "sighting")
+        self.assertIn("sighting_of_ref", sighting)
+
+    def test_suricata_to_indicator_produces_valid_object(self) -> None:
+        exporter = STIXExporter()
+        indicator = exporter.suricata_alert_to_indicator(
+            {
+                "src_ip": "10.0.0.5",
+                "dest_ip": "192.168.40.10",
+                "alert": {"signature": "ET MALWARE Something", "signature_id": 9901101},
+            },
+            technique_id="T1566",
+        )
+        self.assertEqual(indicator["type"], "indicator")
+        self.assertIn("pattern", indicator)
+        self.assertEqual(indicator["pattern_type"], "stix")
+
+    def test_action_to_coa_maps_all_five_actions(self) -> None:
+        exporter = STIXExporter()
+        for action in ("observe", "notify", "throttle", "redirect", "isolate"):
+            coa = exporter.action_to_course_of_action(action, rationale="test")
+            self.assertEqual(coa["type"], "course-of-action")
+            self.assertIn("id", coa)
+            self.assertIn(action, coa["name"])
+
+    def test_export_audit_window_returns_bundle(self) -> None:
+        exporter = STIXExporter()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "triage-audit.jsonl"
+            rows = [
+                {
+                    "ts": "2026-05-13T00:00:00Z",
+                    "kind": "action_decision",
+                    "trace_id": "t-1",
+                    "action": "notify",
+                    "reason": "soc_high_but_noc_fragile",
+                    "chosen_evidence_ids": ["ev-1", "ev-2"],
+                    "level": "warning",
+                },
+                {"ts": "2026-05-13T00:00:01Z", "kind": "evaluation", "trace_id": "t-2"},
+            ]
+            path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+            bundle = exporter.export_audit_window(path, max_entries=10)
+        self.assertEqual(bundle["type"], "bundle")
+        self.assertGreaterEqual(len(bundle["objects"]), 2)
+
+    def test_stix_id_is_deterministic(self) -> None:
+        a = _stix_id("indicator", "same-key")
+        b = _stix_id("indicator", "same-key")
+        self.assertEqual(a, b)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stix_taxii_api_v1.py
+++ b/tests/test_stix_taxii_api_v1.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import azazel_edge_web.app as webapp
+
+
+class STIXTaxiiApiV1Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.tokens = root / "auth_tokens.json"
+        self.tokens.write_text(
+            json.dumps(
+                {
+                    "tokens": [
+                        {"token": "viewer-token", "principal": "viewer-1", "role": "viewer"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.audit_path = root / "triage-audit.jsonl"
+        self.audit_path.write_text(
+            json.dumps(
+                {
+                    "ts": "2026-05-13T00:00:00Z",
+                    "kind": "action_decision",
+                    "trace_id": "trace-1",
+                    "action": "notify",
+                    "reason": "soc_high_but_noc_fragile",
+                    "chosen_evidence_ids": ["ev-1"],
+                    "level": "warning",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        self._orig = {
+            "AUTH_FAIL_OPEN": webapp.AUTH_FAIL_OPEN,
+            "AUTH_TOKENS_FILE": webapp.AUTH_TOKENS_FILE,
+            "TRIAGE_AUDIT_LOG": webapp.TRIAGE_AUDIT_LOG,
+            "TRIAGE_AUDIT_FALLBACK_LOG": webapp.TRIAGE_AUDIT_FALLBACK_LOG,
+        }
+        webapp.AUTH_FAIL_OPEN = False
+        webapp.AUTH_TOKENS_FILE = self.tokens
+        webapp.TRIAGE_AUDIT_LOG = self.audit_path
+        webapp.TRIAGE_AUDIT_FALLBACK_LOG = self.audit_path
+        self.client = webapp.app.test_client()
+
+    def tearDown(self) -> None:
+        webapp.AUTH_FAIL_OPEN = self._orig["AUTH_FAIL_OPEN"]
+        webapp.AUTH_TOKENS_FILE = self._orig["AUTH_TOKENS_FILE"]
+        webapp.TRIAGE_AUDIT_LOG = self._orig["TRIAGE_AUDIT_LOG"]
+        webapp.TRIAGE_AUDIT_FALLBACK_LOG = self._orig["TRIAGE_AUDIT_FALLBACK_LOG"]
+        self.tmp.cleanup()
+
+    def _headers(self) -> dict:
+        return {"X-AZAZEL-TOKEN": "viewer-token"}
+
+    def test_taxii_discovery_returns_api_roots(self) -> None:
+        res = self.client.get("/taxii2/", headers=self._headers())
+        self.assertEqual(res.status_code, 200)
+        payload = res.get_json()
+        self.assertIn("/taxii2/", payload.get("api_roots", []))
+
+    def test_taxii_collections_returns_one_collection(self) -> None:
+        res = self.client.get("/taxii2/collections/", headers=self._headers())
+        self.assertEqual(res.status_code, 200)
+        payload = res.get_json()
+        cols = payload.get("collections", [])
+        self.assertEqual(len(cols), 1)
+        self.assertEqual(cols[0].get("id"), "azazel-edge-decisions")
+
+    def test_taxii_objects_returns_stix_bundle_structure(self) -> None:
+        res = self.client.get("/taxii2/collections/azazel-edge-decisions/objects/", headers=self._headers())
+        self.assertEqual(res.status_code, 200)
+        payload = res.get_json()
+        self.assertIn("objects", payload)
+        self.assertIn("more", payload)
+        self.assertFalse(payload.get("more"))
+
+    def test_taxii_objects_limit_param_respected(self) -> None:
+        extra = [
+            json.dumps(
+                {
+                    "ts": "2026-05-13T00:00:0{}Z".format(i),
+                    "kind": "action_decision",
+                    "trace_id": f"trace-{i+2}",
+                    "action": "notify",
+                    "reason": "soc_high_but_noc_fragile",
+                    "chosen_evidence_ids": [f"ev-{i+2}"],
+                    "level": "warning",
+                }
+            )
+            for i in range(3)
+        ]
+        self.audit_path.write_text(self.audit_path.read_text(encoding="utf-8") + "\n".join(extra) + "\n", encoding="utf-8")
+        res = self.client.get("/taxii2/collections/azazel-edge-decisions/objects/?limit=1", headers=self._headers())
+        self.assertEqual(res.status_code, 200)
+        payload = res.get_json()
+        self.assertLessEqual(len(payload.get("objects", [])), 2)
+
+    def test_taxii_endpoints_require_token(self) -> None:
+        d = self.client.get("/taxii2/")
+        c = self.client.get("/taxii2/collections/")
+        o = self.client.get("/taxii2/collections/azazel-edge-decisions/objects/")
+        self.assertEqual(d.status_code, 403)
+        self.assertEqual(c.status_code, 403)
+        self.assertEqual(o.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add STIX export capability for aggregator/integration flow
- add TAXII 2.1 read-only API endpoint set
- implement integration scope for issues #224 and #225

## Why
- enable standards-based threat intel sharing while keeping control path deterministic

## Deterministic First impact
- no change to deterministic evaluator/arbiter order
- integration/export layer enhancement only

## Validation
- [x] local diff reviewed
- [ ] PYTHONPATH=. .venv/bin/pytest -q

Closes #224
Closes #225