### PR TITLE
docs(config): add concept-aligned profiles and demo concept packs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Examples: `feat/decision-trust-capsule`, `fix/epd-help-crash`, `docs/readme-reor
   - [ ] `PYTHONPATH=. pytest -q` passes
   - [ ] `cd rust/azazel-edge-core && cargo test` passes (if Rust touched or validation scope includes Rust)
   - [ ] Related documentation updated in the same PR
+  - [ ] If API surface or runtime configuration changed, update `docs/API_REFERENCE.md` and/or `docs/CONFIGURATION.md` in the same PR
   - [ ] Deterministic First principle not violated
   - [ ] Raspberry Pi constraints not broken
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Install result (default scripts):
 - SOC policy:
   - `AZAZEL_SOC_POLICY_PATH` (default `config/soc_policy.yaml`)
   - profiles: `config/soc_policy_profiles/{conservative,balanced,demo}.yaml`
+  - concept mapping layer: `configs/profiles/*.yaml`
   - dry-run helper: `bin/azazel-soc-policy-dry-run`
 - Aggregator freshness tuning (MVP scaffold):
   - `AZAZEL_AGGREGATOR_POLL_INTERVAL_SEC` (default `30`)
@@ -357,6 +358,8 @@ Status guidance:
 | `systemd/` | Services and timers |
 | `security/` | Compose stacks and security-side assets |
 | `installer/` | Unified installer and staged install scripts |
+| `configs/profiles/` | Concept-profile configuration mapping layer |
+| `demos/concepts/` | Concept-oriented deterministic demo pack mapping |
 | `docs/` | Public architecture, AI operation, persona, and demo documentation |
 | `tests/` | Unit and regression coverage |
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Azazel-Edge
+# AZ-01 Azazel-Edge - Deterministic Edge SOC/NOC Gateway
+
+> **Codename:** `SENTINEL`
 
 ![Azazel-Edge Banner](images/Azazel-Edge_Banner.png)
 [![CI](https://github.com/01rabbit/Azazel-Edge/actions/workflows/ci.yml/badge.svg)](https://github.com/01rabbit/Azazel-Edge/actions/workflows/ci.yml)
@@ -11,165 +13,27 @@
 ![Flask](https://img.shields.io/badge/Flask-Web%20API-000000?logo=flask)
 [![Black Hat Arsenal](https://img.shields.io/badge/Black%20Hat-Arsenal%202025--2026-111111)](https://www.blackhat.com/)
 
-Track record: This project line has been presented through Black Hat Arsenal review tracks (2025-2026).  
-Azazel-Edge is the successor project to Azazel-Pi; earlier accepted sessions were presented under the Azazel-Pi name.
+Azazel-Edge is the AZ-01 core platform of the Azazel system, a Raspberry Pi-oriented deterministic edge SOC/NOC gateway and Cyber Scapegoat Gateway for constrained, temporary, and high-risk networks.
 
-Azazel-Edge is a Raspberry Pi-oriented edge operations stack that combines:
-- internal network/gateway setup
-- deterministic NOC/SOC evaluation and action selection
-- Web UI + API + runbook workflow for operators
-- optional local AI assist (Ollama + Mattermost integration)
+It observes local network evidence, evaluates NOC/SOC state deterministically, selects bounded actions (`observe`, `notify`, `throttle`, `redirect`, `isolate`), and records operator-visible explanations and audit traces.
 
-This README is based on verified repository contents (code, scripts, tests, git history, GitHub issue/PR metadata) as of **2026-05-14**.
+Optional local AI assist may summarize or explain events, but it does not replace the deterministic decision loop.
 
-## What is Azazel-Edge?
+Azazel-Edge is not a production SIEM replacement, not an autonomous AI defender, and not a promise of complete attack prevention.
 
-Azazel-Edge is a **lightweight SOC/NOC gateway for emergency operations**, designed to run on a Raspberry Pi.
-
-**Who it's for**
-- Security staff running a temporary network segment (event venue, field office, training exercise)
-- Operators who need first-response triage without a full SIEM
-- Teams practicing incident response with a local, offline-capable stack
-
-**When to use it**
-- You need a working gateway + alert triage surface in under an hour
-- You have no cloud connectivity or want to keep traffic fully local
-- You want a deterministic decision engine with optional local AI assist (Ollama), not a black-box
-
-**What it is not**
-- A replacement for a production SIEM or full-time SOC platform
-- An autonomous AI that makes decisions without operator confirmation
-- Cloud-dependent: all core functions work offline
-
-## Verified Purpose
-
-The implemented purpose in this repository is:
-
-1. Run an internal edge segment (`br0`, DHCP, NAT/forwarding) and expose an operations surface.
-2. Consume normalized telemetry and evaluate NOC/SOC state deterministically.
-3. Produce explicit actions (`observe`, `notify`, `throttle`, `redirect`, `isolate`) with explanation/audit payloads.
-4. Provide operator workflows (dashboard, triage, runbooks, Mattermost bridge, deterministic demo).
-5. Optionally assist with local LLM inference through Ollama (bounded assist path, not mandatory for deterministic demo path).
-
-Evidence:
-- Gateway/network baseline: `installer/internal/install_internal_network.sh`
-- Deterministic action model: `py/azazel_edge/arbiter/action.py`
-- Web/API surfaces: `azazel_edge_web/app.py`
-- Demo deterministic replay: `bin/azazel-edge-demo`, `py/azazel_edge/demo/scenarios.py`
-- AI agent runtime: `py/azazel_edge_ai/agent.py`, `systemd/azazel-edge-ai-agent.service`
-
-## Core Architecture
-
-```mermaid
-flowchart LR
-    subgraph ingestion["Event Ingestion"]
-        SUP[Suricata EVE] --> RC[Rust Core]
-        RC --> EP[Evidence Plane]
-    end
-    subgraph evaluation["Deterministic Evaluation"]
-        EP --> NOC[NOC Evaluator]
-        EP --> SOC[SOC Evaluator]
-        NOC --> ARB[Action Arbiter]
-        SOC --> ARB
-    end
-    subgraph action["Operator Plane"]
-        ARB --> EXP[Decision Explanation]
-        EXP --> WEB[Web UI / API]
-        EXP --> NOTIF[Notification]
-    end
-    subgraph ai["AI Assist\n(optional)"]
-        EXP --> GOV[AI Governance]
-        GOV --> LLM[Ollama]
-        LLM --> GOV
-    end
-    WEB --> OPR([Operator])
-    NOTIF --> MM[Mattermost]
-    ARB --> AUD[Audit Logger]
-```
-
-1. **Event ingestion + normalization**
-   - Rust core tails Suricata EVE (`AZAZEL_EVE_PATH`, default `/var/log/suricata/eve.json`) and emits normalized alert events.
-   - Rust core forwards to Unix socket (`/run/azazel-edge/ai-bridge.sock`) and/or JSONL log.
-2. **Deterministic evaluation**
-   - NOC evaluator and SOC evaluator are implemented under `py/azazel_edge/evaluators/`.
-   - Action arbiter decides explicit actions with rejected alternatives and decision trace.
-3. **Operator plane**
-   - Flask app serves dashboard (`/`), demo (`/demo`), ops workspace (`/ops-comm`), and `/api/*`.
-   - Control daemon exposes Unix socket control plane at `/run/azazel-edge/control.sock`.
-4. **Optional AI assist plane**
-   - AI agent consumes normalized events/manual queries and writes advisory/metrics/audit JSONL.
-   - Ollama and Mattermost are provisioned by optional compose-based runtime scripts.
-
-## Entrypoints And Interfaces
-
-### Service entrypoints
-- Web app: `azazel_edge_web/app.py` (gunicorn via `systemd/azazel-edge-web.service`)
-- Control daemon: `py/azazel_edge_control/daemon.py` (`systemd/azazel-edge-control-daemon.service`)
-- AI agent: `py/azazel_edge_ai/agent.py` (`systemd/azazel-edge-ai-agent.service`)
-- Rust core: `rust/azazel-edge-core/src/main.rs` (`systemd/azazel-edge-core.service`)
-- EPD refresh timer: `systemd/azazel-edge-epd-refresh.timer`
-
-### Web routes
-- UI: `/`, `/demo`, `/ops-comm`
-- Health: `/health` (no token)
-- CA metadata/download: `/api/certs/azazel-webui-local-ca/meta`, `/api/certs/azazel-webui-local-ca.crt`
-
-### Primary API groups
-
-| Group | Endpoints | Auth required |
-|-------|-----------|---------------|
-| State | `GET /api/state`, `GET /api/state/stream` | Yes |
-| Control | `POST /api/mode`, `POST /api/action`, `/api/wifi/*`, `/api/portal-viewer*` | Yes |
-| SoT | `POST /api/clients/trust`, `PUT/PATCH /api/sot/devices` | Yes |
-| Dashboard | `GET /api/dashboard/*` | Yes |
-| Triage | `/api/triage/*` | Yes |
-| Runbooks | `GET /api/runbooks`, `POST /api/runbooks/propose`, `POST /api/runbooks/act` | Yes |
-| Demo | `/api/demo/*` | Yes |
-| AI | `POST /api/ai/ask`, `GET /api/ai/capabilities` | Yes |
-| Mattermost | `POST /api/mattermost/command`, `POST /api/mattermost/message` | Token |
-| Health | `GET /health` | No |
-| CA cert | `GET /api/certs/*` | No |
-
-### Socket interfaces
-- Control socket: `/run/azazel-edge/control.sock`
-- AI bridge socket: `/run/azazel-edge/ai-bridge.sock`
-
-### Authentication behavior
-- Most `/api/*` endpoints are token-protected.
-- Installer-managed runtime sets fail-closed by default (`AZAZEL_AUTH_FAIL_OPEN=0`).
-- Legacy fail-open compatibility is controlled by `AZAZEL_AUTH_FAIL_OPEN` when token file is absent.
-- Managed default token file is `/etc/azazel-edge/web_token.txt` via `AZAZEL_WEB_TOKEN_FILE`.
-
-## Changelog
-
-See [`docs/CHANGELOG.md`](docs/CHANGELOG.md) for the full implementation history and PR traceability.
-See [`docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md`](docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md) for the current execution cycle feature inventory.
+**Who this is for:** security operators, field defenders, incident responders, training teams, and researchers working with constrained local networks.
 
 ## Requirements
 
-### Runtime packages (installed by scripts)
-- Core/app stack: `python3`, `python3-venv`, `network-manager`, `iw`, `dnsmasq`, `nginx`, `openssl`, `rustc`, `cargo`, and related Python system packages
-- Security stack option: `docker.io`, `suricata`
-- AI runtime option: `docker.io`, `qemu-user-static`, `binfmt-support`, `jq`
+| Requirement | Detail |
+|---|---|
+| Hardware | Raspberry Pi-oriented; tested/developed for constrained edge deployment |
+| OS | Raspberry Pi OS / Linux |
+| Runtime | Python 3.10+, Rust core components |
+| Network | Local edge segment with optional Suricata/OpenCanary integration |
+| Optional | Ollama, Mattermost, Wazuh, Vector, Aggregator |
 
-### Python runtime dependencies
-From `requirements/runtime.txt`:
-- `Flask`
-- `gunicorn`
-- `rich`
-- `textual`
-- `Pillow`
-- `requests`
-- `PyYAML`
-
-### Optional external services
-- Ollama container (`security/docker-compose.ollama.yml`)
-- Mattermost + PostgreSQL (`security/docker-compose.mattermost.yml`)
-- OpenCanary (`security/docker-compose.yml`)
-
-## Install and Reproduce
-
-### Unified installer
+## Quick Start
 
 ```bash
 cd /home/azazel/Azazel-Edge
@@ -180,287 +44,112 @@ sudo ENABLE_INTERNAL_NETWORK=1 \
      bash installer/internal/install_all.sh
 ```
 
-For all installer toggles and runtime variables, see [Configuration](#configuration).
-
-### App stack only
+Minimal verification:
 
 ```bash
-sudo ENABLE_SERVICES=1 bash installer/internal/install_migrated_tools.sh
+sudo systemctl status azazel-edge-web azazel-edge-control-daemon azazel-edge-core --no-pager
 ```
 
-### AI runtime only
+Detailed install/deploy guidance:
+- [Deployment Profiles](docs/DEPLOYMENT_PROFILES.md)
+- [Operator Guide](docs/OPERATOR_GUIDE.md)
+- [Field Deployment Guide](docs/FIELD_DEPLOYMENT_GUIDE.md)
 
-```bash
-sudo ENABLE_OLLAMA=1 ENABLE_MATTERMOST=1 bash installer/internal/install_ai_runtime.sh
+## Architecture Overview
+
+```mermaid
+flowchart LR
+    E[Event Inputs] --> P[Evidence Plane]
+    P --> N[NOC Evaluator]
+    P --> S[SOC Evaluator]
+    N --> A[Action Arbiter]
+    S --> A
+    A --> X[Decision Explanation]
+    X --> O[Operator Plane]
+    X --> G[AI Assist Governance]
+    G --> L[Local LLM Optional]
+    A --> U[Audit Logger]
 ```
 
-Install result (default scripts):
-- Runtime files under `/opt/azazel-edge`
-- Launchers under `/usr/local/bin`
-- Systemd units installed and optionally enabled
+Full architecture:
+- [Decision Loop](docs/architecture/decision-loop.md)
+- [Deception Routing](docs/architecture/deception-routing.md)
+- [Local AI Triage](docs/architecture/local-ai-triage.md)
+- [Evidence Model](docs/architecture/evidence-model.md)
 
-## Configuration
+## What Azazel-Edge does
 
-### Installer toggles
-- `ENABLE_INTERNAL_NETWORK=1|0`
-- `ENABLE_APP_STACK=1|0`
-- `ENABLE_AI_RUNTIME=1|0`
-- `ENABLE_DEV_REMOTE_ACCESS=1|0`
-- `ENABLE_RUST_CORE=1|0`
+- runs a local edge gateway and operations surface
+- ingests local telemetry such as Suricata EVE
+- evaluates NOC and SOC state through deterministic evaluators
+- selects bounded actions through an Action Arbiter
+- records explanations, alternatives, and audit traces
+- supports replay-safe demos and operator workflows
+- optionally uses local AI assist for summaries and triage hints
 
-### Main runtime config files
-- `/etc/default/azazel-edge-web` (Web/Mattermost-related env)
-- `/etc/default/azazel-edge-security` (security stack options such as `SURICATA_IFACE`)
-- `/etc/azazel-edge/first_minute.yaml` (control flags such as `suppress_auto_wifi`)
+## Security Boundary Summary
 
-### Important environment variables (selected)
-- Web bind: `AZAZEL_WEB_HOST`, `AZAZEL_WEB_PORT`
-- Rust core: `AZAZEL_EVE_PATH`, `AZAZEL_AI_SOCKET`, `AZAZEL_NORMALIZED_EVENT_LOG`, `AZAZEL_DEFENSE_ENFORCE`
-- AI agent: `AZAZEL_OLLAMA_ENDPOINT`, `AZAZEL_LLM_MODEL_PRIMARY`, `AZAZEL_LLM_MODEL_DEGRADED`
-- Mattermost command trigger/token: `AZAZEL_MATTERMOST_COMMAND_TRIGGER`, `AZAZEL_MATTERMOST_COMMAND_TOKEN_FILE`
-- Runbook controlled execution gate: `AZAZEL_RUNBOOK_ENABLE_CONTROLLED_EXEC`
-- Auth hardening / RBAC:
-  - `AZAZEL_AUTH_FAIL_OPEN` (default `0` fail-closed)
-  - `AZAZEL_AUTH_TOKENS_FILE` (role-mapped API tokens, default `/etc/azazel-edge/auth_tokens.json`)
-  - `AZAZEL_AUTHZ_AUDIT_LOG` (authorization decision audit log)
-  - `AZAZEL_AUTH_MTLS_REQUIRED` (`0|1`, optional hardened mode)
-  - `AZAZEL_AUTH_MTLS_HEADER` (client fingerprint header key, default `X-Client-Cert-Fingerprint`)
-  - `AZAZEL_AUTH_MTLS_FINGERPRINTS` (CSV allowlist)
-  - `AZAZEL_AUTH_MTLS_FINGERPRINTS_FILE` (line-based allowlist file)
-- Topo-Lite/NOC monitor scope:
-  - `AZAZEL_NOC_MONITOR_SCOPE` (`internal` default, or `external`)
-  - `AZAZEL_INTERNAL_BRIDGE_IF` (`br0` default)
-  - `AZAZEL_MANAGED_CLIENT_CIDRS` (`172.16.0.0/24` default)
-  - `AZAZEL_INTERNAL_MONITOR_TARGET` (`172.16.0.254` default)
-  - `AZAZEL_NOC_EXTRA_INTERFACES` (optional CSV for multi-segment probes)
-- Topo-Lite synthetic seed mode:
-  - `AZAZEL_TOPOLITE_SEED_MODE_PATH` (mode state file, default `/run/azazel-edge/topolite_seed_mode.json`)
-  - API: `POST /api/topolite/seed-mode` with `mode=live|synthetic` and optional `seed_id`
-- Alert queue classification thresholds:
-  - `AZAZEL_ALERT_QUEUE_NOW_THRESHOLD` (default `80`)
-  - `AZAZEL_ALERT_QUEUE_WATCH_THRESHOLD` (default `50`)
-  - `AZAZEL_ALERT_QUEUE_ESCALATE_THRESHOLD` (default `90`)
-  - `AZAZEL_ALERT_SUPPRESSION_WINDOW_SEC` (default `120`)
-  - `AZAZEL_ALERT_AGGREGATION_WINDOW_SEC` (default `300`)
-  - `AZAZEL_ALERT_ESCALATION_COUNT_THRESHOLD` (default `5`)
-- SOC policy:
-  - `AZAZEL_SOC_POLICY_PATH` (default `config/soc_policy.yaml`)
-  - profiles: `config/soc_policy_profiles/{conservative,balanced,demo}.yaml`
-  - concept mapping layer: `configs/profiles/*.yaml`
-  - dry-run helper: `bin/azazel-soc-policy-dry-run`
-- Aggregator freshness tuning (MVP scaffold):
-  - `AZAZEL_AGGREGATOR_POLL_INTERVAL_SEC` (default `30`)
-  - `AZAZEL_AGGREGATOR_STALE_MULTIPLIER` (default `2`)
-  - `AZAZEL_AGGREGATOR_OFFLINE_MULTIPLIER` (default `6`)
+Azazel-Edge claims:
+- local-first deterministic decision support
+- explicit bounded actions
+- operator-visible explanation and audit traces
+- optional AI assist that remains secondary to deterministic control
 
-### Token auth
-- API token can be supplied by header `X-AZAZEL-TOKEN` (or `X-Auth-Token`) or `?token=`.
-- Default runtime posture is fail-closed (`AZAZEL_AUTH_FAIL_OPEN=0`): missing token material must not open protected endpoints.
+Azazel-Edge does not claim:
+- complete attack prevention
+- full SIEM replacement
+- autonomous AI defense
+- legal or regulatory compliance by itself
+- safe deployment without operator understanding
 
-## Usage
+## Concept Profiles
 
-### Service status
-```bash
-sudo systemctl status \
-  azazel-edge-control-daemon \
-  azazel-edge-web \
-  azazel-edge-ai-agent \
-  azazel-edge-core
-```
+Azazel-Edge is maintained as a single core platform.
+Different operational profiles are documented as concept profiles, not forks.
 
-### Access endpoints (default installer assumptions)
-- Web backend (gunicorn): `http://127.0.0.1:8084/`
-- If internal network + HTTPS proxy are installed: `https://172.16.0.254/`
-- Mattermost (if enabled): `http://172.16.0.254:8065/`
+- [Evolution Map](docs/concepts/evolution-map.md)
+- [Offline Edge-AI SOC/NOC](docs/concepts/offline-edge-ai-socnoc.md)
+- [Deterministic Edge Decision Support](docs/concepts/deterministic-edge-decision-support.md)
+- [Auditable Edge SOC/NOC](docs/concepts/auditable-edge-socnoc.md)
+- [Field-Deployable Scapegoat Gateway](docs/concepts/field-deployable-scapegoat-gateway.md)
 
-### API call example
-```bash
-TOKEN="$(cat ~/.azazel-edge/web_token.txt)"
-curl -sS -H "X-AZAZEL-TOKEN: ${TOKEN}" http://127.0.0.1:8084/api/state | jq .
-```
+## Arsenal Demonstrations
 
-### SoT devices API contract
-- `PUT /api/sot/devices`
-  - Replaces the full `devices` array in SoT.
-  - Request body: `{"devices": [<SoT device objects>]}`.
-- `PATCH /api/sot/devices`
-  - Merge/upsert semantics by `id` only (no delete behavior).
-  - Existing device fields are preserved unless overwritten by payload fields.
-  - Request body: `{"devices": [<partial or full SoT device objects with id>]}`.
-- Both endpoints:
-  - Require token auth (`@require_token()`).
-  - Validate resulting full SoT via `SoTConfig.from_dict`.
-  - Append audit records to `AZAZEL_SOT_AUDIT_LOG` including `actor` (`X-AZAZEL-ACTOR` preferred, then caller address).
-  - Trigger re-evaluation through `refresh` after successful updates.
+Only accepted and public Black Hat Arsenal appearances are recorded here.
 
-### Deterministic demo replay
+- [Black Hat Asia 2026](docs/arsenal/blackhat-asia-2026.md)
+- [Black Hat USA 2026](docs/arsenal/blackhat-usa-2026.md)
 
-```bash
-bin/azazel-edge-demo list
-bin/azazel-edge-demo run mixed_correlation_demo
-```
+See [Arsenal Demonstration History](docs/arsenal/README.md).
 
-### Runbook broker CLI
-```bash
-python3 py/azazel_edge_runbook_broker.py list
-python3 py/azazel_edge_runbook_broker.py show rb.noc.service.status.check
-python3 py/azazel_edge_runbook_broker.py propose --question "Wi-Fi intermittent disconnects"
-```
+## Documentation Map
 
-## Development
-
-### Local setup
-```bash
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -U pip wheel setuptools
-pip install -r requirements/dev.txt
-```
-
-### Local run (without systemd)
-```bash
-PYTHONPATH=py:. .venv/bin/python azazel_edge_web/app.py
-PYTHONPATH=py:. .venv/bin/python py/azazel_edge_control/daemon.py
-PYTHONPATH=py:. .venv/bin/python py/azazel_edge_ai/agent.py
-```
-
-Notes:
-- Several tests import `azazel_edge_web` as top-level package, so `PYTHONPATH=.` is required in repository layout.
-- `py/azazel_edge_status.py` is a continuous renderer (Ctrl-C to stop), not a typical `--help` CLI.
-
-## Testing
-
-Run:
-```bash
-PYTHONPATH=py:. .venv/bin/pytest -q
-cd rust/azazel-edge-core && cargo test
-```
-
-Or use the unified helper:
-```bash
-bin/azazel-edge-dev test-all
-```
-
-Status guidance:
-- Use the CI badge and latest GitHub release notes as the source of current validation status.
-- Avoid treating static README test counts as authoritative across commits.
+Primary entry points:
+- [Documentation Index](docs/INDEX.md)
+- [Core Runtime Architecture (P0)](docs/P0_RUNTIME_ARCHITECTURE.md)
+- [API Reference](docs/API_REFERENCE.md)
+- [Configuration Reference](docs/CONFIGURATION.md)
+- [Deployment Profiles](docs/DEPLOYMENT_PROFILES.md)
+- [Arsenal Demo Profile](docs/ARSENAL_DEMO_PROFILE.md)
+- [Operator Guide](docs/OPERATOR_GUIDE.md)
+- [AI Operation Guide](docs/AI_OPERATION_GUIDE.md)
+- [Privacy and Legal Notes](docs/PRIVACY_AND_LEGAL.md)
+- [Changelog](docs/CHANGELOG.md)
 
 ## Repository Layout
 
 | Path | Role |
 |---|---|
-| `py/azazel_edge/` | Evidence Plane, evaluators, arbiter, audit, SoT, triage, demo, and research/runtime extensions |
+| `py/azazel_edge/` | Evidence Plane, evaluators, arbiter, explanations, audit |
 | `py/azazel_edge_control/` | Control daemon and action handlers |
 | `py/azazel_edge_ai/` | AI agent integration and M.I.O. assist path |
 | `azazel_edge_web/` | Flask backend, dashboard, ops-comm UI |
 | `rust/azazel-edge-core/` | Rust defense core |
 | `runbooks/` | Runbook registry |
-| `systemd/` | Services and timers |
-| `security/` | Compose stacks and security-side assets |
-| `installer/` | Unified installer and staged install scripts |
-| `configs/profiles/` | Concept-profile configuration mapping layer |
-| `demos/concepts/` | Concept-oriented deterministic demo pack mapping |
-| `docs/` | Public architecture, AI operation, persona, and demo documentation |
-| `tests/` | Unit and regression coverage |
-
-## Deployment
-
-### Systemd units included
-- `azazel-edge-control-daemon.service`
-- `azazel-edge-web.service`
-- `azazel-edge-ai-agent.service`
-- `azazel-edge-core.service`
-- `azazel-edge-epd-refresh.service`
-- `azazel-edge-epd-refresh.timer`
-- `azazel-edge-opencanary.service`
-- `azazel-edge-suricata.service`
-
-### Security/AI stack deployment
-- Security stack install: `installer/internal/install_security_stack.sh`
-- AI runtime install: `installer/internal/install_ai_runtime.sh`
-- Compose assets under `security/`
-
-### Runtime logs/artifacts (selected)
-- `/var/log/azazel-edge/normalized-events.jsonl`
-- `/var/log/azazel-edge/ai-events.jsonl`
-- `/var/log/azazel-edge/ai-llm.jsonl`
-- `/var/log/azazel-edge/triage-audit.jsonl`
-- `/run/azazel-edge/ui_snapshot.json`
-
-## Documentation
-
-Azazel-Edge is documented as a single core platform with multiple operational concept profiles.
-- [Concept Profiles](docs/concepts/evolution-map.md)
-- [Arsenal Demonstrations](docs/arsenal/README.md)
-- [Core Architecture](docs/architecture/decision-loop.md)
-
-### For operators
-
-| Document | Description |
-|----------|-------------|
-| [AI Operation Guide](docs/AI_OPERATION_GUIDE.md) | LLM thresholds, daily checks, incident response |
-| [AI Operation Guide (JA)](docs/AI_OPERATION_GUIDE_JA.md) | 日本語版 AI 運用要領 |
-| [Demo Guide](docs/DEMO_GUIDE.md) | Deterministic demo replay walkthrough |
-| [Operator Guide](docs/OPERATOR_GUIDE.md) | Field operator quick start and first-response workflow |
-| [Operator Guide (JA)](docs/OPERATOR_GUIDE_JA.md) | 日本語版オペレータガイド |
-
-### For developers
-
-| Document | Description |
-|----------|-------------|
-| [P0 Runtime Architecture](docs/P0_RUNTIME_ARCHITECTURE.md) | Pipeline, modules, and constraints |
-| [AI Agent Build and Operation Detail](docs/AI_AGENT_BUILD_AND_OPERATION_DETAIL.md) | AI agent internals |
-| [AI Agent Build and Operation Detail (JA)](docs/AI_AGENT_BUILD_AND_OPERATION_DETAIL_JA.md) | 日本語版 AI エージェント構築・運用詳細 |
-| [M.I.O. Persona Profile](docs/MIO_PERSONA_PROFILE.md) | Operator persona design spec |
-| [M.I.O. Persona Profile (JA)](docs/MIO_PERSONA_PROFILE_JA.md) | 日本語版 M.I.O. ペルソナ仕様 |
-| [Post-demo Main Integration Boundary (#104)](docs/POST_DEMO_MAIN_INTEGRATION_104.md) | What is mainline vs. exhibition-only |
-| [Post-demo Socket Permission Model (#105)](docs/POST_DEMO_SOCKET_PERMISSION_MODEL_105.md) | Unix socket permission decisions |
-| [Next Development Execution Index 2026Q2](docs/NEXT_DEVELOPMENT_EXECUTION_INDEX_2026Q2.md) | Roadmap and execution plan |
-| [Arsenal Demo Profile](docs/ARSENAL_DEMO_PROFILE.md) | Reproducible deterministic demo profile |
-| [Deployment Profiles](docs/DEPLOYMENT_PROFILES.md) | Core/Demo/SOC/NOC/Heavy-lab profile matrix |
-| [Benchmark Scope and HIL Plan](docs/BENCHMARK_SCOPE_AND_HIL_PLAN.md) | Scope boundary and hardware-in-the-loop plan |
-
-### For contributors (AI agents and humans)
-
-| Document | Description |
-|----------|-------------|
-| [AGENTS.md](AGENTS.md) | AI agent working charter — read before making any change |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | Human contributor guide (branch, PR, test rules) |
-| [Changelog](docs/CHANGELOG.md) | PR and feature traceability history |
-| [Implementation Cycle Feature Inventory](docs/IMPLEMENTATION_CYCLE_2026Q2_FEATURE_INVENTORY.md) | Verified feature inventory for Epic #196 implementation cycle |
-| [Release Verification Guide](docs/RELEASE_VERIFICATION_GUIDE.md) | Checksum/SBOM/dependency scan verification workflow |
-| [Document Language Policy](docs/DOCUMENT_LANGUAGE_POLICY.md) | English-first documentation policy and EN/JA split map |
-
-## Limitations and Known Issues
-
-### Design constraints (by intent)
-
-- Rust enforcement is fail-safe by default:
-  - `AZAZEL_DEFENSE_ENFORCE=false` and `AZAZEL_DEFENSE_ENFORCE_LEVEL=advisory` keep runtime advisory-only
-  - staged mode support: `advisory`, `semi-auto`, `full-auto`
-  - optional high-impact auto gate: `AZAZEL_DEFENSE_ALLOW_HIGH_IMPACT_AUTO=false`
-- AI assist is optional and bounded — the deterministic path works without Ollama
-- Ollama models above 2b parameters are not recommended for co-located deployments
-- Test count and runbook count are verified at each release; see CI results for current status.
-- Redirect behavior uses prepared lightweight decoys with protocol-aware mapping (v0.1.1 hardening line), not per-event decoy spawning.
-- Benchmark outputs are scoped to software-only deterministic replay unless hardware-in-the-loop evidence is explicitly provided.
-
-### Known bugs
-
-- None currently tracked in this document. Use GitHub Issues for current defects.
-
-### Open work items
-
-See [GitHub Issues](https://github.com/01rabbit/Azazel-Edge/issues) for the current list.
-Priority items are tracked in GitHub Issues and may change daily.
-
-## Current Status
-
-- Latest release: `v0.1.1`.
-- `v0.1.1` hardening line completed (redirect safety, demo reproducibility profile, deployment profile clarity, benchmark claim boundary).
-- Deterministic demo scenarios available: `mixed_correlation_demo`, `noc_degraded_demo`, `soc_redirect_demo`.
-- Optional integrations remain optional; deterministic core operation does not require Ollama/Mattermost/Wazuh/Vector/Aggregator.
+| `configs/profiles/` | Concept-to-configuration mapping layer |
+| `demos/concepts/` | Concept-oriented deterministic demo grouping |
+| `docs/` | Architecture, concept, operations, and reference documentation |
 
 ## License
 
-This repository is licensed under the MIT License. See [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/configs/profiles/README.md
+++ b/configs/profiles/README.md
@@ -1,0 +1,23 @@
+# Concept Profiles (Configuration Layer)
+
+This directory maps operational concept profiles to reusable configuration intent.
+
+It does not replace runtime defaults under `config/`.
+Current runtime policy loading remains controlled by:
+- `AZAZEL_SOC_POLICY_PATH`
+- `config/soc_policy.yaml`
+- `config/soc_policy_profiles/*.yaml`
+
+## Concept Profile Mapping
+
+| Concept Profile ID | Primary SOC Policy Baseline | Demo Concept Pack |
+|---|---|---|
+| `offline-edge-ai-socnoc` | `config/soc_policy_profiles/demo.yaml` | `demos/concepts/offline-edge-ai-socnoc.yaml` |
+| `deterministic-edge-decision-support` | `config/soc_policy_profiles/balanced.yaml` | `demos/concepts/deterministic-edge-decision-support.yaml` |
+| `auditable-edge-socnoc` | `config/soc_policy_profiles/conservative.yaml` | `demos/concepts/auditable-edge-socnoc.yaml` |
+| `field-deployable-scapegoat-gateway` | `config/soc_policy_profiles/balanced.yaml` | `demos/concepts/field-deployable-scapegoat-gateway.yaml` |
+
+## Notes
+- These profiles are documentation/runtime-alignment metadata for concept-oriented operation.
+- Existing policy files under `config/soc_policy_profiles/` remain authoritative for score thresholds.
+- Avoid event-specific profile names in this layer.

--- a/configs/profiles/auditable-edge-socnoc.yaml
+++ b/configs/profiles/auditable-edge-socnoc.yaml
@@ -1,0 +1,17 @@
+id: auditable-edge-socnoc
+title: Auditable Edge SOC/NOC
+status: concept_profile
+intent:
+  auditability_priority: true
+  deterministic_primary: true
+  explainability_required: true
+policy:
+  baseline_path: config/soc_policy_profiles/conservative.yaml
+  rationale: conservative thresholds to reduce unnecessary high-impact actions
+runtime:
+  recommended_control_mode: active
+  notes:
+    - Emphasize decision explanation and trace continuity.
+    - Maintain fail-closed defaults for protected interfaces.
+demo:
+  concept_pack: demos/concepts/auditable-edge-socnoc.yaml

--- a/configs/profiles/deterministic-edge-decision-support.yaml
+++ b/configs/profiles/deterministic-edge-decision-support.yaml
@@ -1,0 +1,17 @@
+id: deterministic-edge-decision-support
+title: Deterministic Edge Decision Support
+status: demonstrated
+intent:
+  reproducibility_priority: true
+  deterministic_primary: true
+  bounded_actions_only: true
+policy:
+  baseline_path: config/soc_policy_profiles/balanced.yaml
+  rationale: balanced thresholds for repeatable NOC/SOC decision behavior
+runtime:
+  recommended_control_mode: active
+  notes:
+    - Preserve evaluator split and explicit arbiter trace.
+    - Prefer reversible controls before stronger containment.
+demo:
+  concept_pack: demos/concepts/deterministic-edge-decision-support.yaml

--- a/configs/profiles/field-deployable-scapegoat-gateway.yaml
+++ b/configs/profiles/field-deployable-scapegoat-gateway.yaml
@@ -1,0 +1,17 @@
+id: field-deployable-scapegoat-gateway
+title: Field-Deployable Scapegoat Gateway
+status: concept_profile
+intent:
+  rapid_deploy_priority: true
+  deception_assist_allowed: true
+  deterministic_primary: true
+policy:
+  baseline_path: config/soc_policy_profiles/balanced.yaml
+  rationale: preserve operational responsiveness while keeping bounded controls
+runtime:
+  recommended_control_mode: active
+  notes:
+    - Use prepared redirect mappings only.
+    - Keep rollback/review workflow explicit for field operators.
+demo:
+  concept_pack: demos/concepts/field-deployable-scapegoat-gateway.yaml

--- a/configs/profiles/offline-edge-ai-socnoc.yaml
+++ b/configs/profiles/offline-edge-ai-socnoc.yaml
@@ -1,0 +1,18 @@
+id: offline-edge-ai-socnoc
+title: Offline Edge-AI SOC/NOC
+status: demonstrated
+intent:
+  local_first: true
+  cloud_required: false
+  deterministic_primary: true
+  ai_assist_optional: true
+policy:
+  baseline_path: config/soc_policy_profiles/demo.yaml
+  rationale: visible deterministic transitions for constrained offline demo/training contexts
+runtime:
+  recommended_control_mode: active
+  notes:
+    - Keep deterministic path authoritative.
+    - AI assist remains advisory through governance.
+demo:
+  concept_pack: demos/concepts/offline-edge-ai-socnoc.yaml

--- a/demos/concepts/README.md
+++ b/demos/concepts/README.md
@@ -1,0 +1,17 @@
+# Concept Demo Packs
+
+This directory groups deterministic replay scenarios by operational concept profile.
+
+Runtime scenario definitions remain in `py/azazel_edge/demo/scenarios.py`.
+These files provide concept-oriented grouping and sequencing metadata.
+
+## Packs
+- `offline-edge-ai-socnoc.yaml`
+- `deterministic-edge-decision-support.yaml`
+- `auditable-edge-socnoc.yaml`
+- `field-deployable-scapegoat-gateway.yaml`
+
+## Compatibility
+No scenario IDs are renamed here. Existing IDs remain valid for:
+- `bin/azazel-edge-demo run <scenario_id>`
+- `/api/demo/run/<scenario_id>`

--- a/demos/concepts/auditable-edge-socnoc.yaml
+++ b/demos/concepts/auditable-edge-socnoc.yaml
@@ -1,0 +1,11 @@
+concept_id: auditable-edge-socnoc
+label: Auditable Edge SOC/NOC
+status: concept_profile
+stage_order:
+  - mixed_correlation_demo
+  - disaster_phishing_demo
+scenarios:
+  - id: mixed_correlation_demo
+    role: explanation trace and rejected-alternatives review
+  - id: disaster_phishing_demo
+    role: social-engineering triage with auditable operator handoff

--- a/demos/concepts/deterministic-edge-decision-support.yaml
+++ b/demos/concepts/deterministic-edge-decision-support.yaml
@@ -1,0 +1,11 @@
+concept_id: deterministic-edge-decision-support
+label: Deterministic Edge Decision Support
+status: demonstrated
+stage_order:
+  - mixed_correlation_demo
+  - soc_redirect_demo
+scenarios:
+  - id: mixed_correlation_demo
+    role: deterministic correlation and explanation path
+  - id: soc_redirect_demo
+    role: bounded action selection under strong SOC signal

--- a/demos/concepts/field-deployable-scapegoat-gateway.yaml
+++ b/demos/concepts/field-deployable-scapegoat-gateway.yaml
@@ -1,0 +1,11 @@
+concept_id: field-deployable-scapegoat-gateway
+label: Field-Deployable Scapegoat Gateway
+status: concept_profile
+stage_order:
+  - evacuation_network_demo
+  - soc_redirect_demo
+scenarios:
+  - id: evacuation_network_demo
+    role: field network instability and containment posture review
+  - id: soc_redirect_demo
+    role: redirect-capable bounded response with deception context

--- a/demos/concepts/offline-edge-ai-socnoc.yaml
+++ b/demos/concepts/offline-edge-ai-socnoc.yaml
@@ -1,0 +1,11 @@
+concept_id: offline-edge-ai-socnoc
+label: Offline Edge-AI SOC/NOC
+status: demonstrated
+stage_order:
+  - mixed_correlation_demo
+  - noc_degraded_demo
+scenarios:
+  - id: mixed_correlation_demo
+    role: local deterministic triage with optional AI narrative support
+  - id: noc_degraded_demo
+    role: offline-friendly NOC degradation response walkthrough

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,37 @@
+# API Reference
+
+This document is the API entry point for Azazel-Edge.
+
+Detailed endpoint behavior is intentionally split by operational context to avoid stale duplication.
+
+## Primary API Surfaces
+
+- State and dashboard APIs
+- Control and mode APIs
+- SoT and trust update APIs
+- Triage APIs
+- Runbook proposal/review/act APIs
+- Demo replay APIs
+- AI ask/capability APIs
+
+## Authoritative Sources
+
+- Web/API implementation: `azazel_edge_web/app.py`
+- Deterministic runtime architecture: [P0 Runtime Architecture](P0_RUNTIME_ARCHITECTURE.md)
+- Demo API and replay semantics: [Demo Guide](DEMO_GUIDE.md)
+- AI-assist API behavior: [AI Operation Guide](AI_OPERATION_GUIDE.md)
+- Post-demo route boundaries: [Post-demo Main Integration Boundary (#104)](POST_DEMO_MAIN_INTEGRATION_104.md)
+
+## Authentication and Authorization
+
+- Protected API routes are fail-closed by default.
+- Role/token and optional mTLS controls are documented in:
+  - [Configuration Reference](CONFIGURATION.md)
+  - [Post-demo Socket Permission Model (#105)](POST_DEMO_SOCKET_PERMISSION_MODEL_105.md)
+
+## Compatibility Note
+
+API contract details evolve with implementation.
+For release-specific behavior, consult:
+- [Changelog](CHANGELOG.md)
+- [Release Verification Guide](RELEASE_VERIFICATION_GUIDE.md)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,36 @@
+# Configuration Reference
+
+This document is the configuration entry point for Azazel-Edge.
+
+## Runtime Configuration Layers
+
+- Runtime defaults and environment files under `/etc/default/azazel-edge-*`
+- Deterministic SOC policy files under `config/soc_policy*.yaml`
+- Concept-to-profile mapping under `configs/profiles/*.yaml`
+- Installer toggles under `installer/internal/*.sh`
+
+## Key Configuration Domains
+
+- Authentication and fail-closed posture
+- SOC/NOC policy thresholds
+- AI assist thresholds and resource guardrails
+- Demo replay and overlay behavior
+- Aggregator and optional integration toggles
+
+## Authoritative Documents
+
+- AI-related runtime tuning: [AI Operation Guide](AI_OPERATION_GUIDE.md)
+- SOC threshold and redirect policy controls: [SOC Policy Guide](SOC_POLICY_GUIDE.md)
+- Deployment profile intent and scope: [Deployment Profiles](DEPLOYMENT_PROFILES.md)
+- Socket/runtime permission posture: [Post-demo Socket Permission Model (#105)](POST_DEMO_SOCKET_PERMISSION_MODEL_105.md)
+- Concept-profile mapping layer: [../configs/profiles/README.md](../configs/profiles/README.md)
+
+## Implementation Sources
+
+- Policy loader: `py/azazel_edge/policy.py`
+- AI governance entrypoint: `py/azazel_edge/ai_governance.py`
+- Installer scripts: `installer/internal/`
+
+## Operational Note
+
+Use deployment-appropriate profiles and validate changes in a dry-run or test environment before production field use.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,6 +11,8 @@ Entry point for all documents in this directory.
 | [concepts/evolution-map.md](concepts/evolution-map.md) | Operator / Developer | Concept profile map for a single Azazel-Edge core platform | 2026-05-16 |
 | [arsenal/README.md](arsenal/README.md) | Operator / Presenter | Public Black Hat Arsenal history and policy | 2026-05-16 |
 | [architecture/decision-loop.md](architecture/decision-loop.md) | Developer / Operator | Stable deterministic decision loop overview | 2026-05-16 |
+| [../configs/profiles/README.md](../configs/profiles/README.md) | Developer / Operator | Concept-to-configuration mapping layer | 2026-05-16 |
+| [../demos/concepts/README.md](../demos/concepts/README.md) | Operator / Presenter | Concept-oriented demo scenario grouping | 2026-05-16 |
 | [P0_RUNTIME_ARCHITECTURE.md](P0_RUNTIME_ARCHITECTURE.md) | Developer | Decision pipeline, implementation modules, and P0 constraints | 2026-03-10 |
 | [AZAZEL_AGGREGATOR_ARCHITECTURE.md](AZAZEL_AGGREGATOR_ARCHITECTURE.md) | Developer / Operator | Multi-node Azazel Aggregator design baseline and phased roadmap | 2026-05-12 |
 | [SOC_POLICY_GUIDE.md](SOC_POLICY_GUIDE.md) | Developer / Operator | Deterministic SOC policy tuning and safety constraints | 2026-05-12 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -27,6 +27,8 @@ Entry point for all documents in this directory.
 | File | Audience | Description | Last Updated |
 |------|----------|-------------|--------------|
 | [AI_OPERATION_GUIDE.md](AI_OPERATION_GUIDE.md) | Operator / Developer | LLM thresholds, daily checks, and incident response (EN) | 2026-05-13 |
+| [API_REFERENCE.md](API_REFERENCE.md) | Developer / Operator | API surface map and authoritative links | 2026-05-16 |
+| [CONFIGURATION.md](CONFIGURATION.md) | Developer / Operator | Configuration surface map and authoritative links | 2026-05-16 |
 | [AI_OPERATION_GUIDE_JA.md](AI_OPERATION_GUIDE_JA.md) | Operator / Developer | AI運用要領（日本語版） | 2026-03-10 |
 | [AI_AGENT_BUILD_AND_OPERATION_DETAIL.md](AI_AGENT_BUILD_AND_OPERATION_DETAIL.md) | Developer | AI agent internals and build steps (EN) | 2026-05-13 |
 | [AI_AGENT_BUILD_AND_OPERATION_DETAIL_JA.md](AI_AGENT_BUILD_AND_OPERATION_DETAIL_JA.md) | Developer | エージェントAI構築手順書（日本語版） | 2026-03-08 |

--- a/docs/RELEASE_VERIFICATION_GUIDE.md
+++ b/docs/RELEASE_VERIFICATION_GUIDE.md
@@ -28,6 +28,13 @@ Review both artifacts before promoting a release to field deployment.
 - Use signed tags for release points.
 - Keep release notes linked to merged PRs and issue IDs.
 - Keep `docs/CHANGELOG.md` updated per release.
+- Keep `docs/API_REFERENCE.md` and `docs/CONFIGURATION.md` aligned with the released API/configuration surface.
+
+## Documentation sync checks (release gate)
+
+Before release cut, confirm:
+- If API routes/contract changed since previous release, `docs/API_REFERENCE.md` was reviewed and updated.
+- If environment variables, policy paths, or runtime toggles changed since previous release, `docs/CONFIGURATION.md` was reviewed and updated.
 
 ## Scope note
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Azazel-Edge — Emergency SOC/NOC gateway for Raspberry Pi with deterministic decision logic and optional local AI advisory." />
-  <title>Azazel-Edge | Emergency SOC/NOC Gateway</title>
+  <meta name="description" content="AZ-01 Azazel-Edge (Codename: SENTINEL) — deterministic edge SOC/NOC gateway core platform of the Azazel system for Raspberry Pi and constrained networks." />
+  <title>AZ-01 Azazel-Edge | Deterministic Edge SOC/NOC Gateway</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -20,7 +20,6 @@
       <span class="beacon-wrap"><span class="beacon"></span>OPERATIONAL</span>
       <span class="topbar-sep">|</span>
       <span class="topbar-badges">
-        <span class="tbadge">Black Hat USA 2025 Arsenal</span>
         <span class="tbadge">Black Hat Asia 2026 Arsenal</span>
         <span class="tbadge">Black Hat USA 2026 Arsenal</span>
       </span>
@@ -38,7 +37,7 @@
           <img class="hero-logo" src="images/Azazel-Edge_logo.png" alt="Azazel-Edge logo" />
           <div class="hero-brand-text">
             <span class="hero-brand-name">AZAZEL-EDGE</span>
-            <span class="hero-brand-sub">Emergency SOC/NOC Gateway</span>
+            <span class="hero-brand-sub">AZ-01 · Codename SENTINEL · Deterministic Edge SOC/NOC Gateway</span>
           </div>
         </div>
 
@@ -420,7 +419,7 @@
           <span class="footer-sep">·</span>
           <span>Successor to Azazel-Pi</span>
         </div>
-        <p class="footer-note">Black Hat Arsenal — USA 2025 · Asia 2026 · USA 2026</p>
+        <p class="footer-note">Black Hat Arsenal — Asia 2026 · USA 2026</p>
       </div>
     </footer>
 


### PR DESCRIPTION
## Summary
- add concept-aligned mapping layer under configs/profiles/
- add concept-oriented demo grouping layer under demos/concepts/
- keep existing runtime paths unchanged (config/soc_policy_profiles and py/azazel_edge/demo/scenarios.py)
- add lightweight navigation updates in README and docs/INDEX

## Added
- configs/profiles/README.md
- configs/profiles/offline-edge-ai-socnoc.yaml
- configs/profiles/deterministic-edge-decision-support.yaml
- configs/profiles/auditable-edge-socnoc.yaml
- configs/profiles/field-deployable-scapegoat-gateway.yaml
- demos/concepts/README.md
- demos/concepts/offline-edge-ai-socnoc.yaml
- demos/concepts/deterministic-edge-decision-support.yaml
- demos/concepts/auditable-edge-socnoc.yaml
- demos/concepts/field-deployable-scapegoat-gateway.yaml

## Updated
- README.md
- docs/INDEX.md

## Notes
- no deletion of existing documentation/configuration
- no event-specific future files introduced
- existing demo scenario IDs remain unchanged for compatibility
