### PR TITLE
docs(cfp): candidate CFP draft, paper, roadmap, and issue planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Different operational profiles are documented as concept profiles, not forks.
 - [Auditable Edge SOC/NOC](docs/concepts/auditable-edge-socnoc.md)
 - [Field-Deployable Scapegoat Gateway](docs/concepts/field-deployable-scapegoat-gateway.md)
 
+Pre-acceptance planning material (not accepted appearances):
+- [Black Hat Europe Arsenal CFP Draft](docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md)
+- [Paper: Auditable Edge SOC/NOC Gateway](docs/papers/auditable-edge-socnoc-europe.md)
+
 ## Arsenal Demonstrations
 
 Only accepted and public Black Hat Arsenal appearances are recorded here.

--- a/docs/BHEU_ARSENAL_DRY_RUN_CHECKLIST.md
+++ b/docs/BHEU_ARSENAL_DRY_RUN_CHECKLIST.md
@@ -1,0 +1,152 @@
+# Black Hat Europe Arsenal — Pre-Submission / Pre-Event Rehearsal Checklist
+
+**Status: rehearsal tracking artifact.**
+This document tracks preparation steps for a Black Hat Europe Arsenal submission that has **not been accepted**. Nothing here implies Black Hat acceptance, scheduling, or appearance. All on-Raspberry-Pi run checkboxes are left unchecked because the actual hardware run is a human step that cannot be pre-confirmed in this document.
+
+---
+
+## Offline Rehearsal Checklist
+
+Steps adapted from the "Demo Readiness Checklist" in [`docs/roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md`](roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md).
+
+### Environment Setup
+
+- [ ] Raspberry Pi-class device powered on, storage verified, no mandatory network dependency.
+- [ ] All scenario files and model weights pre-loaded on device (AI-assist aside requires local Ollama; demo runs fully without it in deterministic mode).
+- [ ] Confirm `AZAZEL_DEFENSE_ENFORCE` is **not set** (default off). Live enforcement must not be active during any demo run.
+
+### Step 1 — Deterministic Replay: `auditable_edge_socnoc` scenario
+
+- [ ] Run `bin/azazel-edge-demo run auditable_edge_socnoc` offline on target hardware.
+- [ ] Confirm output reports `execution.mode = deterministic_replay` and `ai_used = false`.
+- [ ] Confirm the scenario drives a high-confidence SOC bounded reversible-control decision (`action=throttle`).
+- [ ] Confirm `rejected_alternatives` list is non-empty (at minimum one alternative recorded with a reason).
+- [ ] Confirm a `release_condition` string is present in the decision record.
+- [ ] Confirm `config_hash` and `policy_profile` are present in the local decision record.
+
+**Target time for Step 1: ~3 minutes.**
+
+### Step 2 — v2 Explanation Field Walk-Through
+
+- [ ] Open the latest explanation record (via `bin/azazel-edge-audit-review` or `/api/demo/explanation/latest`).
+- [ ] Walk through each auditable field with the audience:
+  - `selected_action`
+  - `rejected_actions` / `why_not_others` (show that alternatives were considered and recorded)
+  - `release_condition` (read the human-readable string aloud)
+  - `policy_profile` and `config_hash` (explain anchoring to known configuration)
+  - `trace_id`
+  - `evidence_ids`
+  - `operator_wording` (plain-language handoff text)
+- [ ] Demonstrate `bin/azazel-edge-audit-review` in read-only mode — confirm it presents the decision → explanation → audit-chain walk without modifying any state.
+
+**Target time for Step 2: ~5 minutes.**
+
+### Step 3 — Audit-Chain `verify_chain` Demonstration
+
+- [ ] Run `verify_chain` against the hash-chained audit log. Confirm it reports no mismatch on the clean log.
+- [ ] Tamper drill: manually alter one byte of a record in a copy of the audit log (do not touch the original). Run `verify_chain` against the copy. Confirm it detects and reports the mismatch at the correct position.
+- [ ] Show audience that the tampered-record chain break is detectable at a specific position, illustrating the tamper-evident property.
+
+**Target time for Step 3: ~4 minutes.**
+
+### Step 4 — SOC Policy Dry-Run
+
+- [ ] Run `bin/azazel-soc-policy-dry-run` against two policy profiles (e.g., `balanced` and `conservative`).
+- [ ] Confirm the command reports the policy hash for each profile and the would-be decisions.
+- [ ] Walk through how a different policy profile yields a different policy hash and potentially different action thresholds — demonstrating reproducibility metadata.
+
+**Target time for Step 4: ~3 minutes.**
+
+### Step 5 — Read-Only Review Command
+
+- [ ] Run `bin/azazel-edge-audit-review` as the primary reviewer walk-through command.
+- [ ] Confirm it is read-only (no writes, no state changes, no enforcement).
+- [ ] Show the decision → explanation → audit-chain navigation.
+
+**Target time for Step 5: ~2 minutes.**
+
+### Step 6 — Optional Local AI Assist (shown separately, clearly labelled)
+
+- [ ] If demonstrating AI assist: confirm it runs only against a local Ollama instance (`127.0.0.1`).
+- [ ] Show that the AI assist step runs *after* the deterministic decision and cannot change it.
+- [ ] Show an audited AI invocation record in the audit log (the governance layer logs every invocation).
+- [ ] Clearly label this as optional and not part of the deterministic path.
+
+**Target time for Step 6 (if shown): ~3 minutes.**
+
+### Step 7 — Fallback Drill
+
+- [ ] Simulate a failure condition (e.g., telemetry feed unavailable, AI assist unavailable).
+- [ ] Confirm the deterministic replay path remains functional with no live telemetry and no live enforcement.
+- [ ] Confirm `bin/azazel-edge-demo run auditable_edge_socnoc` completes successfully in fallback (replay-only) mode.
+- [ ] Confirm no live network redirection or enforcement is triggered in fallback mode.
+
+**Target time for fallback drill: ~3 minutes.**
+
+### Overall Timing Estimate
+
+| Step | Estimated Time |
+|------|----------------|
+| Step 1 — Deterministic replay | ~3 min |
+| Step 2 — Explanation field walk | ~5 min |
+| Step 3 — Audit-chain verify + tamper drill | ~4 min |
+| Step 4 — Policy dry-run | ~3 min |
+| Step 5 — Read-only review command | ~2 min |
+| Step 6 — AI assist (optional) | ~3 min |
+| Step 7 — Fallback drill | ~3 min |
+| **Total (incl. optional AI step)** | **~23 min** |
+| **Total (excl. optional AI step)** | **~20 min** |
+
+Adjust per actual Arsenal slot length. Plan for an audience Q&A buffer.
+
+---
+
+## Reviewer Q&A — Honest Answers
+
+These answers are prepared for the likely Prototype and Planned questions from reviewers. They are candid by design.
+
+### On Prototype items
+
+**Q: Does `trace_id` thread automatically end-to-end from the Rust core through the Python pipeline?**
+
+A: No. The `trace_id` field exists at every stage from the Rust core through the Python pipeline, but automatic end-to-end propagation is **(Prototype)**: there is no integration test confirming the identifier is threaded automatically across the language boundary. Correlation across that boundary cannot currently be guaranteed. The demo correlates within the Python pipeline only and makes no claim of automatic Rust→Python threading.
+
+**Q: Can policy profiles be switched at runtime?**
+
+A: Not yet. Policy profiles are loaded via environment variable (`AZAZEL_SOC_POLICY_PATH`) at start time. Runtime switching without restart is **(Prototype)** — there is no runtime switcher. Three profiles (balanced, conservative, demo) are available and selectable at start.
+
+**Q: Is live nftables/tc enforcement tested and production-ready?**
+
+A: No. Live network enforcement (nftables/tc) lives in the Rust core behind `AZAZEL_DEFENSE_ENFORCE=true`. The default is **false**; the demo always runs with the default (dry-run). The Rust enforcement core does not carry its own automated test coverage, which limits confidence in enforcement behavior even when opted in. The Python redirect path records and audits redirect decisions without executing them. This is **(Prototype)** behavior at the enforcement layer.
+
+### On Planned items
+
+**Q: Can I get a reproducible replay by packaging the exact policy, config, and evidence together?**
+
+A: Partially. Decisions carry `config_hash` and `policy_profile`, which anchor them to a known configuration. However, full config-hash and reproducibility *packaging across all outputs* — a single bundle you could ship to a reviewer and replay exactly — is **(Planned)** and not yet implemented. The infrastructure to support it (per-stream hashes, policy hash at load) is in place; the packaging layer is not.
+
+**Q: Can I export a unified incident evidence bundle?**
+
+A: Not yet as a unified package. Decision explanations and audit logs exist as separate streams. A unified incident evidence-bundle export format — one package containing the explanation record, the consulted evidence, and the relevant audit-chain segment for a single incident — is **(Planned)**.
+
+**Q: Do release conditions trigger automated rollback?**
+
+A: No. Release conditions are recorded as human-readable strings (e.g., `no_repeated_failures_for_300_seconds`) and are reviewed by operators. There is no automated rollback or release-condition orchestration today. Automated release-condition orchestration is **(Planned)**.
+
+### On enforcement and AI boundaries
+
+**Q: Is enforcement on by default?**
+
+A: No. `AZAZEL_DEFENSE_ENFORCE` is **off by default**. The Python path records and audits redirect decisions without executing them. Live nftables/tc enforcement is an explicit opt-in. The demo never performs live network redirection by default. This is stated in the Safety and Ethical Boundaries section and enforced at the code level.
+
+**Q: Can the AI change a decision?**
+
+A: No. AI assist is advisory-only and fully audited. The deterministic path decides before AI is ever invoked. AI assist can summarize, hint, and help phrase explanations; it cannot select or modify an arbiter action. This boundary is enforced in code and covered by tests. Every AI invocation is recorded in the audit log.
+
+**Q: Does the AI autonomously decide or take defensive action?**
+
+A: No. Azazel-Edge is explicitly not an autonomous AI defender. The authoritative decision path is a deterministic evaluator and arbiter. AI is restricted to advisory functions that run *after* the decision is made and that cannot alter it.
+
+---
+
+*No Black Hat Europe acceptance implied. This is a pre-submission and pre-event rehearsal tracking artifact.*

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Black Hat Europe Arsenal CFP draft (`docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md`) and paper-style concept document (`docs/papers/auditable-edge-socnoc-europe.md`) for the Auditable Edge SOC/NOC profile (pre-acceptance planning material; not accepted-appearance records).
+
 ### Changed
 
 ## [0.1.2] - 2026-05-17

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Black Hat Europe Arsenal CFP draft (`docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md`) and paper-style concept document (`docs/papers/auditable-edge-socnoc-europe.md`) for the Auditable Edge SOC/NOC profile (pre-acceptance planning material; not accepted-appearance records).
+- Submission/demo-readiness roadmap (`docs/roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md`) and gh-registerable issue drafts (`docs/issues/blackhat-europe/`) for the Auditable Edge SOC/NOC profile.
 
 ### Changed
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -42,6 +42,15 @@ Entry point for all documents in this directory.
 | [DEMO_GUIDE.md](DEMO_GUIDE.md) | Operator | Deterministic demo replay walkthrough | - |
 | [ARSENAL_DEMO_PROFILE.md](ARSENAL_DEMO_PROFILE.md) | Operator / Presenter | Fixed Black Hat Arsenal demo profile and fallback runbook | 2026-05-14 |
 
+## CFP Drafts and Papers
+
+Pre-acceptance planning material. CFP drafts are not accepted-appearance records and must not be moved to `docs/arsenal/` unless accepted.
+
+| File | Audience | Description | Last Updated |
+|------|----------|-------------|--------------|
+| [cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md](cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md) | Presenter / Reviewer | Black Hat Europe Arsenal CFP draft for the Auditable Edge SOC/NOC profile (not accepted) | 2026-06-10 |
+| [papers/auditable-edge-socnoc-europe.md](papers/auditable-edge-socnoc-europe.md) | Reviewer / Researcher | Paper-style technical description of the Auditable Edge SOC/NOC gateway concept | 2026-06-10 |
+
 ## Planning and Records
 
 | File | Audience | Description | Last Updated |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -50,6 +50,8 @@ Pre-acceptance planning material. CFP drafts are not accepted-appearance records
 |------|----------|-------------|--------------|
 | [cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md](cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md) | Presenter / Reviewer | Black Hat Europe Arsenal CFP draft for the Auditable Edge SOC/NOC profile (not accepted) | 2026-06-10 |
 | [papers/auditable-edge-socnoc-europe.md](papers/auditable-edge-socnoc-europe.md) | Reviewer / Researcher | Paper-style technical description of the Auditable Edge SOC/NOC gateway concept | 2026-06-10 |
+| [roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md](roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md) | Developer / Presenter | Submission- and demo-readiness roadmap for the Auditable Edge SOC/NOC profile | 2026-06-10 |
+| [issues/blackhat-europe/README.md](issues/blackhat-europe/README.md) | Developer | Issue drafts (gh-registerable) for Black Hat Europe CFP readiness | 2026-06-10 |
 
 ## Planning and Records
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -52,6 +52,7 @@ Pre-acceptance planning material. CFP drafts are not accepted-appearance records
 | [papers/auditable-edge-socnoc-europe.md](papers/auditable-edge-socnoc-europe.md) | Reviewer / Researcher | Paper-style technical description of the Auditable Edge SOC/NOC gateway concept | 2026-06-10 |
 | [roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md](roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md) | Developer / Presenter | Submission- and demo-readiness roadmap for the Auditable Edge SOC/NOC profile | 2026-06-10 |
 | [issues/blackhat-europe/README.md](issues/blackhat-europe/README.md) | Developer | Issue drafts (gh-registerable) for Black Hat Europe CFP readiness | 2026-06-10 |
+| [BHEU_ARSENAL_DRY_RUN_CHECKLIST.md](BHEU_ARSENAL_DRY_RUN_CHECKLIST.md) | Developer / Presenter | Pre-submission / pre-event rehearsal checklist for Black Hat Europe Arsenal (not accepted; on-hardware run is a human step) | 2026-06-11 |
 
 ## Planning and Records
 

--- a/docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md
+++ b/docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md
@@ -48,7 +48,7 @@ Azazel-Edge is a single core platform presented through concept profiles; this s
 - **P0 audit logger** — hash-chained, tamper-evident JSONL.
 - **AI governance layer** — local Ollama only, advisory output only, every call audited; AI cannot decide actions.
 - **OpenCanary redirect decision path** — evaluates arbiter plus SOC thresholds and records redirect decisions to state JSON, JSONL, and the audit chain.
