### PR TITLE
docs(audit)+feat(schema): canonical v2 decision-explanation schema + validator (CFP issue 02)

### DIFF
--- a/docs/architecture/evidence-model.md
+++ b/docs/architecture/evidence-model.md
@@ -24,6 +24,83 @@ Evidence records are designed to preserve traceability from observed input to se
 | Audit log event stream | Implemented | Baseline audit logger is included in runtime. |
 | Unified incident bundle package format | Planned | Partial export paths exist; unified operator package remains in progress. |
 
+## Canonical decision-explanation schema (v2)
+
+Records are produced by `DecisionExplainer.explain()` in
+`py/azazel_edge/explanations/decision.py` and written in JSONL format to:
+
+```
+/var/log/azazel-edge/decision-explanations.jsonl
+```
+
+Status: **Implemented**
+
+| Field | Type | Meaning |
+|---|---|---|
+| `ts` | str | ISO 8601 timestamp (UTC, second precision) of when the explanation was generated. |
+| `trace_id` | str | Correlation identifier threaded from the upstream event through the Python pipeline. |
+| `format_version` | str | Schema version; always `"v2"` for records produced by the current explainer. |
+| `selected_action` | str | The action chosen by the arbiter (e.g. `redirect`, `notify`, `isolate`). |
+| `reason` | str | Machine-readable reason code for the chosen action. |
+| `rejected_actions` | list[str] | Names of the alternative actions that were evaluated and not chosen. |
+| `release_condition` | str | Condition under which the applied control should be lifted. |
+| `policy_profile` | str | Identifier of the policy version that governed this decision. |
+| `config_hash` | str | Hash of the active policy/config at decision time (e.g. `sha256:…`). |
+| `why_chosen` | dict | Structured rationale: NOC/SOC states, attack candidates, TI matches, runbook support, client impact, affected scope, and other context used to support the selected action. |
+| `why_not_others` | list[dict] | Per-alternative rejection records, each carrying `action` and `reason`. |
+| `evidence_ids` | list | IDs of the evidence artefacts that were used to support the decision. |
+| `next_checks` | list | Recommended follow-up checks for the operator, derived deterministically from action and state. |
+| `operator_wording` | str | Human-readable summary sentence for operator review. |
+| `machine` | dict | Raw machine context snapshot: `noc_summary`, `soc_summary`, and the full `arbiter` dict. |
+| `trust_capsule` | dict | Integrity capsule signed with HMAC-SHA256; carries `trace_id`, `action`, `confidence`, `evidence_ids`, `hmac_sig`, `ai_contributed`, and `ai_advice_hash`. |
+
+### Tactics-engine DecisionLogger (distinct engine-trace stream)
+
+`DecisionLogger` (in `py/azazel_edge/tactics_engine/decision_logger.py`) writes a
+**separate, low-level internal engine/scoring trace** to:
+
+```
+/opt/azazel-edge/logs/tactics_engine/decision_explanations.jsonl
+```
+
+Its records carry the following fields:
+
+| Field | Notes |
+|---|---|
+| `ts` | ISO 8601 timestamp of the scoring turn. |
+| `decision_id` | UUID generated per turn. |
+| `engine` | Dict with `name` and `version` of the Tactics Engine. |
+| `config_hash` | Hash of the active engine config. |
+| `inputs_snapshot` | Source label, event digest, and minimal raw event data. |
+| `features` | Feature vector extracted by the judge for this turn. |
+| `state_before` | State/suspicion/risk snapshot before the turn. |
+| `score_delta` | Suspicion add and decay values applied this turn. |
+| `constraints_triggered` | List of constraint names that fired (e.g. `cooldown_hit`). |
+| `chosen` | List of chosen transitions or actions with detail dicts. |
+| `state_after` | State/suspicion/risk snapshot after the turn. |
+| `parse_errors` | Count of parse failures encountered during the turn. |
+
+This stream is a **distinct stream** from the canonical v2 explanation record.
+It is a low-level internal engine/scoring trace, not the operator-facing decision
+record.  It intentionally omits `rejected_actions` and `release_condition`
+because those fields belong to the canonical operator decision record (the v2
+explanation), which does carry them.  The two streams must not be conflated.
+
+### trace_id expectations
+
+Within the Python pipeline, the same `trace_id` value appears on the v2
+explanation record and on the related `P0AuditLogger` chain records (each audit
+record carries `trace_id` as a top-level field).  Tests in
+`tests/test_decision_explanation_schema_v1.py` confirm this continuity for the
+Python-internal path.
+
+**Limitation (Prototype gap):** Automatic threading of `trace_id` from the
+Rust core into the Python pipeline is **not verified** and has no integration
+test.  The Rust-core → Python `trace_id` handoff is a known gap; do not assume
+it works end-to-end until an integration test is in place.
+
+Status of Rust → Python trace_id threading: **Prototype**
+
 ## Related Documents
 - [Decision Loop](decision-loop.md)
 - [P0 Runtime Architecture](../P0_RUNTIME_ARCHITECTURE.md)

