### PR TITLE
release(v0.1.1): hardening readiness and demo reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Azazel-Edge is a Raspberry Pi-oriented edge operations stack that combines:
 - Web UI + API + runbook workflow for operators
 - optional local AI assist (Ollama + Mattermost integration)
 
-This README is based on verified repository contents (code, scripts, tests, git history, GitHub issue/PR metadata) as of **2026-05-13**.
+This README is based on verified repository contents (code, scripts, tests, git history, GitHub issue/PR metadata) as of **2026-05-14**.
 
 ## What is Azazel-Edge?
 
@@ -334,7 +334,9 @@ Run:
 PYTHONPATH=py:. .venv/bin/pytest -q
 ```
 
-Latest verified result (2026-05-11): **224 passed, 16 subtests passed**
+Status guidance:
+- Use the CI badge and latest GitHub release notes as the source of current validation status.
+- Avoid treating static README test counts as authoritative across commits.
 
 ## Repository Layout
 
@@ -400,6 +402,9 @@ Latest verified result (2026-05-11): **224 passed, 16 subtests passed**
 | [Post-demo Main Integration Boundary (#104)](docs/POST_DEMO_MAIN_INTEGRATION_104.md) | What is mainline vs. exhibition-only |
 | [Post-demo Socket Permission Model (#105)](docs/POST_DEMO_SOCKET_PERMISSION_MODEL_105.md) | Unix socket permission decisions |
 | [Next Development Execution Index 2026Q2](docs/NEXT_DEVELOPMENT_EXECUTION_INDEX_2026Q2.md) | Roadmap and execution plan |
+| [Arsenal Demo Profile](docs/ARSENAL_DEMO_PROFILE.md) | Reproducible deterministic demo profile |
+| [Deployment Profiles](docs/DEPLOYMENT_PROFILES.md) | Core/Demo/SOC/NOC/Heavy-lab profile matrix |
+| [Benchmark Scope and HIL Plan](docs/BENCHMARK_SCOPE_AND_HIL_PLAN.md) | Scope boundary and hardware-in-the-loop plan |
 
 ### For contributors (AI agents and humans)
 
@@ -423,6 +428,8 @@ Latest verified result (2026-05-11): **224 passed, 16 subtests passed**
 - AI assist is optional and bounded — the deterministic path works without Ollama
 - Ollama models above 2b parameters are not recommended for co-located deployments
 - Test count and runbook count are verified at each release; see CI results for current status.
+- Redirect behavior uses prepared lightweight decoys with protocol-aware mapping (v0.1.1 hardening line), not per-event decoy spawning.
+- Benchmark outputs are scoped to software-only deterministic replay unless hardware-in-the-loop evidence is explicitly provided.
 
 ### Known bugs
 
@@ -435,9 +442,10 @@ Priority items are tracked in GitHub Issues and may change daily.
 
 ## Current Status
 
-- Recent merged PRs include #95, #94, #88, #87, #86 (UI, NOC runtime integration, auth/i18n, SOC maturation).
-- Repository currently contains **48** Python test modules and **15** runbook YAML definitions.
+- Latest release: `v0.1.0`.
+- Current hardening line: `v0.1.1` readiness tasks (redirect safety, demo reproducibility profile, deployment profile clarity, benchmark claim boundary).
 - Deterministic demo scenarios available: `mixed_correlation_demo`, `noc_degraded_demo`, `soc_redirect_demo`.
+- Optional integrations remain optional; deterministic core operation does not require Ollama/Mattermost/Wazuh/Vector/Aggregator.
 
 ## License
 

--- a/config/redirect_policy.yaml
+++ b/config/redirect_policy.yaml
@@ -1,0 +1,9 @@
+redirect_policy:
+  enabled: true
+  prepared_ports:
+    22: 12222
+    80: 18080
+    8080: 18080
+  unsupported_port_action: notify
+  high_risk_unsupported_port_action: isolate
+  scan_burst_action: throttle

--- a/docs/ARSENAL_DEMO_PROFILE.md
+++ b/docs/ARSENAL_DEMO_PROFILE.md
@@ -1,0 +1,86 @@
+# Arsenal Demo Profile
+
+Last updated: 2026-05-14
+
+## 1. Purpose
+
+This demo shows the deterministic edge SOC/NOC decision loop. It is not a full SIEM replacement, not an autonomous AI defender, and not a broad feature tour.
+
+## 2. Demo story
+
+1. Evidence is ingested.
+2. NOC and SOC are evaluated separately.
+3. The Action Arbiter selects a bounded response.
+4. The system records explanation, rejected alternatives, and audit evidence.
+5. The operator inspects the decision and response trace.
+
+## 3. Required components
+
+Mandatory:
+- `azazel-edge-web`
+- `azazel-edge-control-daemon`
+- deterministic replay CLI (`bin/azazel-edge-demo`)
+- `azazel-edge-core` when live Suricata path is included
+- `azazel-edge-opencanary` when redirect behavior is shown
+
+Optional:
+- Mattermost
+- Ollama
+- Aggregator
+- TAXII/STIX
+- SNMP/NetFlow
+- Vector
+- Wazuh
+
+## 4. Demo modes
+
+Replay-only demo (default):
+- safest for Arsenal booth
+- stable evaluator output
+- no dependency on live packet generation
+
+Live-assisted demo:
+- includes Suricata EVE live path
+- must preserve immediate fallback to replay-only mode
+
+## 5. Pre-demo checklist
+
+```bash
+systemctl status azazel-edge-web --no-pager
+systemctl status azazel-edge-control-daemon --no-pager
+systemctl status azazel-edge-core --no-pager
+systemctl status azazel-edge-opencanary --no-pager
+bin/azazel-edge-demo list
+bin/azazel-edge-demo run mixed_correlation_demo
+```
+
+Recommended API sanity checks:
+
+```bash
+TOKEN="$(cat ~/.azazel-edge/web_token.txt)"
+curl -fsS -H "X-AZAZEL-TOKEN: ${TOKEN}" http://127.0.0.1:8084/api/state >/dev/null
+curl -fsS -H "X-AZAZEL-TOKEN: ${TOKEN}" http://127.0.0.1:8084/api/aggregator/nodes >/dev/null || true
+```
+
+## 6. Failure fallback
+
+- Suricata failure: switch to replay-only path immediately.
+- OpenCanary failure: continue replay demo without redirect execution path.
+- Mattermost failure: continue local Web UI + audit walkthrough.
+- Ollama failure: continue deterministic core story (AI assist is optional).
+- Network instability: run local replay scenarios only.
+- Web UI failure: use CLI replay output + JSON logs for deterministic trace.
+
+Final fallback rule:
+- the deterministic replay path must remain the final fallback.
+
+## 7. What not to show first
+
+Do not lead with optional integration tours:
+- Wazuh
+- TAXII/STIX
+- Aggregator fleet view
+- multilingual captive portal
+- vehicle deployment
+
+Lead with deterministic path consistency and bounded action behavior.

--- a/docs/BENCHMARK_DEFINITIONS.md
+++ b/docs/BENCHMARK_DEFINITIONS.md
@@ -30,3 +30,11 @@ The 12% figure has been cited in presentations as a breach-rate estimate.
 The claim requires corpus, enforcement mode, and baseline clarification.
 Until reproducibly measured, treat it as preliminary field observation.
 The `azazel-bench accuracy` command provides reproducible software-path detection metrics.
+
+## Scope boundary
+
+Current repository benchmark outputs are software-only EVE replay benchmarks for deterministic pipeline regression.
+They are not full hardware-in-the-loop forwarding or enforcement performance claims.
+
+See:
+- `docs/BENCHMARK_SCOPE_AND_HIL_PLAN.md`

--- a/docs/BENCHMARK_RESULTS.json
+++ b/docs/BENCHMARK_RESULTS.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-05-14T12:57:24.551930+00:00",
+  "generated_at": "2026-05-14T12:59:11.833583+00:00",
   "benchmark_mode": "software-only-eve-replay",
   "hardware": "software-only",
   "claim_scope": "deterministic pipeline regression",
-  "commit": "f59bd53",
+  "commit": "38f3a6d",
   "test_baseline": "see CI and release notes",
   "os": "macOS-26.5-arm64-arm-64bit",
   "python_version": "3.10.4",
@@ -14,44 +14,44 @@
     "iterations": 200,
     "stages": {
       "T2_eve_parse": {
-        "mean_ms": 0.006,
+        "mean_ms": 0.005,
         "median_ms": 0.005,
-        "p95_ms": 0.007,
-        "p99_ms": 0.032,
+        "p95_ms": 0.005,
+        "p99_ms": 0.006,
         "min_ms": 0.005,
-        "max_ms": 0.035,
-        "stdev_ms": 0.003
+        "max_ms": 0.008,
+        "stdev_ms": 0.0
       },
       "T3_evidence_dispatch": {
-        "mean_ms": 0.018,
-        "median_ms": 0.016,
-        "p95_ms": 0.027,
-        "p99_ms": 0.082,
+        "mean_ms": 0.014,
+        "median_ms": 0.014,
+        "p95_ms": 0.015,
+        "p99_ms": 0.015,
         "min_ms": 0.014,
-        "max_ms": 0.09,
-        "stdev_ms": 0.009
+        "max_ms": 0.017,
+        "stdev_ms": 0.0
       },
       "T4_evaluators": {
-        "mean_ms": 0.2,
-        "median_ms": 0.191,
-        "p95_ms": 0.256,
-        "p99_ms": 0.369,
-        "min_ms": 0.18,
-        "max_ms": 0.512,
-        "stdev_ms": 0.036
+        "mean_ms": 0.178,
+        "median_ms": 0.176,
+        "p95_ms": 0.194,
+        "p99_ms": 0.218,
+        "min_ms": 0.173,
+        "max_ms": 0.229,
+        "stdev_ms": 0.008
       },
       "T5_arbiter": {
-        "mean_ms": 0.013,
-        "median_ms": 0.012,
-        "p95_ms": 0.015,
-        "p99_ms": 0.06,
+        "mean_ms": 0.011,
+        "median_ms": 0.011,
+        "p95_ms": 0.012,
+        "p99_ms": 0.017,
         "min_ms": 0.011,
-        "max_ms": 0.073,
-        "stdev_ms": 0.006
+        "max_ms": 0.019,
+        "stdev_ms": 0.001
       }
     },
-    "total_pipeline_mean_ms": 0.237,
-    "total_pipeline_p95_ms": 0.305
+    "total_pipeline_mean_ms": 0.208,
+    "total_pipeline_p95_ms": 0.226
   },
   "accuracy": {
     "corpus_path": "tests/benchmark/corpus",

--- a/docs/BENCHMARK_RESULTS.json
+++ b/docs/BENCHMARK_RESULTS.json
@@ -1,8 +1,10 @@
 {
-  "generated_at": "2026-05-13T11:58:48.985971+00:00",
-  "hardware": "TBD",
-  "commit": "1707a88",
-  "test_baseline": "328 passed, 62 subtests passed",
+  "generated_at": "2026-05-14T12:57:24.551930+00:00",
+  "benchmark_mode": "software-only-eve-replay",
+  "hardware": "software-only",
+  "claim_scope": "deterministic pipeline regression",
+  "commit": "f59bd53",
+  "test_baseline": "see CI and release notes",
   "os": "macOS-26.5-arm64-arm-64bit",
   "python_version": "3.10.4",
   "suricata_version": "TBD",
@@ -12,44 +14,44 @@
     "iterations": 200,
     "stages": {
       "T2_eve_parse": {
-        "mean_ms": 0.005,
+        "mean_ms": 0.006,
         "median_ms": 0.005,
-        "p95_ms": 0.005,
-        "p99_ms": 0.009,
+        "p95_ms": 0.007,
+        "p99_ms": 0.032,
         "min_ms": 0.005,
-        "max_ms": 0.017,
-        "stdev_ms": 0.001
+        "max_ms": 0.035,
+        "stdev_ms": 0.003
       },
       "T3_evidence_dispatch": {
-        "mean_ms": 0.015,
-        "median_ms": 0.014,
-        "p95_ms": 0.015,
-        "p99_ms": 0.023,
+        "mean_ms": 0.018,
+        "median_ms": 0.016,
+        "p95_ms": 0.027,
+        "p99_ms": 0.082,
         "min_ms": 0.014,
-        "max_ms": 0.028,
-        "stdev_ms": 0.001
+        "max_ms": 0.09,
+        "stdev_ms": 0.009
       },
       "T4_evaluators": {
-        "mean_ms": 0.18,
-        "median_ms": 0.178,
-        "p95_ms": 0.191,
-        "p99_ms": 0.226,
-        "min_ms": 0.175,
-        "max_ms": 0.301,
-        "stdev_ms": 0.011
+        "mean_ms": 0.2,
+        "median_ms": 0.191,
+        "p95_ms": 0.256,
+        "p99_ms": 0.369,
+        "min_ms": 0.18,
+        "max_ms": 0.512,
+        "stdev_ms": 0.036
       },
       "T5_arbiter": {
-        "mean_ms": 0.011,
-        "median_ms": 0.011,
-        "p95_ms": 0.012,
-        "p99_ms": 0.016,
+        "mean_ms": 0.013,
+        "median_ms": 0.012,
+        "p95_ms": 0.015,
+        "p99_ms": 0.06,
         "min_ms": 0.011,
-        "max_ms": 0.017,
-        "stdev_ms": 0.001
+        "max_ms": 0.073,
+        "stdev_ms": 0.006
       }
     },
-    "total_pipeline_mean_ms": 0.211,
-    "total_pipeline_p95_ms": 0.223
+    "total_pipeline_mean_ms": 0.237,
+    "total_pipeline_p95_ms": 0.305
   },
   "accuracy": {
     "corpus_path": "tests/benchmark/corpus",

--- a/docs/BENCHMARK_RESULTS.md
+++ b/docs/BENCHMARK_RESULTS.md
@@ -1,10 +1,10 @@
 # Azazel-Edge Benchmark Results
 
-Generated: 2026-05-14T12:57:24.551930+00:00  
+Generated: 2026-05-14T12:59:11.833583+00:00  
 Hardware: software-only  
 Benchmark mode: software-only-eve-replay  
 Claim scope: deterministic pipeline regression  
-Commit: f59bd53  
+Commit: 38f3a6d  
 Test suite baseline: see CI and release notes
 
 ---
@@ -13,12 +13,12 @@ Test suite baseline: see CI and release notes
 
 | Stage | Mean (ms) | Median (ms) | p95 (ms) | p99 (ms) |
 |---|---|---|---|---|
-| T2_eve_parse | 0.006 | 0.005 | 0.007 | 0.032 |
-| T3_evidence_dispatch | 0.018 | 0.016 | 0.027 | 0.082 |
-| T4_evaluators | 0.2 | 0.191 | 0.256 | 0.369 |
-| T5_arbiter | 0.013 | 0.012 | 0.015 | 0.06 |
+| T2_eve_parse | 0.005 | 0.005 | 0.005 | 0.006 |
+| T3_evidence_dispatch | 0.014 | 0.014 | 0.015 | 0.015 |
+| T4_evaluators | 0.178 | 0.176 | 0.194 | 0.218 |
+| T5_arbiter | 0.011 | 0.011 | 0.012 | 0.017 |
 
-Total pipeline p95: 0.305 ms
+Total pipeline p95: 0.226 ms
 
 ## B-3: Detection Accuracy
 

--- a/docs/BENCHMARK_RESULTS.md
+++ b/docs/BENCHMARK_RESULTS.md
@@ -1,9 +1,11 @@
 # Azazel-Edge Benchmark Results
 
-Generated: 2026-05-13T11:58:48.985971+00:00  
-Hardware: TBD  
-Commit: 1707a88  
-Test suite baseline: 328 passed, 62 subtests passed
+Generated: 2026-05-14T12:57:24.551930+00:00  
+Hardware: software-only  
+Benchmark mode: software-only-eve-replay  
+Claim scope: deterministic pipeline regression  
+Commit: f59bd53  
+Test suite baseline: see CI and release notes
 
 ---
 
@@ -11,12 +13,12 @@ Test suite baseline: 328 passed, 62 subtests passed
 
 | Stage | Mean (ms) | Median (ms) | p95 (ms) | p99 (ms) |
 |---|---|---|---|---|
-| T2_eve_parse | 0.005 | 0.005 | 0.005 | 0.009 |
-| T3_evidence_dispatch | 0.015 | 0.014 | 0.015 | 0.023 |
-| T4_evaluators | 0.18 | 0.178 | 0.191 | 0.226 |
-| T5_arbiter | 0.011 | 0.011 | 0.012 | 0.016 |
+| T2_eve_parse | 0.006 | 0.005 | 0.007 | 0.032 |
+| T3_evidence_dispatch | 0.018 | 0.016 | 0.027 | 0.082 |
+| T4_evaluators | 0.2 | 0.191 | 0.256 | 0.369 |
+| T5_arbiter | 0.013 | 0.012 | 0.015 | 0.06 |
 
-Total pipeline p95: 0.223 ms
+Total pipeline p95: 0.305 ms
 
 ## B-3: Detection Accuracy
 
@@ -34,5 +36,6 @@ Total pipeline p95: 0.223 ms
 
 ## Notes
 
-- Power and startup hardware benchmarks must be run on Raspberry Pi and updated manually.
-- The 12% breach-rate statement remains preliminary until reproduced with hardware validation.
+- This suite validates deterministic pipeline behavior under software-only EVE replay.
+- It does not claim inline forwarding throughput, live Suricata capture capacity, nftables/tc enforcement latency, OpenCanary redirect realism, or co-located Ollama/Mattermost performance.
+- Power and startup hardware benchmarks must be run on Raspberry Pi hardware-in-the-loop plans.

--- a/docs/BENCHMARK_SCOPE_AND_HIL_PLAN.md
+++ b/docs/BENCHMARK_SCOPE_AND_HIL_PLAN.md
@@ -1,0 +1,55 @@
+# Benchmark Scope Boundary and Hardware-in-the-Loop Plan
+
+Last updated: 2026-05-14
+
+## Current benchmark scope
+
+The current benchmark suite validates deterministic pipeline behavior under software-only EVE replay. It is useful for regression testing and reproducibility.
+
+It does **not** claim:
+- full inline forwarding throughput
+- live Suricata capture capacity
+- nftables/tc enforcement latency
+- OpenCanary interaction realism
+- co-located Ollama/Mattermost performance on Raspberry Pi hardware
+
+## Current benchmark metadata
+
+`bin/azazel-bench report` records:
+- `benchmark_mode`
+- `hardware`
+- `claim_scope`
+
+Default values for v0.1.1 hardening are:
+- `benchmark_mode: software-only-eve-replay`
+- `hardware: software-only`
+- `claim_scope: deterministic pipeline regression`
+
+## Hardware-in-the-loop plan (next stages)
+
+1. Pi 5 clean install startup timing
+- measure service-ready timing for `azazel-edge-web`, `azazel-edge-control-daemon`, and `azazel-edge-core`
+
+2. Suricata live alert ingestion latency
+- measure live alert path from packet capture to normalized event emission
+
+3. nftables/tc apply and rollback latency
+- measure action apply/revert timing for throttle, redirect, isolate plans
+
+4. OpenCanary redirect behavior validation
+- verify protocol-aware redirect mapping behavior against prepared decoys
+
+5. Thermal, memory, and load under Demo profile
+- sustained run with deterministic replay and required demo services
+
+6. Optional Heavy lab profile impact
+- co-located optional integrations (Ollama, Mattermost, Wazuh, Vector, Aggregator, TAXII)
+
+## Validation commands
+
+```bash
+PYTHONPATH=py:. .venv/bin/pytest -q tests/benchmark -v
+bin/azazel-bench pipeline
+bin/azazel-bench accuracy
+bin/azazel-bench report
+```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,10 +5,23 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- (none yet)
+- Protocol-aware redirect policy baseline for prepared decoy services:
+  - redirect mapping by destination port
+  - unsupported-port deterministic fallback action
+  - compatibility fallback to `AZAZEL_DEFENSE_HONEYPOT_PORT` when policy file is absent
+  - enforcement metadata for mapping/fallback traceability
+- Arsenal demo profile runbook (`docs/ARSENAL_DEMO_PROFILE.md`).
+- Deployment profile matrix (`docs/DEPLOYMENT_PROFILES.md`) for constrained hardware clarity.
+- Benchmark scope boundary and hardware-in-the-loop plan (`docs/BENCHMARK_SCOPE_AND_HIL_PLAN.md`).
+- Benchmark report metadata fields:
+  - `benchmark_mode`
+  - `hardware`
+  - `claim_scope`
 
 ### Changed
-- (none yet)
+- README testing/current status wording to avoid stale validation claims.
+- Benchmark report wording to identify software-only EVE replay scope.
+- SOC policy guide updated with prepared decoy redirect model notes.
 
 ## [0.1.0] - 2026-05-13
 

--- a/docs/DEPLOYMENT_PROFILES.md
+++ b/docs/DEPLOYMENT_PROFILES.md
@@ -1,0 +1,35 @@
+# Deployment Profiles
+
+Last updated: 2026-05-14
+
+This matrix separates required deterministic core runtime from optional integrations.
+
+## Profile matrix
+
+| Profile | Purpose | Required components | Optional components | Not recommended by default |
+|---|---|---|---|---|
+| Core | Minimal deterministic edge gateway and decision loop | internal network, Suricata, Rust core, Evidence Plane, NOC/SOC evaluators, Action Arbiter, Web UI/API, audit | OpenCanary | Ollama, Mattermost, Wazuh, Vector, Aggregator |
+| Demo | Arsenal-ready reproducible demonstration | Core + deterministic replay + OpenCanary (if redirect shown) | Mattermost | heavy AI, Wazuh, Vector, broad integration tours |
+| SOC integration | Standards-oriented downstream exchange and enrichment | Core + ATT&CK mapping + TI feed + Sigma + STIX/TAXII | Aggregator | co-located heavy AI on constrained hardware |
+| NOC expansion | Field network observability | Core + Wi-Fi sensors + SNMP + NetFlow | Aggregator | Wazuh/Vector unless resources are validated |
+| Heavy lab | Integration testing and development sandbox | most components enabled for integration verification | Ollama, Mattermost, Wazuh, Vector, Aggregator, TAXII | use as field default on constrained Raspberry Pi |
+
+## Notes per profile
+
+Core profile:
+- preserves Deterministic First with minimal operational risk.
+- suitable default for constrained Raspberry Pi deployment.
+
+Demo profile:
+- optimized for reproducibility over breadth.
+- deterministic replay is the safety baseline.
+
+SOC integration profile:
+- adds standards exchange surfaces without changing core action arbitration logic.
+
+NOC expansion profile:
+- expands observability while keeping core deterministic runtime clear.
+
+Heavy lab profile:
+- useful for integration burn-in and compatibility checks.
+- not equivalent to default field runtime sizing.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,6 +13,7 @@ Entry point for all documents in this directory.
 | [SOC_POLICY_GUIDE.md](SOC_POLICY_GUIDE.md) | Developer / Operator | Deterministic SOC policy tuning and safety constraints | 2026-05-12 |
 | [ATTACK_MAPPING_GUIDE.md](ATTACK_MAPPING_GUIDE.md) | Developer / Operator | ATT&CK mapping rules, limits, and maintenance guidance | 2026-05-12 |
 | [BENCHMARK_DEFINITIONS.md](BENCHMARK_DEFINITIONS.md) | Developer / Operator | Reproducible benchmark definitions for operational, latency, power, and breach metrics | 2026-05-13 |
+| [BENCHMARK_SCOPE_AND_HIL_PLAN.md](BENCHMARK_SCOPE_AND_HIL_PLAN.md) | Developer / Operator | Benchmark claim boundary and staged hardware-in-the-loop plan | 2026-05-14 |
 | [POST_DEMO_MAIN_INTEGRATION_104.md](POST_DEMO_MAIN_INTEGRATION_104.md) | Developer | Integration boundary between exhibition-only assets and mainline | 2026-05-11 |
 | [POST_DEMO_SOCKET_PERMISSION_MODEL_105.md](POST_DEMO_SOCKET_PERMISSION_MODEL_105.md) | Developer | Unix socket permission model decisions | - |
 
@@ -32,6 +33,7 @@ Entry point for all documents in this directory.
 | File | Audience | Description | Last Updated |
 |------|----------|-------------|--------------|
 | [DEMO_GUIDE.md](DEMO_GUIDE.md) | Operator | Deterministic demo replay walkthrough | - |
+| [ARSENAL_DEMO_PROFILE.md](ARSENAL_DEMO_PROFILE.md) | Operator / Presenter | Fixed Black Hat Arsenal demo profile and fallback runbook | 2026-05-14 |
 
 ## Planning and Records
 
@@ -55,6 +57,7 @@ Entry point for all documents in this directory.
 | [FIELD_DEPLOYMENT_GUIDE.md](FIELD_DEPLOYMENT_GUIDE.md) | First responder | Rapid deploy checklist | 2026-05-13 |
 | [VEHICLE_DEPLOYMENT_GUIDE.md](VEHICLE_DEPLOYMENT_GUIDE.md) | Military / Civil defense | Vehicle deployment guide for constrained environments | 2026-05-13 |
 | [WAZUH_INTEGRATION_GUIDE.md](WAZUH_INTEGRATION_GUIDE.md) | Developer / Integrator | Wazuh Agent and Vector integration guide | 2026-05-13 |
+| [DEPLOYMENT_PROFILES.md](DEPLOYMENT_PROFILES.md) | Operator / Deployer | Core/Demo/SOC/NOC/Heavy-lab deployment matrix | 2026-05-14 |
 | [HUMANITARIAN_PARTNER_GUIDE.md](HUMANITARIAN_PARTNER_GUIDE.md) | NGO / International org | Partner onboarding guide | 2026-05-13 |
 | [PRIVACY_AND_LEGAL.md](PRIVACY_AND_LEGAL.md) | Municipal officer / Legal | Data handling and legal basis memo | 2026-05-13 |
 | [MAINTENANCE_CHECKLIST.md](MAINTENANCE_CHECKLIST.md) | Operator / Asset manager | Scheduled maintenance procedures | 2026-05-13 |

--- a/docs/RELEASE_NOTES_v0.1.1_DRAFT.md
+++ b/docs/RELEASE_NOTES_v0.1.1_DRAFT.md
@@ -1,0 +1,51 @@
+# Azazel-Edge v0.1.1 Release Notes (Draft)
+
+## Theme
+
+v0.1.1 is a hardening and readiness release. It improves safety, reproducibility, and external review clarity without introducing a broad new subsystem.
+
+## Highlights
+
+### Runtime correctness
+- Protocol-aware prepared decoy redirect mapping in `azazel-edge-core`.
+- Unsupported destination ports no longer imply blind redirect to a single decoy port.
+- Deterministic fallback actions are explicit and traceable.
+
+### Demo and deployment clarity
+- New Arsenal reproducibility profile: `docs/ARSENAL_DEMO_PROFILE.md`.
+- New deployment profile matrix: `docs/DEPLOYMENT_PROFILES.md`.
+
+### Benchmark claim boundary
+- New benchmark scope boundary and staged hardware-in-the-loop plan:
+  - `docs/BENCHMARK_SCOPE_AND_HIL_PLAN.md`
+- Benchmark report now carries explicit mode/scope metadata.
+
+### Documentation safety updates
+- README status/testing sections aligned to CI/release-trace model.
+- Non-overclaiming language reinforced:
+  - not a production SIEM replacement
+  - not an autonomous AI defender
+
+## Scope boundaries
+
+- Deterministic First remains unchanged.
+- AI remains optional and bounded.
+- Fail-safe enforcement gates remain in place.
+- This release does not claim full hardware-in-the-loop forwarding or enforcement performance.
+
+## Validation checklist (release candidate)
+
+```bash
+PYTHONPATH=py:. .venv/bin/pytest -q
+PYTHONPATH=py:. .venv/bin/pytest -q tests/benchmark -v
+bin/azazel-bench pipeline
+bin/azazel-bench accuracy
+bin/azazel-bench report
+```
+
+If Rust toolchain is available:
+
+```bash
+cd rust/azazel-edge-core
+cargo test
+```

--- a/docs/SOC_POLICY_GUIDE.md
+++ b/docs/SOC_POLICY_GUIDE.md
@@ -39,3 +39,32 @@ Use the dry-run helper to evaluate local normalized events without changing enfo
 ```bash
 bin/azazel-soc-policy-dry-run --policy config/soc_policy.yaml --events /var/log/azazel-edge/normalized-events.jsonl --limit 200
 ```
+
+## Redirect safety policy (v0.1.1 hardening)
+
+Runtime redirect planning in `azazel-edge-core` supports protocol-aware mapping via:
+- `config/redirect_policy.yaml`
+- override with `AZAZEL_REDIRECT_POLICY_PATH`
+
+Example:
+
+```yaml
+redirect_policy:
+  enabled: true
+  prepared_ports:
+    22: 12222
+    80: 18080
+    8080: 18080
+  unsupported_port_action: notify
+  high_risk_unsupported_port_action: isolate
+  scan_burst_action: throttle
+```
+
+Behavior:
+- If mapping exists, redirect uses the prepared decoy port.
+- If destination port is unsupported, action falls back deterministically (`notify`, `throttle`, `isolate`, or explicit `observe`) instead of blind redirect.
+- If policy file is absent, runtime keeps backward compatibility with `AZAZEL_DEFENSE_HONEYPOT_PORT` and marks fallback in enforcement metadata.
+
+Important:
+
+Azazel-Edge does not generate a new decoy for every event. On constrained hardware, prepared lightweight decoys are kept ready, and suspicious flows are redirected only when a protocol-aware mapping exists.

--- a/py/azazel_edge/benchmark/report.py
+++ b/py/azazel_edge/benchmark/report.py
@@ -43,9 +43,11 @@ def generate(output_dir: Path) -> Dict[str, Any]:
 
     data: Dict[str, Any] = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "hardware": os.environ.get("AZAZEL_BENCH_HARDWARE", "TBD"),
+        "benchmark_mode": os.environ.get("AZAZEL_BENCH_MODE", "software-only-eve-replay"),
+        "hardware": os.environ.get("AZAZEL_BENCH_HARDWARE", "software-only"),
+        "claim_scope": os.environ.get("AZAZEL_BENCH_CLAIM_SCOPE", "deterministic pipeline regression"),
         "commit": _git_commit(),
-        "test_baseline": "328 passed, 62 subtests passed",
+        "test_baseline": os.environ.get("AZAZEL_BENCH_TEST_BASELINE", "see CI and release notes"),
         "os": platform.platform(),
         "python_version": platform.python_version(),
         "suricata_version": os.environ.get("AZAZEL_BENCH_SURICATA", "TBD"),
@@ -61,6 +63,8 @@ def generate(output_dir: Path) -> Dict[str, Any]:
 
 Generated: {data['generated_at']}  
 Hardware: {data['hardware']}  
+Benchmark mode: {data['benchmark_mode']}  
+Claim scope: {data['claim_scope']}  
 Commit: {data['commit']}  
 Test suite baseline: {data['test_baseline']}
 
@@ -84,8 +88,9 @@ Total pipeline p95: {data['pipeline'].get('total_pipeline_p95_ms', 'n/a')} ms
 
 ## Notes
 
-- Power and startup hardware benchmarks must be run on Raspberry Pi and updated manually.
-- The 12% breach-rate statement remains preliminary until reproduced with hardware validation.
+- This suite validates deterministic pipeline behavior under software-only EVE replay.
+- It does not claim inline forwarding throughput, live Suricata capture capacity, nftables/tc enforcement latency, OpenCanary redirect realism, or co-located Ollama/Mattermost performance.
+- Power and startup hardware benchmarks must be run on Raspberry Pi hardware-in-the-loop plans.
 """
     (output_dir / "BENCHMARK_RESULTS.md").write_text(md, encoding="utf-8")
     return data

--- a/rust/azazel-edge-core/Cargo.toml
+++ b/rust/azazel-edge-core/Cargo.toml
@@ -8,3 +8,4 @@ license = "MIT"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"

--- a/rust/azazel-edge-core/src/main.rs
+++ b/rust/azazel-edge-core/src/main.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::env;
 use std::fs::{self, File, OpenOptions};
@@ -27,6 +28,9 @@ struct Config {
     defense_allow_high_impact_auto: bool,
     defense_iface: String,
     defense_honeypot_port: u16,
+    redirect_policy_path: String,
+    redirect_policy: Option<RedirectPolicyConfig>,
+    redirect_policy_source: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -87,6 +91,55 @@ struct EnforcementOutcome {
     errors: Vec<String>,
     rollback_hint: String,
     result: String,
+    metadata: Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RedirectPolicyRoot {
+    redirect_policy: Option<RedirectPolicyConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RedirectPolicyConfig {
+    #[serde(default)]
+    enabled: bool,
+    #[serde(default)]
+    prepared_ports: HashMap<u16, u16>,
+    #[serde(default = "default_notify")]
+    unsupported_port_action: String,
+    #[serde(default = "default_isolate")]
+    high_risk_unsupported_port_action: String,
+    #[serde(default = "default_throttle")]
+    scan_burst_action: String,
+}
+
+fn default_notify() -> String {
+    "notify".to_string()
+}
+
+fn default_isolate() -> String {
+    "isolate".to_string()
+}
+
+fn default_throttle() -> String {
+    "throttle".to_string()
+}
+
+fn normalize_safe_action(raw: &str, default_action: &str) -> String {
+    match raw.to_ascii_lowercase().as_str() {
+        "observe" | "notify" | "throttle" | "redirect" | "isolate" => raw.to_ascii_lowercase(),
+        _ => default_action.to_string(),
+    }
+}
+
+fn load_redirect_policy(path: &str) -> Result<Option<RedirectPolicyConfig>, String> {
+    let source = Path::new(path);
+    if !source.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(source).map_err(|e| format!("redirect_policy_read_failed:{}", e))?;
+    let parsed: RedirectPolicyRoot = serde_yaml::from_str(&raw).map_err(|e| format!("redirect_policy_parse_failed:{}", e))?;
+    Ok(parsed.redirect_policy)
 }
 
 fn now_epoch() -> f64 {
@@ -111,6 +164,16 @@ fn load_config() -> Config {
             from_start = true;
         }
     }
+
+    let redirect_policy_path = env::var("AZAZEL_REDIRECT_POLICY_PATH").unwrap_or_else(|_| "config/redirect_policy.yaml".to_string());
+    let (redirect_policy, redirect_policy_source) = match load_redirect_policy(&redirect_policy_path) {
+        Ok(Some(policy)) => (Some(policy), format!("file:{}", redirect_policy_path)),
+        Ok(None) => (None, "env_honeypot_fallback".to_string()),
+        Err(e) => {
+            eprintln!("redirect policy load failed, using honeypot fallback: {}", e);
+            (None, format!("invalid_file_env_fallback:{}", redirect_policy_path))
+        }
+    };
 
     Config {
         eve_path: env::var("AZAZEL_EVE_PATH").unwrap_or_else(|_| "/var/log/suricata/eve.json".to_string()),
@@ -137,6 +200,9 @@ fn load_config() -> Config {
             .ok()
             .and_then(|v| v.parse::<u16>().ok())
             .unwrap_or(2222),
+        redirect_policy_path,
+        redirect_policy,
+        redirect_policy_source,
     }
 }
 
@@ -363,15 +429,21 @@ fn should_execute_action(action: &str, cfg: &Config) -> (bool, String) {
 
 fn maybe_enforce(ev: &NormalizedEvent, decision: &DefensiveDecision, cfg: &Config) -> EnforcementOutcome {
     let trace_id = calc_trace_id(ev, decision);
-    let plan = build_enforcement_plan(ev, decision, &cfg.defense_iface, cfg.defense_honeypot_port);
+    let (effective_decision, redirect_meta) = resolve_redirect_decision(ev, decision, cfg);
+    let selected_decoy_port = redirect_meta
+        .get("selected_decoy_port")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u16)
+        .unwrap_or(cfg.defense_honeypot_port);
+    let plan = build_enforcement_plan(ev, &effective_decision, &cfg.defense_iface, selected_decoy_port);
 
     if plan.apply_commands.is_empty() {
         return EnforcementOutcome {
             mode: "disabled".to_string(),
             trace_id,
-            selected_action: decision.action.clone(),
-            target: decision.target.clone(),
-            policy_reason: decision.policy_reason.clone(),
+            selected_action: effective_decision.action.clone(),
+            target: effective_decision.target.clone(),
+            policy_reason: effective_decision.policy_reason.clone(),
             command_plan: plan.apply_commands.clone(),
             rollback_plan: plan.rollback_commands.clone(),
             executed_count: 0,
@@ -379,17 +451,18 @@ fn maybe_enforce(ev: &NormalizedEvent, decision: &DefensiveDecision, cfg: &Confi
             errors: Vec::new(),
             rollback_hint: "no_runtime_change".to_string(),
             result: "no_disruptive_action".to_string(),
+            metadata: redirect_meta,
         };
     }
 
-    let (allowed_by_policy, policy_gate_reason) = should_execute_action(&decision.action, cfg);
+    let (allowed_by_policy, policy_gate_reason) = should_execute_action(&effective_decision.action, cfg);
     if cfg.defense_dry_run || !allowed_by_policy {
         return EnforcementOutcome {
             mode: if cfg.defense_dry_run { "dry_run".to_string() } else { "policy_gated".to_string() },
             trace_id,
-            selected_action: decision.action.clone(),
-            target: decision.target.clone(),
-            policy_reason: format!("{}:{}", decision.policy_reason, policy_gate_reason),
+            selected_action: effective_decision.action.clone(),
+            target: effective_decision.target.clone(),
+            policy_reason: format!("{}:{}", effective_decision.policy_reason, policy_gate_reason),
             command_plan: plan.apply_commands.clone(),
             rollback_plan: plan.rollback_commands.clone(),
             executed_count: 0,
@@ -397,6 +470,7 @@ fn maybe_enforce(ev: &NormalizedEvent, decision: &DefensiveDecision, cfg: &Confi
             errors: Vec::new(),
             rollback_hint: "set AZAZEL_DEFENSE_ENFORCE_LEVEL=full-auto or explicit high-impact approval policy".to_string(),
             result: "planned_not_applied".to_string(),
+            metadata: redirect_meta,
         };
     }
 
@@ -417,9 +491,9 @@ fn maybe_enforce(ev: &NormalizedEvent, decision: &DefensiveDecision, cfg: &Confi
     EnforcementOutcome {
         mode: "enforced".to_string(),
         trace_id,
-        selected_action: decision.action.clone(),
-        target: decision.target.clone(),
-        policy_reason: decision.policy_reason.clone(),
+        selected_action: effective_decision.action.clone(),
+        target: effective_decision.target.clone(),
+        policy_reason: effective_decision.policy_reason.clone(),
         command_plan: plan.apply_commands,
         rollback_plan: plan.rollback_commands,
         executed_count,
@@ -427,6 +501,62 @@ fn maybe_enforce(ev: &NormalizedEvent, decision: &DefensiveDecision, cfg: &Confi
         errors,
         rollback_hint: format!("temporary action ttl={}s; execute rollback_plan when control is no longer needed", cfg.defense_action_ttl_sec),
         result: if failed_count > 0 { "partial_failure".to_string() } else { "applied".to_string() },
+        metadata: redirect_meta,
+    }
+}
+
+fn resolve_redirect_decision(ev: &NormalizedEvent, decision: &DefensiveDecision, cfg: &Config) -> (DefensiveDecision, Value) {
+    let mut metadata = json!({
+        "original_dst_port": ev.target_port,
+        "selected_decoy_port": Value::Null,
+        "redirect_policy_source": cfg.redirect_policy_source,
+        "redirect_mapping_matched": false,
+        "unsupported_port_fallback": "",
+        "fallback_reason": "",
+    });
+    if decision.action != "redirect" {
+        return (decision.clone(), metadata);
+    }
+
+    match &cfg.redirect_policy {
+        Some(policy) => {
+            if !policy.enabled {
+                metadata["selected_decoy_port"] = json!(cfg.defense_honeypot_port);
+                metadata["redirect_mapping_matched"] = json!(true);
+                metadata["fallback_reason"] = json!("policy_disabled_env_honeypot_fallback");
+                return (decision.clone(), metadata);
+            }
+            if let Some(mapped) = policy.prepared_ports.get(&ev.target_port) {
+                metadata["selected_decoy_port"] = json!(mapped);
+                metadata["redirect_mapping_matched"] = json!(true);
+                metadata["fallback_reason"] = json!("prepared_mapping");
+                return (decision.clone(), metadata);
+            }
+
+            let high_risk = ev.risk_score >= 80 || ev.severity <= 2;
+            let fallback = if high_risk {
+                normalize_safe_action(&policy.high_risk_unsupported_port_action, "isolate")
+            } else {
+                normalize_safe_action(&policy.unsupported_port_action, "notify")
+            };
+            metadata["unsupported_port_fallback"] = json!(fallback.clone());
+            metadata["fallback_reason"] = json!(if high_risk {
+                "unsupported_port_high_risk"
+            } else {
+                "unsupported_port_default"
+            });
+            let mut adjusted = decision.clone();
+            adjusted.action = fallback.clone();
+            adjusted.policy_reason = format!("{}:{}", decision.policy_reason, metadata["fallback_reason"].as_str().unwrap_or("unsupported_port"));
+            adjusted.reason = format!("{}; unsupported port={} fallback={}", decision.reason, ev.target_port, fallback);
+            return (adjusted, metadata);
+        }
+        None => {
+            metadata["selected_decoy_port"] = json!(cfg.defense_honeypot_port);
+            metadata["redirect_mapping_matched"] = json!(true);
+            metadata["fallback_reason"] = json!("no_redirect_policy_file_env_honeypot_fallback");
+            (decision.clone(), metadata)
+        }
     }
 }
 
@@ -585,11 +715,14 @@ mod tests {
             defense_dry_run: true,
             defense_enforce_level: "advisory".to_string(),
             defense_action_ttl_sec: 300,
-            defense_allow_high_impact_auto: false,
-            defense_iface: "br0".to_string(),
-            defense_honeypot_port: 2222,
-        }
+        defense_allow_high_impact_auto: false,
+        defense_iface: "br0".to_string(),
+        defense_honeypot_port: 2222,
+        redirect_policy_path: "config/redirect_policy.yaml".to_string(),
+        redirect_policy: None,
+        redirect_policy_source: "env_honeypot_fallback".to_string(),
     }
+}
 
     #[test]
     fn build_enforcement_plan_for_critical_event() {
@@ -642,5 +775,109 @@ mod tests {
         assert!(allowed.contains(&"throttle".to_string()));
         assert!(allowed.contains(&"redirect".to_string()));
         assert!(allowed.contains(&"isolate".to_string()));
+    }
+
+    fn cfg_with_redirect_policy() -> Config {
+        let mut cfg = sample_cfg();
+        cfg.redirect_policy = Some(RedirectPolicyConfig {
+            enabled: true,
+            prepared_ports: HashMap::from([(22_u16, 12222_u16), (80_u16, 18080_u16), (8080_u16, 18080_u16)]),
+            unsupported_port_action: "notify".to_string(),
+            high_risk_unsupported_port_action: "isolate".to_string(),
+            scan_burst_action: "throttle".to_string(),
+        });
+        cfg.redirect_policy_source = "file:config/redirect_policy.yaml".to_string();
+        cfg
+    }
+
+    #[test]
+    fn mapped_ssh_redirect_uses_prepared_port() {
+        let mut ev = sample_event();
+        ev.severity = 2;
+        ev.target_port = 22;
+        let decision = decide_defense(&ev);
+        assert_eq!(decision.action, "redirect");
+        let cfg = cfg_with_redirect_policy();
+        let outcome = maybe_enforce(&ev, &decision, &cfg);
+        assert_eq!(outcome.selected_action, "redirect");
+        assert!(outcome.command_plan.join("\n").contains("to 12222"));
+        assert_eq!(outcome.metadata.get("redirect_mapping_matched").and_then(|v| v.as_bool()), Some(true));
+    }
+
+    #[test]
+    fn mapped_http_redirect_uses_prepared_port() {
+        let mut ev = sample_event();
+        ev.severity = 2;
+        ev.target_port = 80;
+        let decision = decide_defense(&ev);
+        let cfg = cfg_with_redirect_policy();
+        let outcome = maybe_enforce(&ev, &decision, &cfg);
+        assert_eq!(outcome.selected_action, "redirect");
+        assert!(outcome.command_plan.join("\n").contains("to 18080"));
+    }
+
+    #[test]
+    fn unsupported_port_falls_back_to_notify() {
+        let mut ev = sample_event();
+        ev.severity = 2;
+        ev.target_port = 5432;
+        ev.risk_score = 40;
+        let decision = decide_defense(&ev);
+        let cfg = cfg_with_redirect_policy();
+        let outcome = maybe_enforce(&ev, &decision, &cfg);
+        assert_eq!(outcome.selected_action, "notify");
+        assert!(outcome.command_plan.is_empty());
+        assert_eq!(outcome.metadata.get("unsupported_port_fallback").and_then(|v| v.as_str()), Some("notify"));
+    }
+
+    #[test]
+    fn unsupported_high_risk_port_can_fallback_to_isolate() {
+        let mut ev = sample_event();
+        ev.severity = 2;
+        ev.target_port = 5432;
+        ev.risk_score = 95;
+        let decision = decide_defense(&ev);
+        let cfg = cfg_with_redirect_policy();
+        let outcome = maybe_enforce(&ev, &decision, &cfg);
+        assert_eq!(outcome.selected_action, "isolate");
+        assert!(outcome.command_plan.join("\n").contains("input"));
+        assert_eq!(outcome.metadata.get("unsupported_port_fallback").and_then(|v| v.as_str()), Some("isolate"));
+    }
+
+    #[test]
+    fn invalid_redirect_policy_is_rejected() {
+        let parsed = serde_yaml::from_str::<RedirectPolicyRoot>("redirect_policy: [invalid");
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn missing_redirect_policy_falls_back_to_honeypot_env() {
+        let mut ev = sample_event();
+        ev.severity = 2;
+        ev.target_port = 2222;
+        let decision = decide_defense(&ev);
+        let mut cfg = sample_cfg();
+        cfg.redirect_policy = None;
+        cfg.redirect_policy_source = "env_honeypot_fallback".to_string();
+        cfg.defense_honeypot_port = 2222;
+        let outcome = maybe_enforce(&ev, &decision, &cfg);
+        assert_eq!(outcome.selected_action, "redirect");
+        assert!(outcome.command_plan.join("\n").contains("to 2222"));
+    }
+
+    #[test]
+    fn enforcement_gate_still_blocks_high_impact_redirect() {
+        let mut ev = sample_event();
+        ev.severity = 2;
+        ev.target_port = 22;
+        let decision = decide_defense(&ev);
+        let mut cfg = cfg_with_redirect_policy();
+        cfg.defense_enforce = true;
+        cfg.defense_dry_run = false;
+        cfg.defense_enforce_level = "semi-auto".to_string();
+        cfg.defense_allow_high_impact_auto = false;
+        let outcome = maybe_enforce(&ev, &decision, &cfg);
+        assert_eq!(outcome.mode, "policy_gated");
+        assert_eq!(outcome.executed_count, 0);
     }
 }

--- a/rust/azazel-edge-core/src/main.rs
+++ b/rust/azazel-edge-core/src/main.rs
@@ -533,7 +533,7 @@ fn resolve_redirect_decision(ev: &NormalizedEvent, decision: &DefensiveDecision,
                 return (decision.clone(), metadata);
             }
 
-            let high_risk = ev.risk_score >= 80 || ev.severity <= 2;
+            let high_risk = ev.risk_score >= 80 || ev.severity >= 4;
             let fallback = if high_risk {
                 normalize_safe_action(&policy.high_risk_unsupported_port_action, "isolate")
             } else {


### PR DESCRIPTION
## Summary
- implement protocol-aware redirect policy with deterministic fallback and enforcement metadata
- add Arsenal demo reproducibility profile
- add constrained hardware deployment profile matrix
- clarify benchmark claim scope and add HIL validation plan
- update README/docs index/changelog and add v0.1.1 release note draft

## Linked issues
- Closes #252
- Closes #253
- Closes #254
- Closes #255
- Closes #256
- Relates #251

## Validation
- [x] `PYTHONPATH=py:. .venv/bin/pytest -q`
- [x] `PYTHONPATH=py:. .venv/bin/pytest -q tests/benchmark -v`
- [x] `bin/azazel-bench pipeline`
- [x] `bin/azazel-bench accuracy`
- [x] `bin/azazel-bench report`
- [ ] `cargo test` (local Rust toolchain unavailable; run in CI)

## Deterministic/Fail-safe checks
- deterministic evaluator/arbiter path unchanged
- protocol-aware redirect avoids unsupported-port blind redirect
- enforcement gates preserved (`AZAZEL_DEFENSE_ENFORCE`, `AZAZEL_DEFENSE_DRY_RUN`, `AZAZEL_DEFENSE_ENFORCE_LEVEL`, `AZAZEL_DEFENSE_ALLOW_HIGH_IMPACT_AUTO`)
- optional integrations remain optional in docs/profile matrix