-- **Review surfaces** — Web API endpoints (`/api/triage/audit`, `/api/demo/explanation/latest`, dashboard APIs), a unified CLI, and a TUI.
+- **Review surfaces** — Web API endpoints (`/api/triage/audit`, `/api/demo/explanation/latest`, dashboard APIs), a unified CLI, a TUI, and the read-only `bin/azazel-edge-audit-review` command (decision → explanation → audit-chain walk, no state modification).
 
 ## Why This Fits Black Hat Europe Arsenal
 
@@ -77,7 +77,7 @@ The demo is staged and replay-based, designed for a booth and for offline operat
 4. **Policy dry-run.** Replay the same events against a candidate SOC policy profile and compare reported policy hash and would-be decisions.
 5. **Optional local AI assist (shown separately).** Demonstrate that local AI only summarizes and hints, and that its invocation is audited and cannot change the decision.
 
-Demo scenarios: the deterministic showcase uses the existing `mixed_correlation_demo` scenario. A dedicated Europe-flavored scenario id `auditable_edge_socnoc` is **Planned** and does not exist yet; do not present it as available.
+Demo scenarios: the deterministic showcase uses the **`auditable_edge_socnoc`** scenario (available in the demo pack). It drives a high-confidence SOC bounded reversible-control decision (action=throttle) with non-empty rejected alternatives, a release condition, and `config_hash`/`policy_profile` in the local decision record, reviewable read-only via `bin/azazel-edge-audit-review`.
 
 If anything fails, the deterministic replay path is the final fallback, consistent with the Arsenal demo profile.
 
@@ -98,6 +98,8 @@ If anything fails, the deterministic replay path is the final fallback, consiste
 | Local AI assist with enforced governance | Implemented | `py/azazel_edge_ai/agent.py` (local Ollama only), `py/azazel_edge/ai_governance.py`; AI cannot select/modify actions. |
 | Local-first raw-log handling (default) | Implemented | Default Vector config writes only to local files; no raw-log egress path. |
 | Review surfaces (Web API, CLI, TUI) | Implemented | `/api/triage/audit`, `/api/demo/explanation/latest`, dashboard APIs. |
+| Read-only audit review command | Implemented | `bin/azazel-edge-audit-review`; read-only, presents the decision → explanation → audit-chain walk without modifying any state. |
+| Europe demo scenario `auditable_edge_socnoc` | Implemented | Available in the demo pack; drives action=throttle with non-empty rejected alternatives, release condition, and `config_hash`/`policy_profile` in the local decision record. |
 
 ## Planned / Prototype Capabilities
 
@@ -109,7 +111,6 @@ If anything fails, the deterministic replay path is the final fallback, consiste
 | Unified incident evidence bundle export | Planned | Partial export paths exist; unified package format is in progress. |
 | Automated release-condition orchestration | Planned | Release conditions are recorded as reviewable strings; no automated rollback executes them. |
 | Live network redirect/isolation enforcement | Prototype | Code path exists in the Rust core behind `AZAZEL_DEFENSE_ENFORCE=true`; defaults to false with dry-run mode, rollback commands recorded, no automated tests. Never the demo default. |
-| Dedicated Europe demo scenario `auditable_edge_socnoc` | Planned | Does not exist yet; concept demo pack currently references `mixed_correlation_demo` and `disaster_phishing_demo`. |
 
 ## Safety and Ethical Boundaries
 
@@ -122,10 +123,50 @@ If anything fails, the deterministic replay path is the final fallback, consiste
 ## Reviewer Notes
 
 - **Demo-default vs opt-in.** The demo default is deterministic replay with `ai_used = false` and no live enforcement. Live Suricata input and live network enforcement are opt-in and must preserve immediate fallback to replay-only mode.
-- **Honest status.** Items marked Prototype (end-to-end `trace_id` threading, runtime profile switching) and Planned (full reproducibility packaging, unified evidence bundle export, automated release-condition orchestration, the `auditable_edge_socnoc` scenario) are not finished; please treat the tables above as authoritative.
+- **Honest status.** Items marked Prototype (end-to-end `trace_id` threading, runtime profile switching) and Planned (full reproducibility packaging, unified evidence bundle export, automated release-condition orchestration) are not finished; please treat the tables above as authoritative.
 - **Evidence for reviewers.** The behavior described is backed by the test suite at [`../../tests/`](../../tests/), including arbiter, audit-logger (with tamper detection), AI-governance, and config-drift tests.
 - **Privacy posture.** Raw logs never need to leave the site; the only external forwarding is an optional, non-default opt-in (normalized alerts via Wazuh CEF).
 - **No acceptance implied.** This is a draft submission, not a confirmed appearance.
+
+## Claims & Safety Sign-off
+
+Recorded 2026-06-11.
+
+- **Hype scan result.** The three documents reviewed (`docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md`, `docs/papers/auditable-edge-socnoc-europe.md`, `docs/roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md`) were scanned for the project's forbidden-hype phrase set (defined in `tools/claims_discipline.py` and the roadmap validation section); the only match was the checker's own definition list and a `grep` example, not a capability claim. No non-negated hype phrase was found in the draft, paper, or roadmap prose. Sign-off is **not blocked**.
+- **Implemented/Prototype/Planned label review.** Capability status labels were reviewed against repository state. The `auditable_edge_socnoc` scenario and `bin/azazel-edge-audit-review` command are now reflected as Implemented. Per-stream `config_hash`/`policy_profile` and rejected-alternatives/release-condition traceability are reflected as Implemented. The remaining Prototype items (end-to-end `trace_id` threading, runtime profile switching) and Planned items (full reproducibility packaging, unified evidence bundle export, automated release-condition orchestration) remain accurately labelled.
+- **AI-advisory boundary.** The AI-advisory-only and audited boundary is stated accurately: local AI assist cannot select or modify an arbiter action (enforced in code and tests); every AI invocation is audited. This is stated in the Safety and Ethical Boundaries section and the Tool Description.
+- **Enforcement-off-by-default boundary.** The `AZAZEL_DEFENSE_ENFORCE` off-by-default and dry-run posture is stated accurately in the Safety and Ethical Boundaries section and in the Reviewer Notes.
+- **Human proofread.** A final human proofread of the full draft against the submission form has not yet been completed. This remains an open item before submission.
+
+## Abstract Variants
+
+The two variants below restate only claims already present in this draft. No new claims are introduced.
+
+### Short Abstract
+
+Azazel-Edge is a local-first edge SOC/NOC gateway built around a deterministic decision loop rather than an opaque AI defender. Telemetry is normalized into compact evidence, scored by separate NOC and SOC evaluators, and resolved by an Action Arbiter that selects exactly one of five bounded responses: observe, notify, throttle, redirect, isolate. Each decision produces a structured explanation record — the selected action, the rejected alternatives and why they were not chosen, a human-readable release condition, the active policy profile, a configuration hash, and a trace id — and is appended to a hash-chained, tamper-evident audit log. Local AI assist is strictly advisory: it can summarize, hint, and help phrase explanations, but it cannot select or modify an action. Raw logs stay on the device by default. The Arsenal demo runs as a deterministic replay on Raspberry Pi-class hardware, offline-capable, so reviewers can inspect the same explanation JSONL and audit chain an operator would use to justify a decision after the fact.
+
+(1045 characters)
+
+### Detailed Abstract
+
+Many "AI for defense" tools ask operators to trust a black-box verdict. In privacy-sensitive and regulated environments this is a poor fit: reviewers, auditors, and incident handlers need to know why a control was applied, what else was considered, and how to reverse it. Azazel-Edge takes the opposite stance. The deterministic decision loop is authoritative; AI is advisory only and always runs after the decision is made.
+
+The pipeline is small and inspectable. Edge telemetry (for example Suricata EVE events and local probes) is normalized into Evidence Plane records. Two separate deterministic evaluators score state: a NOC evaluator across nine health dimensions and a SOC evaluator whose policy is loaded from a YAML policy file whose SHA-256 hash is computed at load time. Policy thresholds are applied, and the Action Arbiter selects one bounded action from a fixed set — observe, notify, throttle, redirect, isolate — where each action declares whether it is reversible, whether it requires approval, and whether it is audited.
+
+Every decision is explained in machine- and operator-readable form. The DecisionExplainer writes `format_version` "v2" JSONL records containing, among other fields: `selected_action`, `reason`, `rejected_actions` with `why_not_others`, `release_condition` (a human-readable string describing what must hold before the action is relaxed), `policy_profile`, `config_hash`, `trace_id`, `why_chosen`, `evidence_ids`, `next_checks`, and `operator_wording` for plain-language handoff. The record is sealed with an HMAC-signed trust capsule. In parallel, the P0 audit logger appends each event to a hash-chained JSONL log (`chain_prev` / `chain_hash` per record), making after-the-fact tampering detectable; the test suite includes tamper-detection cases.
+
+Local-first handling is the default. The shipped Vector configuration writes only to local files, and no code path sends raw logs to external APIs. AI assist talks only to a local Ollama instance on `127.0.0.1`; an AI governance layer strips raw-log keys before any model call, restricts AI output to advice, summary, and candidate fields, and audits every invocation. The AI cannot pick or alter an arbiter action — this is enforced in code and in tests. Deception is defensive and bounded: a redirect decision can divert selected flows toward prepared OpenCanary decoys, but the Python path records and audits the redirect decision and a recorded enforcement plan; actual network enforcement lives in the Rust core, is opt-in, and is dry-run by default with rollback commands recorded.
+
+Reproducibility is built into the workflow. Three SOC policy profiles (balanced, conservative, demo) are selectable, and a policy dry-run CLI replays normalized events against a candidate policy and reports the policy hash and would-be decisions before anything ships. A deterministic replay demo runner tags every run `execution.mode = deterministic_replay` and `ai_used = false`, so the demo is stable and explainable.
+
+Azazel-Edge does not guarantee legal or regulatory compliance. It supports operator accountability and after-the-fact explanation in regulated contexts by making decisions reviewable, reversible, and traceable.
+
+(3176 characters)
+
+---
+
+*Confirm against the official Black Hat Europe Arsenal submission-form character limits before submission.*
 
 ## Links to Repository Documents
 

