### PR TITLE
docs(docs): add concept profiles, arsenal history, and core architecture structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,11 @@ Status guidance:
 
 ## Documentation
 
+Azazel-Edge is documented as a single core platform with multiple operational concept profiles.
+- [Concept Profiles](docs/concepts/evolution-map.md)
+- [Arsenal Demonstrations](docs/arsenal/README.md)
+- [Core Architecture](docs/architecture/decision-loop.md)
+
 ### For operators
 
 | Document | Description |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -8,6 +8,9 @@ Entry point for all documents in this directory.
 
 | File | Audience | Description | Last Updated |
 |------|----------|-------------|--------------|
+| [concepts/evolution-map.md](concepts/evolution-map.md) | Operator / Developer | Concept profile map for a single Azazel-Edge core platform | 2026-05-16 |
+| [arsenal/README.md](arsenal/README.md) | Operator / Presenter | Public Black Hat Arsenal history and policy | 2026-05-16 |
+| [architecture/decision-loop.md](architecture/decision-loop.md) | Developer / Operator | Stable deterministic decision loop overview | 2026-05-16 |
 | [P0_RUNTIME_ARCHITECTURE.md](P0_RUNTIME_ARCHITECTURE.md) | Developer | Decision pipeline, implementation modules, and P0 constraints | 2026-03-10 |
 | [AZAZEL_AGGREGATOR_ARCHITECTURE.md](AZAZEL_AGGREGATOR_ARCHITECTURE.md) | Developer / Operator | Multi-node Azazel Aggregator design baseline and phased roadmap | 2026-05-12 |
 | [SOC_POLICY_GUIDE.md](SOC_POLICY_GUIDE.md) | Developer / Operator | Deterministic SOC policy tuning and safety constraints | 2026-05-12 |

--- a/docs/architecture/deception-routing.md
+++ b/docs/architecture/deception-routing.md
@@ -1,0 +1,31 @@
+# Deception Routing
+
+## Scope
+This document describes how Azazel-Edge uses bounded, policy-driven routing choices when suspicious activity is observed.
+
+## Decision Modes
+- Observe: record and continue monitoring when risk is below active-control thresholds.
+- Throttle: reduce traffic pace when service continuity is preferred over immediate isolation.
+- Redirect: move selected traffic toward prepared decoy surfaces when mapping and safety checks permit.
+- Isolate: apply strongest containment posture when risk and policy require it.
+
+## OpenCanary Role
+Prepared decoy services (for example OpenCanary) support redirect scenarios. Decoys are pre-positioned so constrained edge nodes can use deception routing without dynamic heavy provisioning.
+
+## Blocking vs Delaying vs Redirecting
+- Blocking/isolation: stop or contain connectivity to reduce immediate exposure.
+- Delaying/throttling: preserve partial service while reducing attack velocity.
+- Redirecting: preserve visibility and reduce direct asset exposure by diverting specific flows.
+
+## Safety Constraints and Release Conditions
+| Control | Status | Notes |
+|---|---|---|
+| Policy-gated action selection | Implemented | Arbiter selects only bounded actions. |
+| Dry-run-first enforcement model | Implemented | Enforce mode is guarded by runtime configuration. |
+| Redirect eligibility constraints | Implemented | Redirect path requires prepared mapping and runtime support. |
+| Automated release-condition orchestration | Planned | Formal multi-condition release automation is not fully generalized. |
+
+## Related Documents
+- [Decision Loop](decision-loop.md)
+- [SOC Policy Guide](../SOC_POLICY_GUIDE.md)
+- [Concept: Field-Deployable Scapegoat Gateway](../concepts/field-deployable-scapegoat-gateway.md)

--- a/docs/architecture/decision-loop.md
+++ b/docs/architecture/decision-loop.md
@@ -1,0 +1,33 @@
+# Decision Loop
+
+## Scope
+This document describes the stable deterministic path used by Azazel-Edge to convert edge telemetry into explicit operator-facing actions.
+
+## Pipeline
+1. Event input (for example Suricata EVE and local probes) is received.
+2. Inputs are normalized into Evidence Plane records.
+3. NOC and SOC evaluators score state deterministically.
+4. Policy thresholds are applied.
+5. Action Arbiter selects one bounded action.
+6. Decision Explanation is generated with rationale and alternatives.
+7. Notification and optional AI assist are executed post-decision.
+8. Audit logging records the full trace.
+
+## Stable Components
+| Component | Status | Notes |
+|---|---|---|
+| Evidence normalization | Implemented | Evidence Plane schema and bus are part of runtime baseline. |
+| Deterministic evaluators | Implemented | NOC and SOC remain separate evaluators. |
+| Policy-based action selection | Implemented | Arbiter action set is bounded. |
+| Reversible control posture | Implemented | Actions are explicit and operator-reviewable. |
+| Reproducibility metadata (`config hash`) | Planned | Partial support exists; full packaging across all outputs is still maturing. |
+
+## Safety Constraints
+- Deterministic path remains authoritative.
+- AI assist is optional and invoked only after deterministic decision stages.
+- Fail-closed defaults are retained for protected API behavior.
+
+## Related Documents
+- [P0 Runtime Architecture](../P0_RUNTIME_ARCHITECTURE.md)
+- [Evidence Model](evidence-model.md)
+- [Local AI Triage](local-ai-triage.md)