--- a/py/azazel_edge/explanations/__init__.py
+++ b/py/azazel_edge/explanations/__init__.py
@@ -1,3 +1,4 @@
 from .decision import DecisionExplainer
+from .schema import validate_v2_explanation
 
-__all__ = ['DecisionExplainer']
+__all__ = ['DecisionExplainer', 'validate_v2_explanation']

--- a/py/azazel_edge/explanations/schema.py
+++ b/py/azazel_edge/explanations/schema.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""schema.py - Validation helper for v2 decision-explanation records.
+
+Dependency-free (stdlib only).  Returns a list of human-readable problem
+strings; an empty list means the record is valid.
+"""
+
+from typing import Any, Dict, List
+
+# Fields that must be present and carry a specific Python type.
+# Extra keys are allowed; omitted keys here are not checked.
+_REQUIRED: List[tuple] = [
+    ("ts", str),
+    ("trace_id", str),
+    ("format_version", str),
+    ("selected_action", str),
+    ("reason", str),
+    ("rejected_actions", list),
+    ("release_condition", str),
+    ("policy_profile", str),
+    ("config_hash", str),
+    ("why_chosen", dict),
+    ("why_not_others", list),
+    ("evidence_ids", list),
+    ("next_checks", list),
+    ("operator_wording", str),
+    ("machine", dict),
+    ("trust_capsule", dict),
+]
+
+
+def validate_v2_explanation(record: Dict[str, Any]) -> List[str]:
+    """Validate a v2 decision-explanation record.
+
+    Args:
+        record: The record dict to validate (typically produced by
+                DecisionExplainer.explain(...)).
+
+    Returns:
+        A list of human-readable problem strings.  Empty list means valid.
+    """
+    problems: List[str] = []
+
+    # format_version must be present and equal 'v2'
+    if "format_version" not in record:
+        problems.append("missing required field: format_version")
+    elif record["format_version"] != "v2":
+        problems.append(
+            f"format_version must be 'v2', got {record['format_version']!r}"
+        )
+
+    # Check presence and type of every required field.
+    # (format_version already handled above, but re-check type for uniformity.)
+    for field_name, expected_type in _REQUIRED:
+        if field_name == "format_version":
+            # Already checked above; only re-check type if present.
+            if field_name in record and not isinstance(record[field_name], expected_type):
+                problems.append(
+                    f"field '{field_name}' must be {expected_type.__name__},"
+                    f" got {type(record[field_name]).__name__}"
+                )
+            continue
+
+        if field_name not in record:
+            problems.append(f"missing required field: {field_name}")
+        elif not isinstance(record[field_name], expected_type):
+            problems.append(
+                f"field '{field_name}' must be {expected_type.__name__},"
+                f" got {type(record[field_name]).__name__}"
+            )
+
+    # trust_capsule must carry hmac_sig (structural spot-check)
+    if "trust_capsule" in record and isinstance(record["trust_capsule"], dict):
+        if "hmac_sig" not in record["trust_capsule"]:
+            problems.append("trust_capsule is missing required key: hmac_sig")
+
+    return problems

--- a/tests/test_decision_explanation_schema_v1.py
+++ b/tests/test_decision_explanation_schema_v1.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import copy
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = ROOT / 'py'
+if str(PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(PY_ROOT))
+
+from azazel_edge.explanations import DecisionExplainer, validate_v2_explanation
+from azazel_edge.audit import P0AuditLogger
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build inputs that produce the redirect decision path
+# (NOC all 'good', SOC suspicion=92/critical, confidence=84/critical,
+#  blast=72/high, client_impact={'score':20,'critical_client_count':0})
+# ---------------------------------------------------------------------------
+
+def _dim(score: int, label: str, evidence_ids: list) -> dict:
+    return {'score': score, 'label': label, 'reasons': [], 'evidence_ids': evidence_ids}
+
+
+def _noc_good() -> dict:
+    return {
+        'availability': _dim(95, 'good', ['noc-a']),
+        'path_health': _dim(95, 'good', ['noc-p']),
+        'device_health': _dim(95, 'good', ['noc-d']),
+        'client_health': _dim(95, 'good', ['noc-c']),
+        'summary': {'status': 'good', 'reasons': []},
+        'evidence_ids': ['noc-a', 'noc-p', 'noc-d', 'noc-c'],
+    }
+
+
+def _soc_critical() -> dict:
+    return {
+        'suspicion': _dim(92, 'critical', ['soc-s']),
+        'confidence': _dim(84, 'critical', ['soc-c']),
+        'technique_likelihood': _dim(60, 'high', ['soc-t']),
+        'blast_radius': _dim(72, 'high', ['soc-b']),
+        'summary': {'status': 'critical', 'reasons': []},
+        'evidence_ids': ['soc-s', 'soc-c', 'soc-t', 'soc-b'],
+    }
+
+
+def _make_redirect_record(trace_id: str = 'trace-schema-v1-test') -> dict:
+    """Build a real v2 explanation via the redirect decision path."""
+    import tempfile
+    from azazel_edge.arbiter import ActionArbiter
+
+    arbiter_result = ActionArbiter().decide(
+        _noc_good(),
+        _soc_critical(),
+        client_impact={'score': 20, 'critical_client_count': 0},
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        explainer = DecisionExplainer(
+            output_path=Path(tmp) / 'test-schema-explanations.jsonl'
+        )
+        return explainer.explain(
+            noc=_noc_good(),
+            soc=_soc_critical(),
+            arbiter=arbiter_result,
+            target='test-edge',
+            trace_id=trace_id,
+            persist=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class ValidateV2ExplanationTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        # Build the canonical redirect record once; individual tests work
+        # on copies so the shared instance stays unmodified.
+        self._canonical = _make_redirect_record()
+
+    # -- happy-path ----------------------------------------------------------
+
+    def test_valid_redirect_record_passes(self) -> None:
+        """A real v2 redirect record must produce no validation errors."""
+        errors = validate_v2_explanation(self._canonical)
+        self.assertEqual(
+            errors, [],
+            msg=f"Expected no errors for a valid record, got: {errors}",
+        )
+
+    # -- missing required fields ---------------------------------------------
+
+    def test_missing_config_hash_returns_error(self) -> None:
+        bad = copy.deepcopy(self._canonical)
+        del bad['config_hash']
+        errors = validate_v2_explanation(bad)
+        self.assertTrue(
+            len(errors) > 0,
+            msg="Expected errors when config_hash is missing",
+        )
+        self.assertTrue(
+            any('config_hash' in e for e in errors),
+            msg=f"Expected an error mentioning 'config_hash', got: {errors}",
+        )
+
+    def test_missing_format_version_returns_error(self) -> None:
+        bad = copy.deepcopy(self._canonical)
+        del bad['format_version']
+        errors = validate_v2_explanation(bad)
+        self.assertTrue(len(errors) > 0)
+        self.assertTrue(any('format_version' in e for e in errors))
+
+    def test_missing_trust_capsule_returns_error(self) -> None:
+        bad = copy.deepcopy(self._canonical)
+        del bad['trust_capsule']
+        errors = validate_v2_explanation(bad)
+        self.assertTrue(len(errors) > 0)
+        self.assertTrue(any('trust_capsule' in e for e in errors))
+
+    # -- wrong format_version value ------------------------------------------
+
+    def test_wrong_format_version_value_returns_error(self) -> None:
+        bad = copy.deepcopy(self._canonical)
+        bad['format_version'] = 'v1'
+        errors = validate_v2_explanation(bad)
+        self.assertTrue(len(errors) > 0)
+        self.assertTrue(any('format_version' in e for e in errors))
+
+    # -- wrong types ---------------------------------------------------------
+
+    def test_evidence_ids_wrong_type_returns_error(self) -> None:
+        """evidence_ids must be a list; a string value should be flagged."""
+        bad = copy.deepcopy(self._canonical)
+        bad['evidence_ids'] = 'x'
+        errors = validate_v2_explanation(bad)
+        self.assertTrue(
+            len(errors) > 0,
+            msg="Expected errors when evidence_ids has wrong type",
+        )
+        self.assertTrue(
+            any('evidence_ids' in e for e in errors),
+            msg=f"Expected an error mentioning 'evidence_ids', got: {errors}",
+        )
+
+    def test_why_chosen_wrong_type_returns_error(self) -> None:
+        bad = copy.deepcopy(self._canonical)
+        bad['why_chosen'] = 'not-a-dict'
+        errors = validate_v2_explanation(bad)
+        self.assertTrue(len(errors) > 0)
+        self.assertTrue(any('why_chosen' in e for e in errors))
+
+    def test_rejected_actions_wrong_type_returns_error(self) -> None:
+        bad = copy.deepcopy(self._canonical)
+        bad['rejected_actions'] = {'action': 'observe'}  # dict instead of list
+        errors = validate_v2_explanation(bad)
+        self.assertTrue(len(errors) > 0)
+        self.assertTrue(any('rejected_actions' in e for e in errors))
+
+    # -- extra keys are allowed ----------------------------------------------
+
+    def test_extra_keys_are_allowed(self) -> None:
+        extra = copy.deepcopy(self._canonical)
+        extra['experimental_field'] = 'some-value'
+        extra['another_new_key'] = [1, 2, 3]
+        errors = validate_v2_explanation(extra)
+        self.assertEqual(
+            errors, [],
+            msg=f"Extra keys should not cause errors, got: {errors}",
+        )
+
+
+class TraceIdContinuityTests(unittest.TestCase):
+    """
+    Verify that within the Python pipeline the same trace_id appears on
+    both the P0AuditLogger record and the v2 explanation record.
+    """
+
+    TRACE_ID = 'trace-bheu-02'
+
+    def test_trace_id_continuity_and_chain_integrity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            audit_path = Path(tmp) / 'audit.jsonl'
+            audit_logger = P0AuditLogger(audit_path)
+
+            # 1. Write an audit record for the action decision.
+            audit_record = audit_logger.log_action_decision(
+                trace_id=self.TRACE_ID,
+                source='arbiter',
+                action='redirect',
+            )
+
+            # 2. Generate the v2 explanation for the same trace.
+            explanation = _make_redirect_record(trace_id=self.TRACE_ID)
+
+            # 3. Both records must carry the same trace_id.
+            self.assertEqual(
+                audit_record['trace_id'],
+                self.TRACE_ID,
+                msg="Audit record must carry the shared trace_id",
+            )
+            self.assertEqual(
+                explanation['trace_id'],
+                self.TRACE_ID,
+                msg="Explanation record must carry the shared trace_id",
+            )
+
+            # 4. The audit chain must be intact.
+            chain_result = P0AuditLogger.verify_chain(audit_path)
+            self.assertTrue(
+                chain_result['ok'],
+                msg=f"verify_chain must report ok=True, got: {chain_result}",
+            )
+            self.assertEqual(
+                chain_result['error'],
+                '',
+                msg=f"verify_chain must report empty error string, got: {chain_result}",
+            )
+            self.assertGreater(
+                chain_result['entries'],
+                0,
+                msg="verify_chain must report at least one entry",
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements **CFP issue 02** — establishes the canonical decision-explanation schema, disambiguates it from the second JSONL stream, and adds a validator + tests. No runtime behavior change to `DecisionExplainer` or `P0AuditLogger`.

## Changes
- **`docs/architecture/evidence-model.md`**
  - Documents the `DecisionExplainer` **v2 record as canonical** (full field table + canonical path `/var/log/azazel-edge/decision-explanations.jsonl`).
  - Documents the tactics-engine **`DecisionLogger`** (`py/azazel_edge/tactics_engine/decision_logger.py`) as a **distinct low-level engine/scoring trace** and explains why it omits `rejected_actions` / `release_condition` (those belong to the canonical operator record).
  - Records **trace_id expectations**: same `trace_id` on the v2 explanation and the related `P0AuditLogger` chain records within the Python pipeline; marks Rust-core → Python automatic threading as a **Prototype** gap (not claimed to work).
- **`py/azazel_edge/explanations/schema.py`** (new) — `validate_v2_explanation(record) -> list[str]` (stdlib-only; required keys + types + `trust_capsule.hmac_sig`). Exported from the package.
- **`tests/test_decision_explanation_schema_v1.py`** (new) — validator happy/error paths (missing field, wrong type, wrong version, extra keys allowed) + a Python-pipeline **trace_id continuity & audit-chain integrity** test using `P0AuditLogger.verify_chain`.

## Validation
`python3.10 -m unittest tests.test_decision_explanation_schema_v1 -v` → 10 tests, all pass. No hype phrases introduced (claims-discipline grep clean).

## Acceptance criteria (issue 02)
- [x] Schema document names the v2 record canonical and lists every field.
- [x] Tactics-engine relationship explicitly documented (scoped as distinct) incl. why it lacks rejected-alternatives / release-condition.
- [x] Schema-validation helper exists; pytest validates a generated v2 record.
- [x] trace_id continuity within the Python pipeline asserted by a test; Rust→Python threading documented as Prototype.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