--- a/docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md
+++ b/docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md
@@ -1,0 +1,141 @@
+# Black Hat Europe Arsenal CFP Draft: Auditable Edge SOC/NOC Gateway
+
+Status: CFP draft — not an accepted appearance. This document must not be moved to `docs/arsenal/` unless accepted.
+
+This is a submission draft for a Black Hat Europe Arsenal proposal. Nothing here implies that the tool has been reviewed, selected, or scheduled. It describes one concept profile of the single Azazel-Edge core platform, framed for privacy-sensitive and regulated operations.
+
+## Proposed Title
+
+Primary title:
+
+- **AZ-01 Azazel-Edge: Auditable Edge SOC/NOC Gateway**
+
+Alternative titles (one-line rationale each):
+
+| Candidate | Rationale |
+|---|---|
+| Azazel-Edge: Deterministic Edge Defense with Explainable Deception and Local AI Triage | Foregrounds the three pillars: deterministic decisions, bounded deception, advisory local AI. |
+| AZ-01 Azazel-Edge: Privacy-Preserving Edge SOC/NOC with Auditable Decision Support | Leads with the privacy and accountability angle most relevant to European reviewers. |
+| Azazel-Edge: Explainable Cyber Scapegoat Gateway for Local-First Incident Response | Keeps the project's "scapegoat" decoy metaphor while stressing local-first handling. |
+| Azazel-Edge: Reviewable Decision Records for Edge SOC/NOC in Regulated Environments | Sober, regulation-facing framing centered on after-the-fact review. |
+| AZ-01 Azazel-Edge: Hash-Chained, Explainable Edge Defense Decisions | Concise, emphasizes the tamper-evident audit chain as the differentiator. |
+
+## Short Abstract
+
+Azazel-Edge is a local-first edge SOC/NOC gateway built around a deterministic decision loop rather than an opaque AI defender. Telemetry is normalized into compact evidence, scored by separate NOC and SOC evaluators, and resolved by an Action Arbiter that selects exactly one of five bounded responses: observe, notify, throttle, redirect, isolate. Each decision produces a structured explanation record — the selected action, the rejected alternatives and why they were not chosen, a human-readable release condition, the active policy profile, a configuration hash, and a trace id — and is appended to a hash-chained, tamper-evident audit log. Local AI assist is strictly advisory: it can summarize, hint, and help phrase explanations, but it cannot select or modify an action. Raw logs stay on the device by default. The Arsenal demo runs as a deterministic replay on Raspberry Pi-class hardware, offline-capable, so reviewers can inspect the same explanation JSONL and audit chain an operator would use to justify a decision after the fact.
+
+## Detailed Abstract
+
+Many "AI for defense" tools ask operators to trust a black-box verdict. In privacy-sensitive and regulated environments this is a poor fit: reviewers, auditors, and incident handlers need to know why a control was applied, what else was considered, and how to reverse it. Azazel-Edge takes the opposite stance. The deterministic decision loop is authoritative; AI is advisory only and always runs after the decision is made.
+
+The pipeline is small and inspectable. Edge telemetry (for example Suricata EVE events and local probes) is normalized into Evidence Plane records. Two separate deterministic evaluators score state: a NOC evaluator across nine health dimensions and a SOC evaluator whose policy is loaded from a YAML policy file whose SHA-256 hash is computed at load time. Policy thresholds are applied, and the Action Arbiter selects one bounded action from a fixed set — observe, notify, throttle, redirect, isolate — where each action declares whether it is reversible, whether it requires approval, and whether it is audited.
+
+Every decision is explained in machine- and operator-readable form. The DecisionExplainer writes `format_version` "v2" JSONL records containing, among other fields: `selected_action`, `reason`, `rejected_actions` with `why_not_others`, `release_condition` (a human-readable string describing what must hold before the action is relaxed), `policy_profile`, `config_hash`, `trace_id`, `why_chosen`, `evidence_ids`, `next_checks`, and `operator_wording` for plain-language handoff. The record is sealed with an HMAC-signed trust capsule. In parallel, the P0 audit logger appends each event to a hash-chained JSONL log (`chain_prev` / `chain_hash` per record), making after-the-fact tampering detectable; the test suite includes tamper-detection cases.
+
+Local-first handling is the default. The shipped Vector configuration writes only to local files, and no code path sends raw logs to external APIs. AI assist talks only to a local Ollama instance on `127.0.0.1`; an AI governance layer strips raw-log keys before any model call, restricts AI output to advice, summary, and candidate fields, and audits every invocation. The AI cannot pick or alter an arbiter action — this is enforced in code and in tests. Deception is defensive and bounded: a redirect decision can divert selected flows toward prepared OpenCanary decoys, but the Python path records and audits the redirect decision and a recorded enforcement plan; actual network enforcement lives in the Rust core, is opt-in, and is dry-run by default with rollback commands recorded.
+
+Reproducibility is built into the workflow. Three SOC policy profiles (balanced, conservative, demo) are selectable, and a policy dry-run CLI replays normalized events against a candidate policy and reports the policy hash and would-be decisions before anything ships. A deterministic replay demo runner tags every run `execution.mode = deterministic_replay` and `ai_used = false`, so the demo is stable and explainable.
+
+Azazel-Edge does not guarantee legal or regulatory compliance. It supports operator accountability and after-the-fact explanation in regulated contexts by making decisions reviewable, reversible, and traceable.
+
+## Tool Description
+
+Azazel-Edge is a single core platform presented through concept profiles; this submission is the "Auditable Edge SOC/NOC" profile. It runs on Raspberry Pi-class edge hardware and is offline-capable. Core components reviewers will see:
+
+- **Deterministic evaluators** — separate NOC evaluator (nine health dimensions) and SOC evaluator, policy loaded from `config/soc_policy.yaml` with a SHA-256 hash computed at load.
+- **Action Arbiter** — selects one of five bounded actions; each output includes the selected action, reason, rejected alternatives with reasons, release condition, chosen evidence ids, decision trace, and policy reference.
+- **DecisionExplainer** — writes `format_version` "v2" explanation JSONL with the fields named above plus an HMAC-signed trust capsule.
+- **P0 audit logger** — hash-chained, tamper-evident JSONL.
+- **AI governance layer** — local Ollama only, advisory output only, every call audited; AI cannot decide actions.
+- **OpenCanary redirect decision path** — evaluates arbiter plus SOC thresholds and records redirect decisions to state JSON, JSONL, and the audit chain.
+- **Review surfaces** — Web API endpoints (`/api/triage/audit`, `/api/demo/explanation/latest`, dashboard APIs), a unified CLI, and a TUI.
+
+## Why This Fits Black Hat Europe Arsenal
+
+European SOC/NOC teams increasingly operate under privacy and accountability expectations that an opaque automated defender cannot satisfy. Arsenal attendees can sit at a Raspberry Pi-class device, trigger a deterministic decision, and immediately read the full explanation record and the hash-chained audit entry that justify it — no cloud, no raw-log egress, no trust-the-model leap. The tool demonstrates a concrete pattern for explainable, reviewable, local-first edge defense rather than a marketing claim, which suits Arsenal's hands-on, source-available format. It also shows a defensive use of deception (controlled decoy observation via OpenCanary, bounded by policy) without any offensive or attack-automation framing.
+
+## Technical Differentiators
+
+| Differentiator | What it means for reviewers |
+|---|---|
+| Rejected alternatives recorded | Each decision lists the actions not chosen and `why_not_others`, so the decision space is visible, not just the outcome. |
+| Release condition per action | Every action carries a human-readable `release_condition` describing what must hold before it is relaxed. |
+| Config hash + policy profile | Decisions carry `config_hash` and `policy_profile`, anchoring them to a known configuration for reproducibility (full cross-output packaging is still maturing). |
+| Hash-chained audit trail | `chain_prev` / `chain_hash` per record makes tampering detectable; tamper-detection is covered by tests. |
+| SOC policy dry-run | A CLI replays normalized events against a candidate policy and reports the policy hash and would-be decisions before rollout. |
+| Deterministic replay demo | Replay runs are tagged `deterministic_replay` with `ai_used = false`, giving stable, explainable demo output. |
+| Enforced AI governance boundary | AI is local-only and advisory; it cannot select or modify an arbiter action, enforced in code and tests. |
+| Reversible, bounded actions | Five explicit actions only, each declaring reversible / approval-required / audited attributes. |
+
+## Demo Plan
+
+The demo is staged and replay-based, designed for a booth and for offline operation on Raspberry Pi-class hardware.
+
+1. **Deterministic path (primary).** Run a replay scenario in `deterministic_replay` mode (`ai_used = false`). Show evidence normalization, separate NOC/SOC scoring, and the Action Arbiter selecting one bounded action.
+2. **Explanation review (live).** Open the latest explanation record via CLI or the Web UI (`/api/demo/explanation/latest`) and walk the fields: `selected_action`, `rejected_actions` / `why_not_others`, `release_condition`, `policy_profile`, `config_hash`, `trace_id`, `operator_wording`.
+3. **Audit chain review (live).** Inspect the hash-chained audit log (`/api/triage/audit`) and show how a modified record breaks the chain.
+4. **Policy dry-run.** Replay the same events against a candidate SOC policy profile and compare reported policy hash and would-be decisions.
+5. **Optional local AI assist (shown separately).** Demonstrate that local AI only summarizes and hints, and that its invocation is audited and cannot change the decision.
+
+Demo scenarios: the deterministic showcase uses the existing `mixed_correlation_demo` scenario. A dedicated Europe-flavored scenario id `auditable_edge_socnoc` is **Planned** and does not exist yet; do not present it as available.
+
+If anything fails, the deterministic replay path is the final fallback, consistent with the Arsenal demo profile.
+
+## Implemented Capabilities
+
+| Capability | Status | Notes |
+|---|---|---|
+| Deterministic NOC evaluator (nine health dimensions) | Implemented | `py/azazel_edge/evaluators/noc.py`. |
+| Deterministic SOC evaluator with hashed policy load | Implemented | `py/azazel_edge/evaluators/soc.py`; policy SHA-256 computed at load in `py/azazel_edge/policy.py`. |
+| Action Arbiter, five bounded actions with profiles | Implemented | `py/azazel_edge/arbiter/action.py`; output includes selected action, reason, rejected alternatives, release condition, evidence ids, decision trace, policy reference. |
+| DecisionExplainer v2 JSONL with trust capsule | Implemented | `py/azazel_edge/explanations/decision.py`; HMAC-signed trust capsule. |
+| Hash-chained tamper-evident audit log | Implemented | `py/azazel_edge/audit/logger.py`; tamper detection covered by tests. |
+| Three SOC policy profiles (balanced/conservative/demo) | Implemented | `config/soc_policy_profiles/`; selected via `AZAZEL_SOC_POLICY_PATH`. |
+| Config drift auditing (per-file SHA-256 baselines) | Implemented | `py/azazel_edge/config_drift.py`. |
+| SOC policy dry-run CLI | Implemented | `bin/azazel-soc-policy-dry-run`; reports policy hash and would-be decisions. |
+| Deterministic replay demo runner (11 scenarios) | Implemented | `bin/azazel-edge-demo`, `py/azazel_edge/demo/scenarios.py`; tagged `deterministic_replay`, `ai_used = false`. |
+| OpenCanary redirect decision path (decision + audit) | Implemented | `py/azazel_edge/opencanary_redirect.py`, `config/redirect_policy.yaml`; records decisions to state JSON, JSONL, audit chain. |
+| Local AI assist with enforced governance | Implemented | `py/azazel_edge_ai/agent.py` (local Ollama only), `py/azazel_edge/ai_governance.py`; AI cannot select/modify actions. |
+| Local-first raw-log handling (default) | Implemented | Default Vector config writes only to local files; no raw-log egress path. |
+| Review surfaces (Web API, CLI, TUI) | Implemented | `/api/triage/audit`, `/api/demo/explanation/latest`, dashboard APIs. |
+
+## Planned / Prototype Capabilities
+
+| Capability | Status | Notes |
+|---|---|---|
+| End-to-end `trace_id` threading (Rust core → Python pipeline) | Prototype | Every layer carries a `trace_id`, but automatic end-to-end threading is not guaranteed and lacks an integration test. |
+| Runtime policy-profile switching | Prototype | Profiles load via environment variable at start; no runtime switcher. |
+| Full config-hash / reproducibility packaging across all outputs | Planned | Partial support exists today. |
+| Unified incident evidence bundle export | Planned | Partial export paths exist; unified package format is in progress. |
+| Automated release-condition orchestration | Planned | Release conditions are recorded as reviewable strings; no automated rollback executes them. |
+| Live network redirect/isolation enforcement | Prototype | Code path exists in the Rust core behind `AZAZEL_DEFENSE_ENFORCE=true`; defaults to false with dry-run mode, rollback commands recorded, no automated tests. Never the demo default. |
+| Dedicated Europe demo scenario `auditable_edge_socnoc` | Planned | Does not exist yet; concept demo pack currently references `mixed_correlation_demo` and `disaster_phishing_demo`. |
+
+## Safety and Ethical Boundaries
+
+- **AI is advisory, never authoritative.** The deterministic decision loop decides. AI assists only with triage hints, summarization, and explanation support, and cannot select or modify an arbiter action (enforced in code and tests).
+- **Deception is defensive and bounded.** Redirect is controlled decoy observation via OpenCanary, gated by policy. There is no offensive or attack-automation capability.
+- **Enforcement is opt-in and dry-run by default.** The Python path records and audits redirect decisions and a recorded enforcement plan. Live nftables/tc enforcement is in the Rust core, off by default, with rollback commands recorded. The demo never performs live network redirection by default.
+- **Local-first by default.** Raw logs never need to leave the site; default configuration keeps them on the device.
+- **No compliance guarantee.** Azazel-Edge does not guarantee legal or regulatory compliance. It supports operator accountability and after-the-fact explanation in regulated contexts.
+
+## Reviewer Notes
+
+- **Demo-default vs opt-in.** The demo default is deterministic replay with `ai_used = false` and no live enforcement. Live Suricata input and live network enforcement are opt-in and must preserve immediate fallback to replay-only mode.
+- **Honest status.** Items marked Prototype (end-to-end `trace_id` threading, runtime profile switching) and Planned (full reproducibility packaging, unified evidence bundle export, automated release-condition orchestration, the `auditable_edge_socnoc` scenario) are not finished; please treat the tables above as authoritative.
+- **Evidence for reviewers.** The behavior described is backed by the test suite at [`../../tests/`](../../tests/), including arbiter, audit-logger (with tamper detection), AI-governance, and config-drift tests.
+- **Privacy posture.** Raw logs never need to leave the site; the only external forwarding is an optional, non-default opt-in (normalized alerts via Wazuh CEF).
+- **No acceptance implied.** This is a draft submission, not a confirmed appearance.
+
+## Links to Repository Documents
+
+- [Concept: Auditable Edge SOC/NOC](../concepts/auditable-edge-socnoc.md)
+- [Decision Loop](../architecture/decision-loop.md)
+- [Evidence Model](../architecture/evidence-model.md)
+- [Local AI Triage](../architecture/local-ai-triage.md)
+- [Deception Routing](../architecture/deception-routing.md)
+- [Concept profile YAML](../../concept_profiles/auditable-edge-socnoc.yaml)
+- [Demo concept pack](../../demos/concepts/auditable-edge-socnoc.yaml)
+- [Demo Guide](../DEMO_GUIDE.md)
+- [Arsenal Demo Profile](../ARSENAL_DEMO_PROFILE.md)
+- [Privacy and Legal](../PRIVACY_AND_LEGAL.md)

--- a/docs/concepts/auditable-edge-socnoc.md
+++ b/docs/concepts/auditable-edge-socnoc.md
@@ -17,7 +17,7 @@ Define a concept profile for privacy-sensitive and regulated operations where ex
 | Capability | Status | Notes |
 |---|---|---|
 | Deterministic action decisions with rationale | Implemented | Decision explanation fields are required in core path. |
-| Audit logging with `trace_id` correlation | Implemented | Audit logger is part of runtime baseline. |
+| Audit logging with `trace_id` correlation | Implemented | Audit logger is part of runtime baseline. End-to-end `trace_id` threading across the Rust/Python boundary remains Prototype. |
 | Structured evidence export for external review | Planned | Existing exports exist in parts of stack; unified profile-level packaging remains planned. |
 | Reproducibility metadata (`config hash` alignment) | Planned | Policy/hash references exist; broader reproducibility packaging is not yet complete. |
 
@@ -41,3 +41,5 @@ The profile depends on Decision Loop determinism, Evidence Model consistency, an
 ## Related Planning Documents
 - [Black Hat Europe Arsenal CFP Draft (not accepted)](../cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md)
 - [Paper: Auditable Edge SOC/NOC Gateway](../papers/auditable-edge-socnoc-europe.md)
+- [Roadmap: Black Hat Europe Auditable Edge SOC/NOC](../roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md)
+- [Issue drafts for CFP readiness](../issues/blackhat-europe/README.md)

--- a/docs/concepts/auditable-edge-socnoc.md
+++ b/docs/concepts/auditable-edge-socnoc.md
@@ -37,3 +37,7 @@ The profile depends on Decision Loop determinism, Evidence Model consistency, an
 - [Evidence Model](../architecture/evidence-model.md)
 - [Local AI Triage](../architecture/local-ai-triage.md)
 - [Auditable Profile Translation Matrix](auditable-profile-diff.md)
+
+## Related Planning Documents
+- [Black Hat Europe Arsenal CFP Draft (not accepted)](../cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md)
+- [Paper: Auditable Edge SOC/NOC Gateway](../papers/auditable-edge-socnoc-europe.md)

--- a/docs/concepts/evolution-map.md
+++ b/docs/concepts/evolution-map.md
@@ -21,6 +21,12 @@ deployment model, and security value.
 | Black Hat Asia 2026 | Offline Edge-AI SOC/NOC | Azazel-Pi: Offline Edge-AI SOC/NOC Gateway with Mock-LLM Scoring and Ollama Fallback |
 | Black Hat USA 2026 | Deterministic Edge Decision Support | Azazel-Edge: Deterministic Edge Decision Support for Constrained SOC/NOC Operations |
 
+## CFP Candidates (Not Accepted)
+
+| Target Event | Concept | Status |
+|---|---|---|
+| Black Hat Europe (candidate) | Auditable Edge SOC/NOC | CFP draft only — not accepted, not scheduled. See [CFP draft](../cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md). |
+
 ## Design Principle
 
 The repository should not be forked for each regional presentation.