--- a/docs/architecture/evidence-model.md
+++ b/docs/architecture/evidence-model.md
@@ -1,0 +1,30 @@
+# Evidence Model
+
+## Scope
+This document describes how Azazel-Edge keeps compact, reviewable evidence for deterministic SOC/NOC decision support.
+
+## Evidence Objects
+- Event records: normalized telemetry inputs with source and trace correlation.
+- Decision logs: evaluator and arbiter outputs with selected action rationale.
+- Action records: operator-facing control intent and resulting state changes.
+- Incident bundles: grouped evidence context for handoff or review.
+
+## Auditability
+Evidence records are designed to preserve traceability from observed input to selected action and explanation. `trace_id` continuity is required across stages.
+
+## Raw Logs vs Compact Evidence
+- Raw logs preserve original upstream detail and transport context.
+- Compact evidence normalizes key fields for reproducible deterministic evaluation and operator review.
+
+## Export Model
+| Capability | Status | Notes |
+|---|---|---|
+| Normalized evidence records | Implemented | Evidence Plane schemas and buses exist in runtime modules. |
+| Decision explanation records | Implemented | Explanation fields are part of deterministic path expectations. |
+| Audit log event stream | Implemented | Baseline audit logger is included in runtime. |
+| Unified incident bundle package format | Planned | Partial export paths exist; unified operator package remains in progress. |
+
+## Related Documents
+- [Decision Loop](decision-loop.md)
+- [P0 Runtime Architecture](../P0_RUNTIME_ARCHITECTURE.md)
+- [Concept: Auditable Edge SOC/NOC](../concepts/auditable-edge-socnoc.md)

--- a/docs/architecture/local-ai-triage.md
+++ b/docs/architecture/local-ai-triage.md
@@ -1,0 +1,33 @@
+# Local AI Triage
+
+## Scope
+This document defines the optional local AI assist role in Azazel-Edge.
+
+## Design Position
+- Local-first operation is the default design goal.
+- Cloud dependency is not required for core deterministic behavior.
+- AI assist is governed and secondary to deterministic evaluators and arbiter.
+
+## Supported Uses
+- Summarization of deterministic outputs
+- Operator-facing explanation support
+- Triage hints and candidate next checks
+- Runbook suggestion support
+
+## Boundaries
+| Boundary | Status | Notes |
+|---|---|---|
+| AI assist through governance entrypoint | Implemented | Governed path is required for in-scope AI calls. |
+| Output type limits (`advice/summary/candidate`) | Implemented | Governance constraints are explicit. |
+| AI as final action authority | Not allowed | Action decisions stay in deterministic control path. |
+| Broad autonomous execution | Not allowed | Controlled execution requires explicit approval design. |
+
+## Limitations
+- AI response quality depends on local model/runtime availability.
+- AI downtime must not block deterministic operation.
+- High-cost models are not default for constrained co-located Raspberry Pi deployments.
+
+## Related Documents
+- [AI Operation Guide](../AI_OPERATION_GUIDE.md)
+- [P0 Runtime Architecture](../P0_RUNTIME_ARCHITECTURE.md)
+- [Decision Loop](decision-loop.md)

--- a/docs/arsenal/README.md
+++ b/docs/arsenal/README.md
@@ -1,0 +1,13 @@
+# Arsenal Demonstration History
+
+This directory records only accepted and public Black Hat Arsenal appearances.
+
+Azazel-Edge is maintained as a single core platform, and each Arsenal appearance demonstrates one operational profile of that same platform.
+
+## Public Entries
+- [Black Hat Asia 2026](blackhat-asia-2026.md)
+- [Black Hat USA 2026](blackhat-usa-2026.md)
+
+## Policy
+- Do not add future event files before acceptance is public.
+- Represent future ideas as concept profiles under `docs/concepts/`.

