### PR TITLE
docs(runbook): finalize release changelog and benchmark artifacts

### DIFF
--- a/docs/BENCHMARK_RESULTS.json
+++ b/docs/BENCHMARK_RESULTS.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-05-13T10:58:32.091354+00:00",
+  "generated_at": "2026-05-13T11:58:48.985971+00:00",
   "hardware": "TBD",
-  "commit": "eea897b",
+  "commit": "1707a88",
   "test_baseline": "328 passed, 62 subtests passed",
   "os": "macOS-26.5-arm64-arm-64bit",
-  "python_version": "3.10.20",
+  "python_version": "3.10.4",
   "suricata_version": "TBD",
   "load_condition": "synthetic EVE replay",
   "network_conditions": "offline synthetic corpus",
@@ -12,44 +12,44 @@
     "iterations": 200,
     "stages": {
       "T2_eve_parse": {
-        "mean_ms": 0.003,
-        "median_ms": 0.003,
-        "p95_ms": 0.004,
-        "p99_ms": 0.007,
-        "min_ms": 0.003,
-        "max_ms": 0.009,
+        "mean_ms": 0.005,
+        "median_ms": 0.005,
+        "p95_ms": 0.005,
+        "p99_ms": 0.009,
+        "min_ms": 0.005,
+        "max_ms": 0.017,
         "stdev_ms": 0.001
       },
       "T3_evidence_dispatch": {
-        "mean_ms": 0.01,
-        "median_ms": 0.01,
-        "p95_ms": 0.013,
-        "p99_ms": 0.026,
-        "min_ms": 0.009,
-        "max_ms": 0.032,
-        "stdev_ms": 0.002
+        "mean_ms": 0.015,
+        "median_ms": 0.014,
+        "p95_ms": 0.015,
+        "p99_ms": 0.023,
+        "min_ms": 0.014,
+        "max_ms": 0.028,
+        "stdev_ms": 0.001
       },
       "T4_evaluators": {
-        "mean_ms": 0.117,
-        "median_ms": 0.117,
-        "p95_ms": 0.131,
-        "p99_ms": 0.171,
-        "min_ms": 0.104,
-        "max_ms": 0.199,
+        "mean_ms": 0.18,
+        "median_ms": 0.178,
+        "p95_ms": 0.191,
+        "p99_ms": 0.226,
+        "min_ms": 0.175,
+        "max_ms": 0.301,
         "stdev_ms": 0.011
       },
       "T5_arbiter": {
-        "mean_ms": 0.008,
-        "median_ms": 0.008,
-        "p95_ms": 0.01,
-        "p99_ms": 0.021,
-        "min_ms": 0.007,
-        "max_ms": 0.022,
-        "stdev_ms": 0.002
+        "mean_ms": 0.011,
+        "median_ms": 0.011,
+        "p95_ms": 0.012,
+        "p99_ms": 0.016,
+        "min_ms": 0.011,
+        "max_ms": 0.017,
+        "stdev_ms": 0.001
       }
     },
-    "total_pipeline_mean_ms": 0.138,
-    "total_pipeline_p95_ms": 0.158
+    "total_pipeline_mean_ms": 0.211,
+    "total_pipeline_p95_ms": 0.223
   },
   "accuracy": {
     "corpus_path": "tests/benchmark/corpus",

--- a/docs/BENCHMARK_RESULTS.md
+++ b/docs/BENCHMARK_RESULTS.md
@@ -1,8 +1,8 @@
 # Azazel-Edge Benchmark Results
 
-Generated: 2026-05-13T10:58:32.091354+00:00  
+Generated: 2026-05-13T11:58:48.985971+00:00  
 Hardware: TBD  
-Commit: eea897b  
+Commit: 1707a88  
 Test suite baseline: 328 passed, 62 subtests passed
 
 ---
@@ -11,12 +11,12 @@ Test suite baseline: 328 passed, 62 subtests passed
 
 | Stage | Mean (ms) | Median (ms) | p95 (ms) | p99 (ms) |
 |---|---|---|---|---|
-| T2_eve_parse | 0.003 | 0.003 | 0.004 | 0.007 |
-| T3_evidence_dispatch | 0.01 | 0.01 | 0.013 | 0.026 |
-| T4_evaluators | 0.117 | 0.117 | 0.131 | 0.171 |
-| T5_arbiter | 0.008 | 0.008 | 0.01 | 0.021 |
+| T2_eve_parse | 0.005 | 0.005 | 0.005 | 0.009 |
+| T3_evidence_dispatch | 0.015 | 0.014 | 0.015 | 0.023 |
+| T4_evaluators | 0.18 | 0.178 | 0.191 | 0.226 |
+| T5_arbiter | 0.011 | 0.011 | 0.012 | 0.016 |
 
-Total pipeline p95: 0.158 ms
+Total pipeline p95: 0.223 ms
 
 ## B-3: Detection Accuracy
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,14 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- (none yet)
+
+### Changed
+- (none yet)
+
+## [0.1.0] - 2026-05-13
+
+### Added
 - Aggregator MVP scaffold (design-to-implementation bridge):
   - in-memory node registry with registration and summary ingest
   - freshness classification (`fresh` / `stale` / `offline`)


### PR DESCRIPTION
## Summary
Finalize post-release documentation updates after v0.1.0 publication.

## Changes
- finalize changelog structure for released version `0.1.0`
- refresh benchmark result artifacts generated from benchmark validation run

## Validation
- `PYTHONPATH=py:. .venv/bin/pytest -q tests/benchmark -v`
- `bin/azazel-bench pipeline`
- `bin/azazel-bench accuracy`
- `bin/azazel-bench report`