--- a/docs/issues/blackhat-europe/01-confirm-auditable-decision-fields.md
+++ b/docs/issues/blackhat-europe/01-confirm-auditable-decision-fields.md
@@ -1,0 +1,70 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] Confirm current auditable decision fields" \
+  --body-file docs/issues/blackhat-europe/01-confirm-auditable-decision-fields.md \
+  --label "blackhat-europe" --label "testing" --label "audit"
+-->
+
+## Summary
+
+Turn the 2026-06-10 code audit of the auditable decision fields into a durable,
+repeatable verification artifact: a documented field inventory for the v2
+decision-explanation record and the Action Arbiter output, plus a pytest that
+asserts the required auditable fields are present in a generated explanation
+record.
+
+Status note: on 2026-06-10 the required fields were verified present in
+`DecisionExplainer` v2 output and `ActionArbiter` output. This issue does not add
+new fields; it makes that verification automatic so the claim cannot silently
+regress before submission.
+
+## Rationale
+
+The CFP draft and paper claim that each decision records its selected action,
+rejected alternatives, a release condition, the active policy profile, a config
+hash, a trace id, consulted evidence ids, and operator-facing wording. A one-time
+manual audit is not durable. A focused test keeps the submission claim honest and
+makes the field set the demo walk depends on resistant to regression.
+
+## Tasks
+
+- [ ] Document a field inventory for the v2 explanation record (from
+      `py/azazel_edge/explanations/decision.py`) and the arbiter output (from
+      `py/azazel_edge/arbiter/action.py`), noting which field name appears on which
+      record (e.g. `rejected_alternatives` on the arbiter, `rejected_actions` /
+      `why_not_others` on the explanation).
+- [ ] Add a pytest that generates an explanation record from a representative
+      decision and asserts presence (and basic type) of: `selected_action`,
+      `rejected_actions` (and arbiter `rejected_alternatives`), `release_condition`,
+      `policy_profile`, `config_hash`, `trace_id`, `evidence_ids`, and
+      `operator_wording`.
+- [ ] Assert the record carries `format_version` `v2`.
+- [ ] Record in the test docstring that this codifies the 2026-06-10 audit.
+
+## Acceptance Criteria
+
+- [ ] A documented field inventory exists (in the test module docstring and/or a
+      docs note) listing each required field and its source record.
+- [ ] A new pytest fails if any of the listed required fields is missing from a
+      freshly generated explanation record.
+- [ ] The test passes against current code with no production-code change required.
+- [ ] The test asserts `format_version == "v2"`.
+
+## Files Likely Affected
+
+- `py/azazel_edge/explanations/decision.py` (read-only reference)
+- `py/azazel_edge/arbiter/action.py` (read-only reference)
+- `tests/` (new test, e.g. `tests/test_decision_explanation_fields_v1.py`)
+- `docs/roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md` (cross-reference)
+
+## Dependencies
+
+None. This is the first issue in the implementation order; Issues 02-06 build on
+the field set confirmed here.
+
+## Risk
+
+Low. Read-only verification plus a new test; no production behavior changes. The
+only risk is encoding the field set incorrectly, mitigated by asserting against
+real generated output rather than a hand-written fixture.

--- a/docs/issues/blackhat-europe/02-normalize-decision-explanation-jsonl.md
+++ b/docs/issues/blackhat-europe/02-normalize-decision-explanation-jsonl.md
@@ -1,0 +1,83 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] Normalize decision-explanation JSONL schema" \
+  --body-file docs/issues/blackhat-europe/02-normalize-decision-explanation-jsonl.md \
+  --label "blackhat-europe" --label "documentation" --label "testing"
+-->
+
+## Summary
+
+Document the `DecisionExplainer` v2 JSONL record as the canonical
+decision-explanation schema, define its relationship to the second
+decision-explanation stream (the tactics-engine `DecisionLogger`), add a
+schema-validation helper plus test, and make trace_id presence and threading
+expectations across streams explicit.
+
+## Rationale
+
+There are currently two decision-explanation JSONL writers with different schemas:
+
+- **Canonical (v2):** `DecisionExplainer` writes to
+  `/var/log/azazel-edge/decision-explanations.jsonl` with fields including `ts`,
+  `trace_id`, `format_version`, `selected_action`, `reason`, `rejected_actions`,
+  `release_condition`, `policy_profile`, `config_hash`, `why_chosen`,
+  `why_not_others`, `evidence_ids`, `next_checks`, `operator_wording`, `machine`,
+  and `trust_capsule` (with `hmac_sig`).
+- **Tactics-engine:** `DecisionLogger` writes to
+  `/opt/azazel-edge/logs/tactics_engine/decision_explanations.jsonl` with fields
+  `ts`, `decision_id`, `engine`, `config_hash`, `inputs_snapshot`, `features`,
+  `state_before`, `score_delta`, `constraints_triggered`, `chosen`, `state_after`,
+  `parse_errors`. It has no rejected-alternatives or release-condition fields.
+
+Reviewers should not have to reverse-engineer which record is authoritative.
+trace_id threading is a known Prototype gap: the Rust core computes its own
+trace_id, and automatic end-to-end threading into the Python pipeline is not
+verified and has no integration test.
+
+## Tasks
+
+- [ ] Document the v2 record as the canonical decision-explanation schema (field
+      names, types, meaning, and the canonical output path).
+- [ ] Document the tactics-engine `DecisionLogger` schema and explicitly decide its
+      relationship to the canonical schema: either map its fields onto the canonical
+      record or mark it as a distinct internal engine-trace stream (and say why it
+      omits rejected-alternatives / release-condition).
+- [ ] Add a schema-validation helper that checks a v2 record against the documented
+      schema (required keys, types) and a pytest exercising it on a generated record.
+- [ ] Record trace_id expectations across streams: within the Python pipeline the
+      same trace_id should appear on the explanation and the related audit records.
+- [ ] For the Rust core -> Python boundary, add an integration test for automatic
+      trace_id threading, or, if it cannot be made to pass yet, record the gap as a
+      documented limitation labeled Prototype (do not claim it works).
+
+## Acceptance Criteria
+
+- [ ] A schema document names the v2 record as canonical and lists every field.
+- [ ] The tactics-engine schema relationship is explicitly documented (mapped or
+      scoped as distinct), including why it lacks rejected-alternatives / release-
+      condition fields.
+- [ ] A schema-validation helper exists and a pytest validates a generated v2 record.
+- [ ] trace_id continuity within the Python pipeline is asserted by a test, OR the
+      threading gap is documented as Prototype with no overstated claim.
+
+## Files Likely Affected
+
+- `py/azazel_edge/explanations/decision.py` (canonical v2 writer; reference)
+- tactics-engine `DecisionLogger` module (second stream; reference / mapping)
+- `docs/architecture/evidence-model.md` (schema documentation cross-reference)
+- `tests/test_decision_explanation_v2.py` style (new schema-validation test)
+- `docs/roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md`
+
+## Dependencies
+
+Depends on Issue 01 (field inventory). Feeds Issues 03 and 04, which extend the
+non-canonical streams, and Issue 05, whose review walk uses only the canonical
+record.
+
+## Risk
+
+Medium. The schema duality is genuine and is the most likely thing to confuse a
+reviewer; if it is mis-documented the submission claims could be undercut. Risk is
+bounded by keeping the v2 record clearly canonical and being candid about the
+tactics-engine stream and the Prototype trace_id threading gap.

--- a/docs/issues/blackhat-europe/03-add-rejected-alternatives-release-conditions.md
+++ b/docs/issues/blackhat-europe/03-add-rejected-alternatives-release-conditions.md
@@ -1,0 +1,79 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] Add rejected alternatives and release conditions where missing" \
+  --body-file docs/issues/blackhat-europe/03-add-rejected-alternatives-release-conditions.md \
+  --label "blackhat-europe" --label "audit" --label "testing"
+-->
+
+## Summary
+
+The main Action Arbiter decision path already records rejected alternatives and a
+release condition for every decision. This issue audits the *other*
+decision-bearing streams, adds those fields where they make operational sense, and
+documents a deliberate reason where a stream intentionally omits them.
+
+## Rationale
+
+`ActionArbiter` (`py/azazel_edge/arbiter/action.py`) emits `rejected_alternatives`
+(action + reason pairs) and a `release_condition` string, surfaced in the v2
+explanation as `rejected_actions` / `why_not_others` and `release_condition`. This
+is the headline differentiator in the CFP draft.
+
+Other streams that record decisions do not all carry these fields:
+
+- The tactics-engine `DecisionLogger` record has no rejected-alternatives or
+  release-condition fields.
+- The OpenCanary redirect path (`py/azazel_edge/opencanary_redirect.py`) records
+  redirect decisions to state JSON, JSONL, and the audit chain; its records need
+  checking for these fields.
+
+Consistency here is what lets a reviewer trust that "the decision space is
+visible" applies wherever a decision is recorded, not only on the primary path.
+
+## Tasks
+
+- [ ] State explicitly (in the schema doc) that the main arbiter path already
+      carries both `rejected_alternatives` and `release_condition`.
+- [ ] Enumerate every stream that records an action or decision (at minimum: the
+      v2 explanation, the tactics-engine `DecisionLogger`, the OpenCanary redirect
+      records, and any action-decision records in the audit chain).
+- [ ] For each stream, verify whether rejected-alternatives and release-condition
+      information is present.
+- [ ] Where the fields make sense and are missing (e.g. the redirect record should
+      carry the arbiter's release condition), add them, sourced from the arbiter
+      output rather than recomputed.
+- [ ] Where a stream intentionally omits them (e.g. a low-level engine trace),
+      document the reason in the schema doc.
+- [ ] Add or extend a test asserting the fields are present on each stream that is
+      supposed to carry them.
+
+## Acceptance Criteria
+
+- [ ] A per-stream table records, for each decision-bearing stream, whether it
+      carries rejected-alternatives and release-condition fields and why.
+- [ ] Streams that should carry the fields and previously did not now do, with the
+      values sourced from the arbiter output.
+- [ ] A test asserts presence of these fields on each stream expected to carry them.
+- [ ] No stream silently lacks the fields without a documented justification.
+
+## Files Likely Affected
+
+- `py/azazel_edge/arbiter/action.py` (source of truth; reference)
+- `py/azazel_edge/opencanary_redirect.py` (redirect records; likely extended)
+- tactics-engine `DecisionLogger` module (document omission or extend)
+- `py/azazel_edge/audit/logger.py` (action-decision records; reference)
+- `docs/architecture/evidence-model.md` (per-stream documentation)
+- `tests/` (field-presence assertions)
+
+## Dependencies
+
+Depends on Issue 02 (stream inventory and canonical schema). Related to Issue 04,
+which performs the same per-stream audit for `config_hash` / `policy_profile`.
+
+## Risk
+
+Medium. Editing the redirect path touches a decision-recording code path; changes
+must add fields only and must not alter which decision is recorded or trigger any
+enforcement (enforcement stays off by default). Tamper-evident chain behavior must
+remain intact.

--- a/docs/issues/blackhat-europe/04-config-hash-policy-profile-traceability.md
+++ b/docs/issues/blackhat-europe/04-config-hash-policy-profile-traceability.md
@@ -1,0 +1,82 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] Config hash / policy profile traceability across outputs" \
+  --body-file docs/issues/blackhat-europe/04-config-hash-policy-profile-traceability.md \
+  --label "blackhat-europe" --label "audit" --label "documentation"
+-->
+
+## Summary
+
+The SOC policy SHA-256 hash and `config_hash` already appear in v2 explanation
+records. This issue verifies that every decision-bearing output stream carries
+`config_hash` and `policy_profile`, extends the streams where they are missing,
+and documents the reproducibility story. It advances the Planned full
+config-hash / reproducibility packaging across all outputs.
+
+## Rationale
+
+Reproducibility anchoring is a stated technical differentiator: a recorded
+decision should be tied to a known configuration and policy profile.
+
+- The SOC policy SHA-256 is computed at load (`py/azazel_edge/policy.py`); the
+  arbiter exposes it as `policy_hash`.
+- The v2 explanation record carries `policy_profile` and `config_hash`
+  (Implemented).
+- Three policy profiles exist under `config/soc_policy_profiles/` selected via
+  `AZAZEL_SOC_POLICY_PATH`; config-drift auditing exists
+  (`py/azazel_edge/config_drift.py`).
+
+Full packaging across *all* outputs is Planned. This issue narrows that gap by
+making the per-stream coverage explicit and consistent, without claiming the
+Planned packaging is finished.
+
+## Tasks
+
+- [ ] State explicitly that `config_hash` + `policy_profile` are present in v2
+      explanation records (Implemented).
+- [ ] Audit each decision-bearing stream (audit-chain action-decision records, the
+      OpenCanary redirect records, demo replay outputs, and the tactics-engine
+      record) for `config_hash` and `policy_profile`.
+- [ ] Extend streams that are missing one or both fields, sourcing the policy hash
+      from the loaded policy (`policy_hash`) and the profile from the active
+      `AZAZEL_SOC_POLICY_PATH` selection.
+- [ ] Confirm demo replay outputs carry `config_hash` / `policy_profile` so the
+      reviewer can tie a demo decision to a profile.
+- [ ] Document the reproducibility story: what is anchored today, and what full
+      cross-output packaging (Planned) would still add. Do not describe the Planned
+      packaging as done.
+- [ ] Add a test asserting `config_hash` and `policy_profile` presence on each
+      stream expected to carry them.
+
+## Acceptance Criteria
+
+- [ ] A per-stream table records `config_hash` / `policy_profile` presence and the
+      source of each value.
+- [ ] Streams that should carry both fields and previously did not now do.
+- [ ] Demo replay outputs carry `config_hash` and `policy_profile`.
+- [ ] A documented reproducibility note distinguishes Implemented anchoring from
+      the Planned full-packaging work.
+- [ ] A test asserts presence of both fields on each expected stream.
+
+## Files Likely Affected
+
+- `py/azazel_edge/policy.py` (policy hash; reference)
+- `py/azazel_edge/explanations/decision.py` (reference)
+- `py/azazel_edge/opencanary_redirect.py` (likely extended)
+- `py/azazel_edge/audit/logger.py` (action-decision records; reference / extended)
+- `py/azazel_edge/demo/scenarios.py` (demo output fields)
+- `py/azazel_edge/config_drift.py` (reference)
+- `docs/architecture/evidence-model.md`, `docs/SOC_POLICY_GUIDE.md`
+- `tests/` (field-presence assertions)
+
+## Dependencies
+
+Depends on Issue 02 (stream inventory). Parallel to Issue 03 (same per-stream audit
+for a different field set). Advances the Planned reproducibility-packaging item.
+
+## Risk
+
+Medium. Adds metadata fields to decision-recording streams; must not change
+decision content or chain integrity, and must not imply the Planned full packaging
+is complete.