--- a/docs/arsenal/blackhat-asia-2026.md
+++ b/docs/arsenal/blackhat-asia-2026.md
@@ -1,0 +1,33 @@
+# Black Hat Asia 2026
+
+## Public Title
+Azazel-Pi: Offline Edge-AI SOC/NOC Gateway with Mock-LLM Scoring and Ollama Fallback
+
+## Concept Profile
+Offline Edge-AI SOC/NOC
+
+## Focus
+Demonstrate offline-capable edge SOC/NOC decision support on constrained hardware with deterministic control path and optional local AI assist.
+
+## Demo Scope
+- Deterministic evidence-to-action flow
+- Replay-safe demonstration mode
+- Optional local advisory path when available
+
+## Core Capabilities Demonstrated
+| Capability | Status | Notes |
+|---|---|---|
+| Deterministic NOC/SOC evaluation | Implemented | Core evaluators and arbiter path. |
+| Decision explanation and trace fields | Implemented | Includes selected action rationale and alternatives. |
+| Optional local AI advisory fallback | Implemented | Bounded by governance; not authoritative. |
+
+## Relationship to Mainline Azazel-Edge
+This Arsenal appearance demonstrates one operational profile of the same Azazel-Edge core platform. It does not represent a separate long-term fork.
+
+## Related Concept Profile
+- [Offline Edge-AI SOC/NOC](../concepts/offline-edge-ai-socnoc.md)
+
+## Related Architecture Documents
+- [Decision Loop](../architecture/decision-loop.md)
+- [Local AI Triage](../architecture/local-ai-triage.md)
+- [Evidence Model](../architecture/evidence-model.md)

--- a/docs/arsenal/blackhat-usa-2026.md
+++ b/docs/arsenal/blackhat-usa-2026.md
@@ -1,0 +1,33 @@
+# Black Hat USA 2026
+
+## Public Title
+Azazel-Edge: Deterministic Edge Decision Support for Constrained SOC/NOC Operations
+
+## Concept Profile
+Deterministic Edge Decision Support
+
+## Focus
+Present reproducible deterministic scoring and policy-based action selection for constrained SOC/NOC operations.
+
+## Demo Scope
+- Deterministic evaluator split (NOC/SOC)
+- Explicit bounded action arbitration
+- Operator-visible explanation and audit context
+
+## Core Capabilities Demonstrated
+| Capability | Status | Notes |
+|---|---|---|
+| Split NOC/SOC deterministic evaluation | Implemented | Separate evaluation stages feed one arbiter. |
+| Bounded action selection | Implemented | Uses explicit action classes only. |
+| Policy-aware decision traceability | Implemented | Includes why-chosen and why-not-others context. |
+
+## Relationship to Mainline Azazel-Edge
+This Arsenal appearance demonstrates one operational profile of the same Azazel-Edge core platform. Regional presentation focus does not imply a separate codebase.
+
+## Related Concept Profile
+- [Deterministic Edge Decision Support](../concepts/deterministic-edge-decision-support.md)
+
+## Related Architecture Documents
+- [Decision Loop](../architecture/decision-loop.md)
+- [Deception Routing](../architecture/deception-routing.md)
+- [Evidence Model](../architecture/evidence-model.md)

--- a/docs/concepts/auditable-edge-socnoc.md
+++ b/docs/concepts/auditable-edge-socnoc.md
@@ -1,0 +1,38 @@
+# Auditable Edge SOC/NOC
+
+## Purpose
+Define a concept profile for privacy-sensitive and regulated operations where explainability, traceability, and reversible controls are prioritized.
+
+## Operational Assumption
+- Every response decision should be reviewable from recorded evidence.
+- Audit records must preserve deterministic path context.
+- AI assist must remain governed and secondary.
+
+## Target Environment
+- Privacy-sensitive organizations
+- Regulated operational environments
+- Teams requiring post-incident review and accountability
+
+## Core Capabilities
+| Capability | Status | Notes |
+|---|---|---|
+| Deterministic action decisions with rationale | Implemented | Decision explanation fields are required in core path. |
+| Audit logging with `trace_id` correlation | Implemented | Audit logger is part of runtime baseline. |
+| Structured evidence export for external review | Planned | Existing exports exist in parts of stack; unified profile-level packaging remains planned. |
+| Reproducibility metadata (`config hash` alignment) | Planned | Policy/hash references exist; broader reproducibility packaging is not yet complete. |
+
+## Demo Narrative
+This profile focuses on showing how operators can justify decisions using deterministic outputs, explanation fields, and audit traces rather than relying on opaque automation.
+
+## Relationship to Core Architecture
+The profile depends on Decision Loop determinism, Evidence Model consistency, and AI governance boundaries.
+
+## What This Concept Is Not
+- Not a guarantee of legal compliance by itself
+- Not full governance automation
+- Not a future event acceptance claim
+
+## Related Architecture Documents
+- [Decision Loop](../architecture/decision-loop.md)
+- [Evidence Model](../architecture/evidence-model.md)
+- [Local AI Triage](../architecture/local-ai-triage.md)