--- a/docs/issues/blackhat-europe/05-audit-trace-viewer-cli-review-path.md
+++ b/docs/issues/blackhat-europe/05-audit-trace-viewer-cli-review-path.md
@@ -1,0 +1,70 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] Audit trace viewer / CLI review path" \
+  --body-file docs/issues/blackhat-europe/05-audit-trace-viewer-cli-review-path.md \
+  --label "blackhat-europe" --label "tooling" --label "documentation"
+-->
+
+## Summary
+
+Add a read-only, operator-facing review command that walks a decision through its
+explanation record and the hash-chained audit log, give it a reviewer-friendly
+output suited to the Arsenal demo, and document the review path. Build on the
+existing review surfaces; do not add any write or enforcement capability.
+
+## Rationale
+
+Review surfaces already exist: Web API endpoints (`/api/triage/audit`,
+`/api/demo/explanation/latest`), a unified CLI, and a TUI. What is missing is a
+single command that performs the decision -> explanation -> audit-chain walk a
+reviewer cares about: show the latest (or a selected) decision explanation, then
+verify the audit chain and surface the chain status. This is the live portion of
+the demo's "explanation review" and "audit chain review" steps and should be
+read-only.
+
+## Tasks
+
+- [ ] Add a read-only review subcommand to the unified CLI that:
+      - prints the latest (or a `--trace-id` selected) v2 explanation record fields
+        relevant to review (`selected_action`, `rejected_actions` / `why_not_others`,
+        `release_condition`, `policy_profile`, `config_hash`, `trace_id`,
+        `evidence_ids`, `operator_wording`);
+      - runs `verify_chain` over the audit log and reports OK or the first mismatch
+        position.
+- [ ] Ensure the command performs no writes, no policy changes, and no enforcement.
+- [ ] Provide a compact, reviewer-friendly output mode suitable for a booth screen.
+- [ ] Document the review path (command usage and the decision -> explanation ->
+      audit walk) in the demo guide / review documentation.
+- [ ] Add a test for the command's read-only behavior and chain-status reporting,
+      including the case where a tampered record is detected.
+
+## Acceptance Criteria
+
+- [ ] A documented read-only CLI subcommand exists that shows a decision
+      explanation and verifies the audit chain.
+- [ ] The command makes no writes and cannot trigger enforcement (verified by test
+      and/or by construction).
+- [ ] The command reports chain OK and reports the first mismatch on a tampered log.
+- [ ] The review path is documented end to end for demo use.
+
+## Files Likely Affected
+
+- unified CLI entry (e.g. `bin/azazel-edge-*` and the CLI module under
+  `py/azazel_edge/`)
+- `py/azazel_edge/audit/logger.py` (`verify_chain`; reference)
+- `py/azazel_edge/explanations/decision.py` (record source; reference)
+- `docs/DEMO_GUIDE.md`, `docs/ARSENAL_DEMO_PROFILE.md` (review-path documentation)
+- `tests/` (read-only behavior and chain-status test)
+
+## Dependencies
+
+Depends on Issues 01 and 02 (confirmed fields and canonical schema) and benefits
+from Issues 03-04 (consistent fields across streams). Used by Issue 06's demo walk
+and rehearsed in Issue 10.
+
+## Risk
+
+Low. The command is read-only by design. The only risk is accidental coupling to a
+write path; mitigated by asserting read-only behavior in tests and keeping the
+command on the verification / display code paths only.

--- a/docs/issues/blackhat-europe/06-europe-demo-auditable-edge-socnoc.md
+++ b/docs/issues/blackhat-europe/06-europe-demo-auditable-edge-socnoc.md
@@ -1,0 +1,82 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] Europe demo scenario auditable_edge_socnoc" \
+  --body-file docs/issues/blackhat-europe/06-europe-demo-auditable-edge-socnoc.md \
+  --label "blackhat-europe" --label "demo" --label "testing"
+-->
+
+## Summary
+
+Add a new deterministic replay scenario with id `auditable_edge_socnoc` to
+`DemoScenarioPack`, framed for privacy-sensitive, regulated, local-first European
+operation, that exercises a decision with rejected alternatives, a release
+condition, `config_hash` / `policy_profile` display, and the audit-chain review.
+Register it in the concept pack. Do not use any disaster, shelter, or emergency
+narrative, and do not rename or delete any existing scenario id.
+
+## Rationale
+
+The CFP draft and paper currently note that a dedicated Europe scenario
+`auditable_edge_socnoc` is Planned and does not exist; the concept pack reuses
+`mixed_correlation_demo` and `disaster_phishing_demo`. The Europe-facing demo
+needs a scenario whose narrative matches the profile (auditable, explainable,
+local-first, regulated) rather than a disaster/shelter framing, and that directly
+showcases the auditable decision record and the audit-chain walk.
+
+## Tasks
+
+- [ ] Add a new scenario `auditable_edge_socnoc` to `DemoScenarioPack.scenarios()`
+      in `py/azazel_edge/demo/scenarios.py`, following the existing structure
+      (`description`, `demo` metadata, `events`).
+- [ ] Choose events that drive a decision with non-empty rejected alternatives and
+      a meaningful release condition (e.g. a bounded-control or redirect path), so
+      the explanation walk is substantive.
+- [ ] Use neutral, regulated/privacy-sensitive framing in all narrative text. No
+      disaster, shelter, evacuation, or emergency wording.
+- [ ] Confirm the run reports `execution.mode = deterministic_replay` and
+      `ai_used = false` (inherited from the runner) and that the explanation carries
+      `config_hash` / `policy_profile`.
+- [ ] Register the new id in `demos/concepts/auditable-edge-socnoc.yaml`
+      `stage_order` and `scenarios`. Consider replacing the `disaster_phishing_demo`
+      reference in this Europe-facing pack with the new scenario, while keeping the
+      `disaster_phishing_demo` id intact everywhere else (do not rename or delete it).
+- [ ] Update the CFP draft Demo Plan reference to name `auditable_edge_socnoc` once
+      it exists (replacing the "Planned / does not exist" note).
+- [ ] Add a test in `tests/test_demo_scenario_pack_v1.py` style asserting the
+      scenario exists, runs, and produces an explanation with the required auditable
+      fields (rejected alternatives, release condition, `config_hash`,
+      `policy_profile`).
+
+## Acceptance Criteria
+
+- [ ] `bin/azazel-edge-demo run auditable_edge_socnoc` runs fully offline and
+      reports `deterministic_replay` and `ai_used = false`.
+- [ ] The scenario's explanation record contains non-empty rejected alternatives
+      and a release condition, plus `config_hash` and `policy_profile`.
+- [ ] The scenario narrative contains no disaster/shelter/emergency framing.
+- [ ] No existing scenario id is renamed or removed; `disaster_phishing_demo`
+      remains a valid id.
+- [ ] `demos/concepts/auditable-edge-socnoc.yaml` lists `auditable_edge_socnoc` in
+      `stage_order` and `scenarios`.
+- [ ] A test covers the scenario.
+
+## Files Likely Affected
+
+- `py/azazel_edge/demo/scenarios.py` (new scenario)
+- `demos/concepts/auditable-edge-socnoc.yaml` (registration)
+- `docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md` (Demo Plan reference)
+- `tests/test_demo_scenario_pack_v1.py` (new assertions)
+
+## Dependencies
+
+Depends on Issues 01, 02, 04, and 05 (confirmed fields, canonical schema,
+config-hash/profile coverage, review command) so the demo walk uses verified,
+consistent data.
+
+## Risk
+
+Medium. The scenario must keep deterministic replay stable and must not introduce
+disaster framing or rename existing ids (a hard rule in `demos/concepts/README.md`).
+Risk is contained because the scenario reuses existing deterministic machinery and
+adds only data plus registration.

--- a/docs/issues/blackhat-europe/07-cfp-draft-and-paper.md
+++ b/docs/issues/blackhat-europe/07-cfp-draft-and-paper.md
@@ -1,0 +1,70 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] CFP draft and paper" \
+  --body-file docs/issues/blackhat-europe/07-cfp-draft-and-paper.md \
+  --label "blackhat-europe" --label "documentation"
+-->
+
+## Summary
+
+Track the CFP submission draft and the supporting paper for the Auditable Edge
+SOC/NOC profile. The bulk of this work is already done in this branch (commit
+ff8ef98). This issue records what landed and lists only the genuinely remaining
+pre-submission tasks.
+
+## Rationale
+
+A reviewable submission needs a CFP draft and a backing paper whose every claim
+matches repository state. Most of that exists. What remains is review and fitting,
+not authoring: a claims/safety sign-off, fitting the abstracts to the actual Black
+Hat submission-form character limits, and a final proofread before submission.
+
+## Tasks
+
+Already done (commit ff8ef98), recorded for traceability:
+
+- [x] CFP draft written: `docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md`.
+- [x] Paper written: `docs/papers/auditable-edge-socnoc-europe.md`.
+- [x] `docs/INDEX.md` "CFP Drafts and Papers" section added.
+- [x] README links added.
+- [x] Evolution-map "CFP Candidates (Not Accepted)" section added.
+- [x] Concept-doc planning links added
+      (`docs/concepts/auditable-edge-socnoc.md`).
+- [x] CHANGELOG entry added.
+
+Remaining:
+
+- [ ] Claims/safety review sign-off: confirm no forbidden hype phrasing, that every
+      Implemented/Prototype/Planned label matches ground truth, and that AI-advisory
+      / enforcement-off-by-default boundaries are stated accurately. (Use the Issue
+      09 check.)
+- [ ] Fit the short and detailed abstracts to the actual Black Hat Europe Arsenal
+      submission-form character limits, without introducing new claims.
+- [ ] Final proofread of the CFP draft and paper before submission.
+
+## Acceptance Criteria
+
+- [ ] A recorded claims/safety sign-off exists (e.g. a checked item or note) for the
+      CFP draft and paper.
+- [ ] Abstract variants exist that fit the submission-form character limits and
+      contain no claims absent from the full draft.
+- [ ] A final proofread pass is completed and noted.
+- [ ] The CFP draft remains outside `docs/arsenal/` and continues to state that no
+      acceptance is implied.
+
+## Files Likely Affected
+
+- `docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md`
+- `docs/papers/auditable-edge-socnoc-europe.md`
+
+## Dependencies
+
+Depends on Issue 09 (claims-discipline check) for the sign-off, and reflects the
+status established by Issues 01-06.
+
+## Risk
+
+Low. Remaining work is review and fitting on already-landed documents. The main
+risk is over-claiming when trimming abstracts to fit limits; mitigated by running
+the Issue 09 check on the final text.

--- a/docs/issues/blackhat-europe/08-docs-navigation-readme-links.md
+++ b/docs/issues/blackhat-europe/08-docs-navigation-readme-links.md
@@ -1,0 +1,66 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] Docs navigation / README links" \
+  --body-file docs/issues/blackhat-europe/08-docs-navigation-readme-links.md \
+  --label "blackhat-europe" --label "documentation"
+-->
+
+## Summary
+
+Track documentation navigation for the Black Hat Europe material. Most navigation
+links landed in this branch (commit ff8ef98). This issue records what is done and
+covers the remaining task: registering this roadmap and the issues directory in
+`docs/INDEX.md` and the concept doc, while keeping any README addition minimal.
+
+## Rationale
+
+The CFP draft, paper, and their entry points are already linked from README, the
+INDEX, the evolution map, and the concept doc. The newly added planning artifacts
+(this roadmap and the `docs/issues/blackhat-europe/` directory) are not yet
+discoverable from the INDEX or the concept doc, so a reader cannot navigate to the
+plan from the canonical entry points.
+
+## Tasks
+
+Already done (commit ff8ef98), recorded for traceability:
+
+- [x] README links to the CFP draft and paper.
+- [x] `docs/INDEX.md` "CFP Drafts and Papers" section.
+- [x] Evolution-map "CFP Candidates (Not Accepted)" section.
+- [x] Concept-doc planning links.
+
+Remaining:
+
+- [x] Register `docs/roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md` in
+      `docs/INDEX.md` (appropriate section, with the no-acceptance framing).
+- [x] Reference the roadmap and the `docs/issues/blackhat-europe/` directory from
+      `docs/concepts/auditable-edge-socnoc.md` "Related Planning Documents".
+- [ ] Keep the issues directory `README.md` minimal (what the dir is + how to
+      register issues with `gh`); do not duplicate issue bodies elsewhere.
+- [ ] Final navigation pass: confirm all relative links resolve from the rendered
+      docs site as well as from the repository view.
+
+## Acceptance Criteria
+
+- [ ] `docs/INDEX.md` links to the roadmap.
+- [ ] The concept doc references the roadmap and the issues directory.
+- [ ] The issues directory `README.md` remains minimal and accurate.
+- [ ] No new top-level README clutter; any README change is minimal.
+- [ ] Navigation continues to state that no Black Hat acceptance is implied.
+
+## Files Likely Affected
+
+- `docs/INDEX.md`
+- `docs/concepts/auditable-edge-socnoc.md`
+- `docs/issues/blackhat-europe/README.md`
+
+## Dependencies
+
+Depends on the roadmap and issues directory existing (this task set). Reflects the
+documents produced under Issue 07.
+
+## Risk
+
+Low. Navigation-only edits to existing index and concept documents. Risk is limited
+to broken relative links; mitigated by verifying the paths resolve.

--- a/docs/issues/blackhat-europe/09-claims-discipline-validation.md
+++ b/docs/issues/blackhat-europe/09-claims-discipline-validation.md
@@ -1,0 +1,65 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] Claims-discipline validation" \
+  --body-file docs/issues/blackhat-europe/09-claims-discipline-validation.md \
+  --label "blackhat-europe" --label "testing" --label "documentation"
+-->
+
+## Summary
+
+Add an automated check (a validation script or pytest, e.g.
+`tests/test_claims_discipline_v1.py`) that fails on forbidden hype phrasing in
+README and docs, on any "Black Hat Europe" reference inside `docs/arsenal/`, and on
+any file matching `blackhat-europe-*.md` inside `docs/arsenal/`. Optionally wire it
+into CI (noting that CI changes need review).
+
+## Rationale
+
+The submission and supporting docs must stay sober and must not imply acceptance.
+Manual review is error-prone, especially while abstracts are trimmed to fit
+submission-form limits (Issue 07). An automated check makes the discipline
+enforceable and repeatable, and guards the rule that CFP material must not appear
+under `docs/arsenal/` before acceptance.
+
+## Tasks
+
+- [ ] Add a check that scans `README.md` and `docs/` and fails on forbidden hype
+      phrases (case-insensitive): "world's first", "military-grade", "unbreakable",
+      "guaranteed protection", "autonomous AI defender", and close variants. Exclude
+      the check's own forbidden-phrase list from matching itself.
+- [ ] Add a check that fails if any file under `docs/arsenal/` contains a
+      "Black Hat Europe" reference (pre-acceptance guard).
+- [ ] Add a check that fails if any file matching `docs/arsenal/blackhat-europe-*.md`
+      exists (pre-acceptance guard).
+- [ ] Implement as a pytest (e.g. `tests/test_claims_discipline_v1.py`) and/or a
+      runnable script, so it works locally and in the validation grep set.
+- [ ] Optionally wire into CI; note in the issue/PR that CI configuration changes
+      require human review (per repository policy).
+- [ ] Verify the check fails on a seeded violation and passes on the current tree.
+
+## Acceptance Criteria
+
+- [ ] The check fails when a forbidden hype phrase is present in README or docs.
+- [ ] The check fails when `docs/arsenal/` contains a "Black Hat Europe" reference.
+- [ ] The check fails when a `docs/arsenal/blackhat-europe-*.md` file exists.
+- [ ] The check passes against the current repository state.
+- [ ] A seeded-violation test demonstrates each failure path.
+
+## Files Likely Affected
+
+- `tests/test_claims_discipline_v1.py` (new) and/or a script under `bin/` or `tools/`
+- `README.md`, `docs/` (scanned, not modified by the check)
+- CI configuration (optional; requires human review)
+
+## Dependencies
+
+Independent of Issues 01-06; used by Issue 07 (claims/safety sign-off) and listed
+in the roadmap's validation grep set. Should land before submission text is
+finalized.
+
+## Risk
+
+Low. The check is read-only over the tree. The main risk is false positives from
+overly broad patterns; mitigated by scoping phrases tightly and excluding the
+check's own phrase list.

--- a/docs/issues/blackhat-europe/10-arsenal-demo-dry-run-checklist.md
+++ b/docs/issues/blackhat-europe/10-arsenal-demo-dry-run-checklist.md
@@ -1,0 +1,69 @@
+<!--
+Register with:
+gh issue create \
+  --title "[BHEU] Arsenal demo dry-run checklist" \
+  --body-file docs/issues/blackhat-europe/10-arsenal-demo-dry-run-checklist.md \
+  --label "blackhat-europe" --label "demo"
+-->
+
+## Summary
+
+Track a final pre-submission and pre-event rehearsal of the Auditable Edge SOC/NOC
+demo: a full offline run on Raspberry Pi-class hardware, a fallback drill, timing,
+and reviewer Q&A preparation including honest answers about Prototype and Planned
+items and enforcement-off-by-default.
+
+## Rationale
+
+The demo is offline deterministic replay on constrained hardware. A rehearsal that
+exercises the whole package on the target device de-risks the booth experience and
+ensures the team can answer reviewer questions candidly. This is a tracking
+checklist, not a code change.
+
+## Tasks
+
+- [ ] Run `bin/azazel-edge-demo run auditable_edge_socnoc` fully offline on the
+      target Raspberry Pi-class device; confirm `deterministic_replay` and
+      `ai_used = false`.
+- [ ] Walk the v2 explanation fields on-device (`selected_action`,
+      `rejected_actions` / `why_not_others`, `release_condition`, `policy_profile`,
+      `config_hash`, `trace_id`, `evidence_ids`, `operator_wording`).
+- [ ] Run the audit-chain verification and demonstrate a tampered record breaking
+      the chain.
+- [ ] Run the SOC policy dry-run (`bin/azazel-soc-policy-dry-run`) comparing two
+      profiles; confirm reported policy hash and would-be decisions.
+- [ ] Exercise the read-only review command (Issue 05).
+- [ ] Perform a fallback drill: confirm replay-only mode with no live telemetry and
+      no live enforcement, and a quick recovery if anything fails mid-demo.
+- [ ] Time the full walk and trim to the booth slot.
+- [ ] Prepare reviewer Q&A: honest framing of Prototype items (Rust->Python trace_id
+      threading, runtime profile switching, live nft/tc enforcement) and Planned
+      items (full reproducibility packaging, unified evidence bundle, automated
+      release-condition orchestration), and confirm enforcement is off by default.
+- [ ] Confirm the optional local-AI-assist aside (if shown) stays advisory and
+      audited, and never changes a decision.
+
+## Acceptance Criteria
+
+- [ ] A completed offline rehearsal on Raspberry Pi-class hardware is recorded.
+- [ ] The fallback drill passed (replay-only, no live enforcement).
+- [ ] The full walk fits the intended booth timing.
+- [ ] A reviewer Q&A note exists with honest Prototype/Planned answers and the
+      enforcement-off-by-default statement.
+- [ ] No step required or enabled live network enforcement.
+
+## Files Likely Affected
+
+- None (rehearsal / tracking). May reference `docs/DEMO_GUIDE.md` and
+  `docs/ARSENAL_DEMO_PROFILE.md`.
+
+## Dependencies
+
+Depends on Issue 06 (the scenario), Issue 05 (review command), and Issues 01-04
+(verified, consistent fields). Run last in the implementation order.
+
+## Risk
+
+Low. A rehearsal exercise. The main operational risk is accidentally enabling live
+enforcement during the run; mitigated by keeping `AZAZEL_DEFENSE_ENFORCE` off and
+confirming replay-only mode as an explicit checklist item.

--- a/docs/issues/blackhat-europe/README.md
+++ b/docs/issues/blackhat-europe/README.md
@@ -1,0 +1,41 @@
+# Black Hat Europe Issue Drafts
+
+This directory holds issue drafts for making the Auditable Edge SOC/NOC concept
+profile CFP-submission-ready and demo-ready for a Black Hat Europe Arsenal
+application. Nothing here implies acceptance, scheduling, or review by Black Hat.
+
+These are source-controlled issue bodies, not registered issues. Each file is a
+self-contained issue body with a suggested `gh` registration command in an HTML
+comment at the top.
+
+## Register an issue with gh
+
+Each file's header comment gives the exact command. The general form is:
+
+```sh
+gh issue create \
+  --title "[BHEU] <title>" \
+  --body-file docs/issues/blackhat-europe/NN-<slug>.md \
+  --label "blackhat-europe" --label "<documentation|demo|tooling|testing|audit>"
+```
+
+Create the `blackhat-europe` label once if it does not exist:
+
+```sh
+gh label create blackhat-europe --description "Black Hat Europe Arsenal CFP readiness" --color "5319e7"
+```
+
+## Files
+
+- `01-confirm-auditable-decision-fields.md`
+- `02-normalize-decision-explanation-jsonl.md`
+- `03-add-rejected-alternatives-release-conditions.md`
+- `04-config-hash-policy-profile-traceability.md`
+- `05-audit-trace-viewer-cli-review-path.md`
+- `06-europe-demo-auditable-edge-socnoc.md`
+- `07-cfp-draft-and-paper.md`
+- `08-docs-navigation-readme-links.md`
+- `09-claims-discipline-validation.md`
+- `10-arsenal-demo-dry-run-checklist.md`
+
+See the roadmap: `docs/roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md`.

--- a/docs/papers/auditable-edge-socnoc-europe.md
+++ b/docs/papers/auditable-edge-socnoc-europe.md
@@ -344,9 +344,9 @@ enforcement.
 The auditable concept pack (`demos/concepts/auditable-edge-socnoc.yaml`) currently
 references two existing scenarios: `mixed_correlation_demo`, used to exercise the
 explanation trace and rejected-alternatives review, and `disaster_phishing_demo`,
-used for social-engineering triage with auditable operator handoff. A dedicated
-Europe-framed scenario with the id `auditable_edge_socnoc` does **not exist yet** and
-is **(Planned)**; the concept pack reuses the two existing scenarios above.
+an existing scenario id the pack currently reuses for coverage until a dedicated
+Europe scenario lands. A dedicated Europe-framed scenario with the id
+`auditable_edge_socnoc` does **not exist yet** and is **(Planned)**; see Section 11.
 
 Reviewers can inspect the outputs along the same paths operators would use: the v2
 decision-explanation JSONL at