--- a/docs/concepts/deterministic-edge-decision-support.md
+++ b/docs/concepts/deterministic-edge-decision-support.md
@@ -1,0 +1,38 @@
+# Deterministic Edge Decision Support
+
+## Purpose
+Describe the operational profile centered on reproducible, policy-based decision support for constrained SOC/NOC operations.
+
+## Operational Assumption
+- The deterministic path is primary.
+- Evaluator outputs and Action Arbiter decisions must be explainable and traceable.
+- Optional integrations must not change core decision authority.
+
+## Target Environment
+- Constrained SOC/NOC teams
+- Incident response training environments
+- Edge deployments requiring predictable operator handoff
+
+## Core Capabilities
+| Capability | Status | Notes |
+|---|---|---|
+| NOC/SOC split deterministic evaluation | Implemented | NOC and SOC evaluators are separate modules. |
+| Bounded action set (`observe/notify/throttle/redirect/isolate`) | Implemented | Action Arbiter uses explicit bounded actions. |
+| Decision explanation fields | Implemented | Includes rationale and rejected alternatives. |
+| Policy-driven threshold tuning | Implemented | SOC policy profiles and dry-run tooling exist. |
+
+## Demo Narrative
+This profile demonstrates stable and repeatable edge decision support where the same evidence and policy produce a predictable action and explanation.
+
+## Relationship to Core Architecture
+This concept is a direct expression of the core Decision Loop and Evidence Model, with emphasis on policy consistency and audit traceability.
+
+## What This Concept Is Not
+- Not AI-first threat adjudication
+- Not opaque score generation
+- Not event-specific branching of the codebase
+
+## Related Architecture Documents
+- [Decision Loop](../architecture/decision-loop.md)
+- [Evidence Model](../architecture/evidence-model.md)
+- [Deception Routing](../architecture/deception-routing.md)

--- a/docs/concepts/evolution-map.md
+++ b/docs/concepts/evolution-map.md
@@ -1,0 +1,32 @@
+# Azazel-Edge Evolution Map
+
+Azazel-Edge is maintained as a single core platform.
+Each concept profile demonstrates a different operational assumption,
+deployment model, and security value.
+
+## Concept Profiles
+
+| Concept | Focus | Typical Scenario | Status |
+|---|---|---|---|
+| Offline Edge-AI SOC/NOC | Offline operation, local analysis, compact edge demo | Isolated or network-constrained environments | Demonstrated |
+| Deterministic Edge Decision Support | Reproducible scoring and policy-based response | Constrained SOC/NOC operations | Demonstrated |
+| Auditable Edge SOC/NOC | Explanation, audit trail, reversible controls | Privacy-sensitive or regulated environments | Concept profile |
+| Field-Deployable Scapegoat Gateway | Rapid deployment, deception, evidence export | Event, field, and critical infrastructure networks | Concept profile |
+
+## Public Arsenal Demonstrations
+
+| Event | Concept | Public Title |
+|---|---|---|
+| Black Hat Asia 2026 | Offline Edge-AI SOC/NOC | Azazel-Pi: Offline Edge-AI SOC/NOC Gateway with Mock-LLM Scoring and Ollama Fallback |
+| Black Hat USA 2026 | Deterministic Edge Decision Support | Azazel-Edge: Deterministic Edge Decision Support for Constrained SOC/NOC Operations |
+
+## Design Principle
+
+The repository should not be forked for each regional presentation.
+Regional differences should be represented as concept profiles, demo scenarios, configuration profiles, and documentation.
+
+## Related Concept Documents
+- [Offline Edge-AI SOC/NOC](offline-edge-ai-socnoc.md)
+- [Deterministic Edge Decision Support](deterministic-edge-decision-support.md)
+- [Auditable Edge SOC/NOC](auditable-edge-socnoc.md)
+- [Field-Deployable Scapegoat Gateway](field-deployable-scapegoat-gateway.md)