--- a/docs/papers/auditable-edge-socnoc-europe.md
+++ b/docs/papers/auditable-edge-socnoc-europe.md
@@ -1,0 +1,416 @@
+# Auditable Edge SOC/NOC Gateway for Privacy-Sensitive and Constrained Operations
+
+*Status note: this is a concept-profile document supporting a CFP draft for Black Hat Europe Arsenal. It is not a record of an accepted appearance and makes no claim of acceptance. Sibling concept profiles have been demonstrated as Asia 2026 and USA 2026 profiles; the profile described here is a concept profile.*
+
+## Abstract
+
+Edge, branch, and temporary networks are increasingly operated in privacy-sensitive
+and regulated settings where exporting raw telemetry to a cloud SIEM is undesirable,
+contractually constrained, or legally fraught. At the same time, operators are
+expected to justify, after the fact, why any automated control acted. Black-box
+machine-learning responders make this difficult: their decisions resist
+post-incident review. Azazel-Edge is a small gateway design that addresses this
+gap. It is not a black-box AI defender. Response decisions are made by a
+deterministic decision loop that converts normalized telemetry into one of five
+bounded, reviewable actions — observe, notify, throttle, redirect, isolate — each
+carrying an explicit action profile (reversibility, approval requirement, audit
+status). Local AI is restricted to triage hints, summarization, and explanation
+assistance, and cannot select or alter actions. Raw logs are handled local-first
+and are not sent to external APIs; they do not need to leave the site. Every
+decision emits a structured explanation record and is recorded in a hash-chained,
+tamper-evident audit log, so operators can reconstruct and explain decisions later.
+Deception is limited to defensive observation via controlled decoys bounded by
+policy. The system does not guarantee legal or regulatory compliance; it is a tool
+that supports operator accountability in regulated environments. This paper
+describes the design, the implemented decision and evidence machinery, and its
+honest limitations.
+
+## 1. Problem Statement
+
+Small networks at the edge — branch offices, clinics, pop-up sites, temporary
+event infrastructure, and other constrained deployments — are frequently operated
+in contexts where data handling is sensitive or regulated. Two pressures
+collide in these settings.
+
+First, the default architecture of modern detection-and-response tooling assumes
+that raw telemetry can be shipped to a centralized, often cloud-hosted, analytics
+backend. In privacy-sensitive or regulated environments this assumption is often
+undesirable or disallowed: raw logs may contain personal data, the destination may
+be outside an acceptable jurisdiction, or the contractual posture simply forbids
+bulk export. The operator needs detection and decision support without making
+external raw-log export a precondition for the system to function.
+
+Second, when an automated control does act — when it throttles, redirects, or
+isolates traffic — the operator is accountable for that action. In a regulated
+environment, "the model decided" is not an adequate account. Operators must be
+able to explain *why* the control acted, on the basis of recorded evidence, often
+weeks later and to a non-technical reviewer or auditor. Black-box ML responders
+are poorly suited to this: the very property that makes them flexible, an opaque
+learned decision surface, is what makes them resist after-the-fact review.
+
+Azazel-Edge takes the position that, for these settings, the response decision
+itself should be deterministic and explainable, the data should stay local by
+default, and an audit trace should be preserved so the decision can be
+reconstructed and justified later.
+
+## 2. Design Goals
+
+The design is organized around six goals, each of which maps onto a concrete
+implemented mechanism described later in this paper.
+
+- **Determinism.** The authoritative decision path is a deterministic evaluator
+  and arbiter. Given the same normalized evidence and the same policy, it produces
+  the same action. There is no learned model in the decision path.
+- **Explainability.** Every decision produces a structured explanation that names
+  the selected action, the reason, the rejected alternatives and why each was
+  rejected, the evidence that was consulted, and a human-readable operator wording.
+- **Auditability.** Decisions are recorded in a hash-chained, tamper-evident audit
+  log keyed by a `trace_id`, so the record of a decision can be verified and
+  reconstructed.
+- **Local-first data handling.** Raw logs are handled locally. Default log sinks
+  write to local files. Raw logs are not sent to external APIs and do not need to
+  leave the site.
+- **Bounded, reversible response.** The arbiter may select only from a small,
+  fixed set of actions, each carrying an explicit profile describing whether it is
+  reversible, whether it requires approval, and that it is audited.
+- **Advisory-only AI.** Local AI assist is limited to triage hints, summarization,
+  and explanation assistance. It is governed, secondary, and cannot select or alter
+  actions.
+
+## 3. Threat and Operational Model
+
+The threat model is deliberately scoped to what a small edge gateway can credibly
+address, rather than overstated.
+
+**In scope.** The system targets opportunistic and commodity threats observed on
+small networks: opportunistic scanning, brute-force attempts, and lateral probing
+across a modest number of hosts. These are the activities a single, co-located
+gateway can observe and respond to in a bounded way.
+
+**Deployment.** The reference deployment is a single Raspberry Pi-class gateway
+co-located with the network it observes. This constrains both the compute budget
+(small local models, limited throughput) and the architectural assumptions (one
+node, local storage, no mandatory backhaul).
+
+**Non-goals.** The system is explicitly *not*:
+
+- an EDR or host-based agent platform;
+- a compliance product — it does not guarantee legal or regulatory compliance, and
+  is instead a tool that *supports* operator accountability;
+- a perimeter or detection platform for large enterprises with high traffic volumes
+  and dedicated SOC staff.
+
+Within this scope, the operational model assumes a human operator who reviews and
+remains accountable for the gateway's actions, supported by the explanation and
+audit machinery described below.
+
+## 4. System Overview
+
+Azazel-Edge separates a fast deterministic decision path from optional, governed,
+advisory functions. Telemetry — for example Suricata EVE alerts and local
+probes — is received and normalized into Evidence Plane records. Two deterministic
+evaluators then score the current state independently: a NOC evaluator covering
+network and service health dimensions (availability, path health, device health,
+client health, capacity health, client inventory health, service health,
+resolution health, and config-drift health), and a SOC evaluator scoring security
+state (suspicion, confidence, technique likelihood, blast radius). Policy
+thresholds are applied, and an `ActionArbiter` selects exactly one bounded action.
+A `DecisionExplainer` then produces a structured explanation, and a hash-chained
+audit logger records the trace. Notification and any AI assist run only *after* the
+deterministic decision has been made.
+
+A `trace_id` is intended to thread through the entire path. The field exists at
+every stage from the Rust core through the Python pipeline; however, fully
+automatic end-to-end propagation is **(Prototype)** — there is no integration test
+confirming the identifier is threaded automatically across the language boundary.
+
+The deterministic path is authoritative. AI is invoked only post-decision and is
+constrained as described in Section 7. Default log handling is local-first: the
+default Vector sinks write to local files only.
+
+## 5. Deterministic Decision Loop
+
+The decision loop is the heart of the design and is implemented, not aspirational.
+It proceeds as follows: telemetry is normalized into Evidence Plane records; the
+deterministic NOC and SOC evaluators score state; policy thresholds are applied;
+the `ActionArbiter` selects one bounded action; the `DecisionExplainer` records the
+rationale; and the audit logger records the full trace.
+
+### 5.1 The five bounded actions and their profiles
+
+The arbiter may select only from five actions. Each action carries a fixed
+*action profile* recording its reversibility, whether it requires approval, that it
+is audited, its effect, and its control mode. These profiles are defined in code
+(`ActionArbiter.ACTION_PROFILES`):
+
+| Action   | reversible | approval_required | audited | effect                 | mode               |
+|----------|------------|-------------------|---------|------------------------|--------------------|
+| observe  | true       | false             | true    | visibility_only        | passive            |
+| notify   | true       | false             | true    | operator_notification  | human_loop         |
+| throttle | true       | true              | true    | traffic_shaping        | bounded_control    |
+| redirect | true       | true              | true    | controlled_redirect    | bounded_control    |
+| isolate  | true       | true              | true    | segment_isolation      | high_risk_control  |
+
+Two properties follow directly from this table. All five actions are marked
+`audited`. The three impactful actions — throttle, redirect, isolate — are marked
+`approval_required`, while observe and notify are not. This makes the boundedness
+and reviewability of the action set a structural property of the system rather than
+a convention.
+
+### 5.2 Selection logic
+
+The arbiter validates that the NOC and SOC inputs carry their required keys, then
+derives a small number of decision predicates. Two are central: `noc_fragile`,
+true when availability, path, or device health is labelled `poor` or `critical`;
+and `strong_soc`, true when the suspicion label is `high` or `critical` *and*
+confidence meets the policy's `strong_soc` minimum. The escalating actions
+(isolate, redirect, throttle) are gated on `strong_soc and not noc_fragile` plus
+action-specific suspicion, confidence, and blast-radius thresholds drawn from the
+active policy's `action_mapping`. Notably, a strong SOC signal on a fragile network
+de-escalates to `notify` (reason `soc_high_but_noc_fragile`) rather than applying a
+control on an already-degraded path. A separate client-impact guard further
+downgrades any control action to `notify` when the estimated client-impact score is
+high or any critical clients are affected (reason
+`client_impact_too_high_for_control`).
+
+### 5.3 Rejected alternatives and release conditions
+
+For every decision, the arbiter records *why other actions were not chosen*. It
+emits a `rejected_alternatives` list, each entry pairing an `action` with a
+`reason` (for example `{'action': 'redirect', 'reason': 'availability_risk_too_high'}`
+or `{'action': 'isolate', 'reason': 'threat_signal_not_strong_enough'}`). This is
+what allows a reviewer to confirm not only that the chosen action was justified, but
+that the more aggressive options were correctly declined.
+
+Each decision also carries a `release_condition` — a human-readable string stating
+when the control may be released. The implemented conditions are:
+`no_repeated_failures_for_300_seconds` (throttle, redirect),
+`manual_review_and_no_high_risk_signals_for_600_seconds` (isolate),
+`operator_acknowledged_or_signal_stabilized` (notify), and
+`observe_only_no_control_applied` (observe). These are recorded strings reviewed by
+operators; automated release-condition orchestration is **(Planned)** — there is no
+automated rollback today.
+
+Finally, the arbiter records `chosen_evidence_ids`, the deduplicated, sorted set of
+evidence identifiers actually consulted for the selected action, so the explanation
+points back at concrete evidence rather than at the entire input.
+
+## 6. Evidence Model and Audit Trace
+
+The evidence model distinguishes two layers. *Raw logs* preserve original upstream
+detail and transport context and are handled local-first. *Compact evidence*
+normalizes the key fields needed for reproducible deterministic evaluation and
+operator review. The decision path consumes compact evidence; raw logs are never a
+prerequisite for external review and are not exported to external APIs.
+
+### 6.1 The v2 decision-explanation record
+
+The `DecisionExplainer` writes `format_version` `v2` JSONL records to
+`/var/log/azazel-edge/decision-explanations.jsonl` (falling back to a local `/tmp`
+path if the canonical directory is not writable). The following is a representative
+*trimmed* record. Every key shown is a real field emitted by the explainer; the
+values are illustrative.
+
+```json
+{
+  "ts": "2026-06-10T09:14:07+00:00",
+  "trace_id": "trace-7f3a91",
+  "format_version": "v2",
+  "selected_action": "redirect",
+  "reason": "soc_high_confidence_redirect_is_preferred",
+  "rejected_actions": ["observe", "notify", "throttle", "isolate"],
+  "release_condition": "no_repeated_failures_for_300_seconds",
+  "policy_profile": "soc-policy-v1",
+  "config_hash": "9b1c4a2e7d0f5a83",
+  "why_chosen": {
+    "format_version": "v2",
+    "action": "redirect",
+    "reason": "soc_high_confidence_redirect_is_preferred",
+    "control_mode": "opencanary_redirect",
+    "noc_status": "good",
+    "soc_status": "high",
+    "noc_dimensions": {
+      "availability": "good",
+      "path_health": "good",
+      "device_health": "good"
+    },
+    "attack_candidates": ["T1110", "T1046"],
+    "client_impact": {"score": 10, "critical_client_count": 0}
+  },
+  "why_not_others": [
+    {"action": "isolate", "reason": "isolate_gate_not_satisfied"},
+    {"action": "observe", "reason": "insufficient_response_for_detected_threat"}
+  ],
+  "evidence_ids": ["ev-1042", "ev-1051", "ev-1077"],
+  "next_checks": ["verify_control_applied_and_reversible",
+                  "review_soc_evidence_and_attack_candidates"],
+  "operator_wording": "Selected action redirect for azazel-edge because soc_high_confidence_redirect_is_preferred. NOC status is good and SOC status is high. Control mode: opencanary_redirect.",
+  "machine": {"noc_summary": {}, "soc_summary": {}, "arbiter": {}},
+  "trust_capsule": {"hmac_sig": "…"}
+}
+```
+
+The record carries both the machine-facing rationale (`why_chosen`,
+`why_not_others`, `evidence_ids`) and an `operator_wording` string suitable for a
+human reviewer, plus `next_checks` suggesting follow-up review steps. The
+`trust_capsule` carries an HMAC over the explanation for integrity.
+
+### 6.2 Hash-chained audit log
+
+Decisions are recorded by `P0AuditLogger`, which writes JSONL records of typed
+kinds (for example `event_receive`, `evaluation`, `action_decision`,
+`notification`, `ai_assist`, and the triage-session kinds). Each record carries a
+`chain_prev` field set to the prior record's `chain_hash`, and its own `chain_hash`
+computed as a SHA-256 over the canonical (sorted-key) JSON of the record. A
+`verify_chain` routine walks the file, checks that each `chain_prev` matches the
+previous `chain_hash` and that each recomputed hash matches, and reports the first
+mismatch. This makes the log tamper-evident: a modified or removed record breaks the
+chain at a detectable position. This mechanism is implemented and tested.
+
+### 6.3 Reproducibility metadata
+
+A SHA-256 hash of the active policy is computed at load (the arbiter exposes it as
+`policy_hash`), and the explanation record carries both `policy_profile` and
+`config_hash`. The repository ships three policy profiles — balanced, conservative,
+and demo — and the auditable profile recommends the conservative profile to reduce
+unnecessary high-impact actions. Config-drift auditing is implemented. Full
+config-hash and reproducibility *packaging across all outputs* is **(Planned)**, as
+is a unified incident evidence-bundle export format. Runtime policy-profile
+switching today is environment-variable-at-start only **(Prototype)**.
+
+## 7. AI Assist Governance
+
+Local AI is optional, secondary, and tightly governed by `AIGovernance`. It cannot
+select or alter actions; the deterministic path has already decided before AI is
+ever invoked.
+
+**Invocation whitelist.** `should_invoke` permits AI only for an allowed set of
+intents (`advice`, `summary`, `candidate`) and only for specific source/risk-band
+combinations — for example `advice` is permitted only for `suricata_eve` events in
+an `ambiguous` or `uncertain` risk band, and `summary`/`candidate` are permitted for
+explicit operator-facing sources (operator, ops_comm, mattermost, dashboard).
+Anything else is refused with a recorded reason.
+
+**Payload sanitization.** Before any model call, `sanitize_payload` keeps only a
+whitelist of compact keys and strips raw-log content. The forbidden keys removed are
+`raw`, `raw_log`, `full_log`, `message`, `line`, `payload`, and `event`. Raw logs
+therefore do not reach the model; this is the mechanism behind the local-first,
+no-raw-export property.
+
+**Output validation.** `validate_output` constrains the model's output to advisory
+fields only — `advice`, `summary`, `candidate`, `runbook_candidates`, and
+`attack_candidates` — rejecting any extra keys, enforcing types, and truncating
+lengths. If validation fails, the system falls back to a minimal advisory result
+rather than adopting unconstrained output.
+
+**Local-only and fully audited.** The assist path uses a local Ollama runtime only;
+there is no external API dependency for AI. Every invocation is audited: the
+governance layer logs `ai_assist` records at input, decision, output, review, and
+fallback stages, so the use of AI is itself reconstructable from the audit chain. AI
+downtime does not block deterministic operation.
+
+## 8. Deception and Reversible Response
+
+Deception in Azazel-Edge is *not* an unrestricted offensive capability. It is
+defensive observation via controlled decoys (OpenCanary), bounded by policy. When
+the arbiter selects `redirect`, selected flows can be diverted toward
+pre-positioned decoy surfaces to preserve visibility while reducing direct exposure
+of real assets. Decoys are pre-positioned so a constrained edge node need not
+provision them dynamically.
+
+Two safety properties bound this. First, redirect (like throttle and isolate)
+carries `approval_required: true` in its action profile, so impactful actions are
+gated. Second, the response posture is reversible: every action profile is marked
+`reversible`, and each control carries a `release_condition`.
+
+**Enforcement is opt-in and dry-run by default.** This distinction is important and
+must not be overstated. The Python redirect path *records and audits* redirect
+decisions — it writes the decision to a state JSON file, to JSONL, and into the
+audit chain. Actual network enforcement (nftables/tc) lives in the Rust core and is
+gated behind `AZAZEL_DEFENSE_ENFORCE=true`. The default is **false**; in dry-run
+(the default), rollback commands are *recorded but not executed*. Live network
+redirection is therefore never the default behavior — it is an explicit opt-in.
+Release conditions are recorded human-readable strings reviewed by operators;
+automated release orchestration and rollback are **(Planned)**.
+
+## 9. Demo Scenario
+
+The reviewer-facing entry point is the deterministic replay demo. A demo runner
+executes the pipeline with `execution.mode = 'deterministic_replay'` and
+`ai_used = False`, so a reviewer sees the deterministic decision path produce
+explanations and audit records without any AI in the loop and without live
+enforcement.
+
+The auditable concept pack (`demos/concepts/auditable-edge-socnoc.yaml`) currently
+references two existing scenarios: `mixed_correlation_demo`, used to exercise the
+explanation trace and rejected-alternatives review, and `disaster_phishing_demo`,
+used for social-engineering triage with auditable operator handoff. A dedicated
+Europe-framed scenario with the id `auditable_edge_socnoc` does **not exist yet** and
+is **(Planned)**; the concept pack reuses the two existing scenarios above.
+
+Reviewers can inspect the outputs along the same paths operators would use: the v2
+decision-explanation JSONL at
+`/var/log/azazel-edge/decision-explanations.jsonl`, the hash-chained audit log via
+the `verify_chain` mechanism, and the Web/CLI/TUI review surfaces — including the
+`/api/triage/audit` and `/api/demo/explanation/latest` endpoints and the SOC policy
+dry-run CLI.
+
+## 10. Limitations
+
+This section is candid by design; the value of the system depends on not
+overstating it.
+
+- **Prototype trace_id threading.** The `trace_id` field exists at every stage, but
+  automatic end-to-end propagation across the Rust core and Python pipeline is
+  unverified and has no integration test (Prototype). Correlation across the
+  language boundary cannot yet be guaranteed.
+- **Enforcement off by default.** Actual nftables/tc enforcement is opt-in
+  (`AZAZEL_DEFENSE_ENFORCE=true`) and dry-run by default. The Python path records
+  and audits redirect decisions; it does not itself enforce them.
+- **Release conditions are not auto-executed.** Release conditions are recorded,
+  human-readable strings reviewed by operators. There is no automated rollback today
+  (Planned).
+- **No unified evidence bundle yet.** Decision explanations and audit logs exist as
+  separate streams; a unified incident evidence-bundle export format is not yet
+  implemented (Planned). Full config-hash/reproducibility packaging across all
+  outputs is likewise Planned.
+- **Single-file Rust core without tests.** The enforcement core is a single-file Rust
+  component and does not currently carry its own test coverage, which limits
+  confidence in enforcement behavior even when opted in.
+- **Deterministic rules have inherent limits.** A deterministic, rule-based decision
+  path is, by construction, blind to novel patterns it was not designed to score. It
+  trades adaptive coverage for explainability; it will not catch what its rules do
+  not encode.
+- **Small-model AI assist quality.** AI assist runs on small local models suited to
+  Raspberry Pi-class hardware. Its triage hints and summaries are advisory and of
+  limited quality, and its availability depends on local runtime health. It must
+  never be relied on as a decision authority.
+
+## 11. Future Work
+
+Several limitations above map directly onto planned work. The most impactful items
+are: verifying and testing automatic `trace_id` propagation across the Rust/Python
+boundary; a unified incident evidence-bundle export that packages explanation
+records, consulted evidence, and the relevant audit-chain segment for a single
+incident; full config-hash and reproducibility packaging across all outputs so that
+a recorded decision can be replayed against its exact policy; automated
+release-condition orchestration so that recorded release conditions can drive
+reviewed, auditable rollback rather than purely manual review; runtime policy-profile
+switching beyond environment-variable-at-start; and a dedicated Europe demo scenario
+(`auditable_edge_socnoc`) framing the profile around privacy-sensitive, regulated,
+local-first operation. Test coverage for the Rust enforcement core is a prerequisite
+for treating opt-in enforcement as production-ready.
+
+## References / Related Project Documents
+
+- Concept: Auditable Edge SOC/NOC — [`../concepts/auditable-edge-socnoc.md`](../concepts/auditable-edge-socnoc.md)
+- Decision Loop — [`../architecture/decision-loop.md`](../architecture/decision-loop.md)
+- Evidence Model — [`../architecture/evidence-model.md`](../architecture/evidence-model.md)
+- Local AI Triage — [`../architecture/local-ai-triage.md`](../architecture/local-ai-triage.md)
+- Deception Routing — [`../architecture/deception-routing.md`](../architecture/deception-routing.md)
+- Concept profile (YAML) — [`../../concept_profiles/auditable-edge-socnoc.yaml`](../../concept_profiles/auditable-edge-socnoc.yaml)
+- Demo concept pack (YAML) — [`../../demos/concepts/auditable-edge-socnoc.yaml`](../../demos/concepts/auditable-edge-socnoc.yaml)
+- Demo Guide — [`../DEMO_GUIDE.md`](../DEMO_GUIDE.md)
+- Privacy and Legal — [`../PRIVACY_AND_LEGAL.md`](../PRIVACY_AND_LEGAL.md)
+- SOC Policy Guide — [`../SOC_POLICY_GUIDE.md`](../SOC_POLICY_GUIDE.md)
+- Evolution Map — [`../concepts/evolution-map.md`](../concepts/evolution-map.md)

--- a/docs/roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md
+++ b/docs/roadmaps/blackhat-europe-auditable-edge-socnoc-roadmap.md
@@ -1,0 +1,172 @@
+# Roadmap: Black Hat Europe Auditable Edge SOC/NOC
+
+Status: planning artifact for a CFP submission draft. This roadmap describes work
+toward *submission readiness and demo readiness* for a Black Hat Europe Arsenal
+application. It does not imply that Black Hat Europe has reviewed, accepted, or
+scheduled anything. All status labels use the project convention:
+Implemented / Prototype / Planned / Conceptual / Unknown.
+
+## Goal
+
+Make the Auditable Edge SOC/NOC concept profile of the single Azazel-Edge core
+platform CFP-submission-ready and demo-ready for a Black Hat Europe Arsenal
+application, with every claim in the submission and demo backed by verifiable
+repository state (code, tests, configuration, and recorded outputs). The
+emphasis is European: privacy-sensitive, regulated, auditable, explainable,
+local-first operation.
+
+## Scope
+
+- Documentation that records, rather than overstates, current capability.
+- Schema documentation and validation for the decision-explanation records.
+- A dedicated, non-disaster Europe demo scenario for deterministic replay.
+- Read-only operator review tooling for the decision -> explanation -> audit walk.
+- Claims-discipline checks that fail on hype and on premature `docs/arsenal/` entries.
+- A pre-submission and pre-event rehearsal checklist.
+
+## Non-Goals
+
+- Any new attack capability or attack automation. All work is defensive,
+  documentation, auditability, demo, or operations support.
+- MEA field-deployment, disaster, shelter, or emergency framing for the Europe
+  profile.
+- Live network enforcement enabled by default (`AZAZEL_DEFENSE_ENFORCE` stays
+  off by default; demo stays dry-run / replay).
+- Any claim or implication of legal or regulatory compliance guarantees.
+- A repository split, fork, or a long-lived Europe branch.
+- Moving CFP material into `docs/arsenal/` or otherwise implying acceptance.
+- Changes under `installer/`, `security/`, or `systemd/` (human approval required
+  per `AGENTS.md`).
+
+## Milestones
+
+| Milestone | Theme | Issues |
+|---|---|---|
+| M1 | Evidence verification — make the 2026-06-10 field audit repeatable and document the canonical schema | 01, 02 |
+| M2 | Traceability gaps — extend rejected-alternatives / release-condition and config-hash / policy-profile coverage across decision-bearing streams | 03, 04 |
+| M3 | Review experience — read-only operator review command and reviewer walk-through | 05 |
+| M4 | Europe demo — add the `auditable_edge_socnoc` deterministic replay scenario | 06 |
+| M5 | Submission package — finish claims/safety review and docs navigation (both mostly done) | 07, 08 |
+| M6 | Discipline and dry run — automated claims-discipline check and the pre-event rehearsal checklist | 09, 10 |
+
+## Issue Breakdown
+
+Per-issue detail lives in `docs/issues/blackhat-europe/`. This table summarizes
+only the issue, the status of the *underlying capability* it builds on, and the
+primary issue file.
+
+| Issue | Title | Underlying capability status | File |
+|---|---|---|---|
+| 01 | Confirm current auditable decision fields | Implemented (fields verified 2026-06-10; issue makes verification repeatable) | `docs/issues/blackhat-europe/01-confirm-auditable-decision-fields.md` |
+| 02 | Normalize decision-explanation JSONL schema | Implemented (v2 writer); trace_id threading is Prototype | `docs/issues/blackhat-europe/02-normalize-decision-explanation-jsonl.md` |
+| 03 | Add rejected alternatives and release conditions where missing | Implemented (main arbiter path); gap in other streams | `docs/issues/blackhat-europe/03-add-rejected-alternatives-release-conditions.md` |
+| 04 | Config hash / policy profile traceability | Implemented (explanation records); Planned (full packaging) | `docs/issues/blackhat-europe/04-config-hash-policy-profile-traceability.md` |
+| 05 | Audit trace viewer / CLI review path | Implemented (web + CLI + TUI surfaces); adds read-only review command | `docs/issues/blackhat-europe/05-audit-trace-viewer-cli-review-path.md` |
+| 06 | Europe demo scenario `auditable_edge_socnoc` | Planned (scenario does not exist) | `docs/issues/blackhat-europe/06-europe-demo-auditable-edge-socnoc.md` |
+| 07 | CFP draft and paper | Implemented (draft + paper landed in commit ff8ef98); residual review tasks | `docs/issues/blackhat-europe/07-cfp-draft-and-paper.md` |
+| 08 | Docs navigation / README links | Implemented (README + INDEX links landed); residual navigation tasks | `docs/issues/blackhat-europe/08-docs-navigation-readme-links.md` |
+| 09 | Claims-discipline validation | Planned (no automated check yet) | `docs/issues/blackhat-europe/09-claims-discipline-validation.md` |
+| 10 | Arsenal demo dry-run checklist | Planned (rehearsal artifact) | `docs/issues/blackhat-europe/10-arsenal-demo-dry-run-checklist.md` |
+
+## Implementation Order
+
+Dependency-ordered. Each step states why it precedes the next.
+
+1. **Issue 01** — Lock the field inventory and a repeatable test first. Everything
+   downstream relies on knowing exactly which auditable fields exist today.
+2. **Issue 02** — Document the canonical v2 schema and its relationship to the
+   tactics-engine `DecisionLogger` stream, and make trace_id expectations explicit.
+   This frames the traceability work and prevents the schema duality from
+   surfacing as a surprise during review.
+3. **Issue 03** — With the schemas documented, verify and (where sensible) extend
+   rejected-alternatives / release-condition coverage on the non-arbiter streams.
+4. **Issue 04** — In the same streams, verify and extend `config_hash` /
+   `policy_profile` coverage; advances the Planned reproducibility-packaging item.
+5. **Issue 05** — Build the read-only review command on top of the now-verified
+   fields and chain, so the reviewer walk is exercising real, consistent data.
+6. **Issue 06** — Add the Europe demo scenario, which the review command and the
+   documented schema let us showcase end to end.
+7. **Issue 09** — Stand up the claims-discipline check before finalizing
+   submission text, so the text is validated automatically.
+8. **Issues 07 and 08** — Close out the residual CFP / paper review tasks and the
+   docs-navigation tasks (the bulk landed in commit ff8ef98); these depend on the
+   demo (06) and discipline check (09) being settled.
+9. **Issue 10** — The pre-event rehearsal checklist runs last, exercising the
+   whole package on target hardware.
+
+## Validation Plan
+
+- **pytest suites to run** (real files in `tests/`):
+  - `tests/test_action_arbiter_v1.py`, `tests/test_action_arbiter_v2.py`
+  - `tests/test_decision_explanation_v1.py`, `tests/test_decision_explanation_v2.py`
+  - `tests/test_audit_logger_v1.py` (includes tamper-detection / chain verification)
+  - `tests/test_soc_policy_v1.py`, `tests/test_soc_policy_dry_run_v1.py`
+  - `tests/test_config_drift_audit_v1.py`
+  - `tests/test_demo_scenario_pack_v1.py` (plus the new scenario assertions from Issue 06)
+  - new field-presence test from Issue 01 and schema-validation test from Issue 02
+  - new claims-discipline test from Issue 09 (e.g. `tests/test_claims_discipline_v1.py`)
+- **Claims-discipline grep set** (must return no matches in `README.md` and `docs/`,
+  outside of the explicit "forbidden phrases" lists that name them):
+  - `grep -rniE "world'?s first|military[- ]grade|unbreakable|guaranteed protection|autonomous AI defender" README.md docs/`
+  - `grep -rni "black hat europe" docs/arsenal/` (must be empty pre-acceptance)
+  - `ls docs/arsenal/blackhat-europe-*.md` (must not exist pre-acceptance)
+- **Demo replay verification**:
+  - `bin/azazel-edge-demo run auditable_edge_socnoc` runs offline and reports
+    `execution.mode = deterministic_replay` and `ai_used = false`.
+  - The run produces an explanation record carrying the required auditable fields.
+  - The hash-chained audit log verifies (`verify_chain` reports no mismatch).
+
+## Demo Readiness Checklist
+
+- [ ] Replay scenario `auditable_edge_socnoc` runs fully offline on Raspberry
+      Pi-class hardware.
+- [ ] Explanation JSONL field walk-through rehearsed (`selected_action`,
+      `rejected_actions` / `why_not_others`, `release_condition`, `policy_profile`,
+      `config_hash`, `trace_id`, `evidence_ids`, `operator_wording`).
+- [ ] Audit-chain `verify_chain` demonstration rehearsed, including showing a
+      modified record breaking the chain.
+- [ ] SOC policy dry-run comparison rehearsed (`bin/azazel-soc-policy-dry-run`),
+      reporting policy hash and would-be decisions for two profiles.
+- [ ] Read-only review command (Issue 05) rehearsed for the decision ->
+      explanation -> audit walk.
+- [ ] Fallback to replay-only mode confirmed (no live telemetry, no live
+      enforcement).
+- [ ] Hardware checklist confirmed (device, power, storage, no network dependency,
+      pre-loaded models for the optional AI-assist aside).
+- [ ] Honest answers prepared for Prototype (trace_id threading, runtime profile
+      switching, live enforcement) and Planned items.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Schema duality (v2 `DecisionExplainer` vs tactics-engine `DecisionLogger`) confuses reviewers | Medium | Issue 02 documents the canonical schema and explicitly maps or scopes the second stream; the reviewer walk uses only the v2 record. |
+| Prototype trace_id threading gap is discovered live | Medium | State it up front as Prototype (Issues 02, 10); the demo correlates within the Python pipeline only and does not claim Rust->Python automatic threading. |
+| Submission text over-claims | Medium | Issue 09 adds an automated forbidden-phrase check; Issue 07 requires a claims/safety sign-off before submission. |
+| Europe demo scenario work slips | Medium | Scenario (Issue 06) is dependency-isolated and reuses existing deterministic machinery; replay-only fallback to an existing scenario remains available. |
+| Premature `docs/arsenal/` entry implies acceptance | Low | Issue 09 fails on any `docs/arsenal/blackhat-europe-*.md` or "Black Hat Europe" reference under `docs/arsenal/`. |
+| Live enforcement triggered during demo | Low | `AZAZEL_DEFENSE_ENFORCE` stays off; demo is deterministic replay; checklist (Issue 10) confirms replay-only. |
+
+## Definition of Done
+
+- [ ] Issue 01: field inventory documented and a passing field-presence test exists.
+- [ ] Issue 02: canonical v2 schema documented, second stream mapped or scoped,
+      schema-validation helper/test added, trace_id expectation recorded (test or
+      documented limitation).
+- [ ] Issue 03: every decision-bearing stream either carries rejected-alternatives /
+      release-condition fields or has a documented reason it does not.
+- [ ] Issue 04: every decision-bearing stream either carries `config_hash` and
+      `policy_profile` or has a documented reason it does not; reproducibility story
+      documented.
+- [ ] Issue 05: a read-only review command exists and is documented.
+- [ ] Issue 06: `auditable_edge_socnoc` scenario exists, is registered (no existing
+      id renamed or removed), runs offline, and is covered by a test.
+- [ ] Issue 07: claims/safety sign-off recorded; abstracts fit the submission-form
+      limits; final proofread done.
+- [ ] Issue 08: roadmap and issues directory registered in `docs/INDEX.md` and the
+      concept doc; README kept minimal.
+- [ ] Issue 09: claims-discipline check passes and fails appropriately on seeded
+      violations.
+- [ ] Issue 10: full offline rehearsal completed on target hardware with a passed
+      fallback drill.
+- [ ] All validation greps return clean; named pytest suites pass.


### PR DESCRIPTION
## Summary

Adds the planning and submission-draft documentation for candidate CFP submission-preparation material around the *Auditable Edge SOC/NOC* concept profile of the single Azazel-Edge core. **Documentation only — no code changes.**

> These are planning/draft artifacts. Nothing here implies that an event has reviewed, accepted, or scheduled anything. Status labels follow the project convention (Implemented / Prototype / Planned / Conceptual / Unknown).

## What's included

- **CFP draft** — `docs/cfp/blackhat-europe-arsenal-auditable-edge-socnoc.md`
- **Supporting paper** — `docs/papers/auditable-edge-socnoc-paper.md`
- **Readiness roadmap** — `docs/roadmaps/auditable-edge-socnoc-cfp-roadmap.md` (milestones M1–M6, validation plan, demo-readiness checklist, risks, definition of done)
- **10 issue drafts** — `docs/issues/auditable-edge-socnoc/01..10` + `README.md`
- Navigation / cross-references in `README.md`, `docs/INDEX.md`, `docs/CHANGELOG.md`, `docs/concepts/`

## Registered tracking issues

The 10 issue drafts have been registered as GitHub issues (labels: `auditable-edge-socnoc-cfp` + per-issue):

| Roadmap | Issue | # |
|---|---|---|
| M1 | Confirm current auditable decision fields | #267 |
| M1 | Normalize decision-explanation JSONL schema | #268 |
| M2 | Add rejected alternatives / release conditions | #269 |
| M2 | Config hash / policy profile traceability | #270 |
| M3 | Audit trace viewer / CLI review path | #271 |
| M4 | auditable demo scenario `auditable_edge_socnoc` | #272 |
| M5 | CFP draft and paper | #264 |
| M5 | Docs navigation / README links | #265 |
| M6 | Claims-discipline validation | #273 |
| M6 | Arsenal demo dry-run checklist | #266 |

## Safety / scope

- No attack capability, no enforcement changes (`AZAZEL_DEFENSE_ENFORCE` stays off by default).
- No changes under `installer/`, `security/`, or `systemd/`.
- No CFP material placed under `docs/arsenal/` (acceptance not implied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