--- a/docs/concepts/field-deployable-scapegoat-gateway.md
+++ b/docs/concepts/field-deployable-scapegoat-gateway.md
@@ -1,0 +1,38 @@
+# Field-Deployable Scapegoat Gateway
+
+## Purpose
+Define a concept profile for rapid deployment of an edge SOC/NOC gateway that can use deception-assisted response in constrained field networks.
+
+## Operational Assumption
+- Deployment speed and operational clarity are critical.
+- Deterministic policy selects whether to observe, throttle, redirect, or isolate.
+- Deception routing is controlled, bounded, and reviewable.
+
+## Target Environment
+- Event and venue networks
+- Critical infrastructure edge segments
+- Mobile or temporary command-post deployments
+
+## Core Capabilities
+| Capability | Status | Notes |
+|---|---|---|
+| Rapid edge gateway setup on Raspberry Pi | Implemented | Installer and deployment guides exist for constrained runtime. |
+| Deception-assisted redirect path | Implemented | OpenCanary redirect integration exists in current stack. |
+| Reversible action posture for incident handling | Implemented | Action model is bounded and operator-visible. |
+| Incident evidence bundle export workflow | Conceptual | Unified field-operator bundle workflow is not fully formalized. |
+
+## Demo Narrative
+This profile demonstrates how a single edge node can stabilize first-response operations, surface deterministic decisions, and optionally use redirect/deception to reduce immediate exposure.
+
+## Relationship to Core Architecture
+This concept reuses the same Decision Loop and Evidence Model while emphasizing Deception Routing behavior for constrained deployments.
+
+## What This Concept Is Not
+- Not autonomous active defense
+- Not a promise of complete attack prevention
+- Not a separate regional fork
+
+## Related Architecture Documents
+- [Decision Loop](../architecture/decision-loop.md)
+- [Deception Routing](../architecture/deception-routing.md)
+- [Evidence Model](../architecture/evidence-model.md)

--- a/docs/concepts/offline-edge-ai-socnoc.md
+++ b/docs/concepts/offline-edge-ai-socnoc.md
@@ -1,0 +1,38 @@
+# Offline Edge-AI SOC/NOC
+
+## Purpose
+Define an operational profile for running Azazel-Edge as a local-first SOC/NOC gateway when internet connectivity is unavailable or intentionally disabled.
+
+## Operational Assumption
+- Core detection and response must work without cloud services.
+- Deterministic evaluation remains authoritative.
+- Local AI assist is optional and bounded by AI Assist Governance.
+
+## Target Environment
+- Temporary emergency networks
+- Isolated field offices
+- Connectivity-constrained exercises and incident drills
+
+## Core Capabilities
+| Capability | Status | Notes |
+|---|---|---|
+| Deterministic NOC/SOC evaluation | Implemented | Core evaluator/arbiter path in repository runtime. |
+| Local replay-based demo path | Implemented | Deterministic demo scenarios are available. |
+| Local LLM advisory (Ollama) | Implemented | Optional; not required for deterministic operation. |
+| Offline-first fallback operation | Implemented | Core functions do not require cloud access. |
+
+## Demo Narrative
+This profile demonstrates first-response operations where telemetry is normalized locally, evaluated deterministically, and translated into explicit actions with audit traces. AI output is treated as advisory context only.
+
+## Relationship to Core Architecture
+This profile uses the same Decision Loop, Evidence Model, and local AI triage boundaries as other Azazel-Edge profiles.
+
+## What This Concept Is Not
+- Not an autonomous AI defense system
+- Not a replacement for full-scale SIEM operations
+- Not a separate product fork
+
+## Related Architecture Documents
+- [Decision Loop](../architecture/decision-loop.md)
+- [Local AI Triage](../architecture/local-ai-triage.md)
+- [Evidence Model](../architecture/evidence-model.md)


### PR DESCRIPTION
## Summary
- add a new documentation layer split into concept profiles, accepted/public Arsenal history, and stable core architecture
- create docs/concepts/, docs/arsenal/, and docs/architecture/ without deleting existing docs
- add concise navigation links from README and docs index to the new structure

## Files Added
- docs/concepts/offline-edge-ai-socnoc.md
- docs/concepts/deterministic-edge-decision-support.md
- docs/concepts/auditable-edge-socnoc.md
- docs/concepts/field-deployable-scapegoat-gateway.md
- docs/concepts/evolution-map.md
- docs/arsenal/README.md
- docs/arsenal/blackhat-asia-2026.md
- docs/arsenal/blackhat-usa-2026.md
- docs/architecture/decision-loop.md
- docs/architecture/deception-routing.md
- docs/architecture/local-ai-triage.md
- docs/architecture/evidence-model.md

## Files Updated
- README.md
- docs/INDEX.md

## Notes
- preserves existing documents (no removals)
- avoids future unaccepted event pages and keeps those ideas under concept profiles
- uses conservative capability status labels (Implemented/Planned/Prototype/Conceptual)
