### PR TITLE
feat(demo): auditable_edge_socnoc replay scenario (CFP issue 06)

### DIFF
--- a/demos/concepts/auditable-edge-socnoc.yaml
+++ b/demos/concepts/auditable-edge-socnoc.yaml
@@ -2,10 +2,10 @@ concept_id: auditable-edge-socnoc
 label: Auditable Edge SOC/NOC
 status: concept_profile
 stage_order:
+  - auditable_edge_socnoc
   - mixed_correlation_demo
-  - disaster_phishing_demo
 scenarios:
+  - id: auditable_edge_socnoc
+    role: regulated EU edge segment — auditable reversible control decision with offline audit-chain review; demonstrates config_hash and policy_profile in the local decision record
   - id: mixed_correlation_demo
     role: explanation trace and rejected-alternatives review
-  - id: disaster_phishing_demo
-    role: social-engineering triage with auditable operator handoff

--- a/py/azazel_edge/demo/scenarios.py
+++ b/py/azazel_edge/demo/scenarios.py
@@ -309,6 +309,62 @@ class DemoScenarioPack:
                     {'event_id': 'sh-h2', 'source': 'suricata_eve', 'kind': 'alert', 'subject': '10.0.0.45->192.168.50.50:80/TCP', 'severity': 70, 'confidence': 0.78, 'attrs': {'sid': 220500, 'attack_type': 'suspicious web access', 'category': 'Potentially Bad Traffic', 'target_port': 80, 'risk_score': 70, 'confidence_raw': 78, 'src_ip': '10.0.0.45', 'dst_ip': '192.168.50.50'}},
                 ],
             },
+            'auditable_edge_socnoc': {
+                'description': 'Regulated EU edge segment: high-confidence SOC signal drives auditable reversible control with a full local decision record.',
+                'demo': {
+                    'title': 'Auditable Edge SOC/NOC — EU Regulated Segment',
+                    'summary': 'Cross-source SOC evidence from a regulated EU edge node promotes bounded reversible control, producing a complete offline audit record without any cloud dependency.',
+                    'attack_label': 'DNS C2 Beacon (EU Segment)',
+                    'default_hold_sec': 8,
+                    'talk_track': 'Suricata and flow evidence raise a high-confidence SOC signal on a privacy-sensitive EU edge segment. The deterministic replay shows why the arbiter selects auditable reversible control, how the decision record is produced locally, and what the operator sees before any action is taken.',
+                    'decision_path': {
+                        'first_pass': {
+                            'headline': 'SOC SIGNAL: CRITICAL (REGULATED SEGMENT)',
+                            'detail': 'The Suricata alert and failed TLS flow align on the same source / destination pair within the regulated EU edge segment.',
+                        },
+                        'second_pass': {
+                            'headline': 'CORRELATION SUPPORT ACTIVE',
+                            'detail': 'Cross-source evidence keeps the case on the SOC path; the local-first decision record is written before the arbiter selects control.',
+                        },
+                        'final_policy': {
+                            'headline': 'FINAL POLICY: AUDITABLE REVERSIBLE CONTROL',
+                            'detail': 'The suspicious flow moves into bounded reversible control. The config hash and policy profile are embedded in the offline audit record for post-action review.',
+                        },
+                    },
+                    'proofs': {
+                        'detection': {
+                            'status': 'active',
+                            'headline': 'SURICATA ALERT ACTIVE (EU SEGMENT)',
+                            'detail': 'The core trigger comes from Suricata and is reinforced by aligned flow evidence captured within the local regulated segment.',
+                            'evidence': 'sid=210001 | flow anomaly support | segment=eu-regulated',
+                        },
+                        'control': {
+                            'status': 'active',
+                            'headline': 'AUDITABLE REVERSIBLE CONTROL READY',
+                            'detail': 'The arbiter keeps the response bounded and reversible; the operator may inspect or cancel before the control takes effect.',
+                            'evidence': 'action=throttle | mode=route_preference | audit_chain=local',
+                        },
+                        'explanation': {
+                            'status': 'active',
+                            'headline': 'OFFLINE AUDIT RECORD READY',
+                            'detail': 'The explanation payload carries config_hash and policy_profile for post-action accountability. No data leaves the local segment.',
+                            'evidence': 'config_hash embedded | policy_profile embedded | local-first decision record',
+                        },
+                    },
+                },
+                'events': [
+                    {'event_id': 'eu-soc-1', 'source': 'suricata_eve', 'kind': 'alert', 'subject': '10.0.1.5->192.168.60.10:443/TCP', 'severity': 88, 'confidence': 0.92, 'attrs': {'sid': 210001, 'attack_type': 'DNS C2 Beacon', 'category': 'Potentially Bad Traffic', 'target_port': 443, 'risk_score': 88, 'confidence_raw': 92, 'src_ip': '10.0.1.5', 'dst_ip': '192.168.60.10'}},
+                    {'event_id': 'eu-flow-1', 'source': 'flow_min', 'kind': 'flow_summary', 'subject': '10.0.1.5->192.168.60.10:443/TCP', 'severity': 45, 'confidence': 0.70, 'attrs': {'src_ip': '10.0.1.5', 'dst_ip': '192.168.60.10', 'dst_port': 443, 'flow_state': 'failed', 'app_proto': 'tls'}},
+                    {'event_id': 'eu-probe-1', 'source': 'noc_probe', 'kind': 'icmp_probe', 'subject': '192.168.60.1', 'severity': 0, 'confidence': 0.95, 'attrs': {'reachable': True}},
+                ],
+                'scoring': {
+                    'scenario_id': 'auditable_edge_socnoc',
+                    'response_time_sec': None,
+                    'correct_action': None,
+                    'runbook_proposed': None,
+                    'drills_completed': 0,
+                },
+            },
         }
 
     def stage_order(self) -> List[str]:

--- a/tests/test_auditable_edge_socnoc_scenario_v1.py
+++ b/tests/test_auditable_edge_socnoc_scenario_v1.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = ROOT / 'py'
+if str(PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(PY_ROOT))
+
+from azazel_edge.demo import DemoScenarioPack, DemoScenarioRunner
+
+FORBIDDEN_WORDS = {'disaster', 'shelter', 'evacuation', 'emergency', 'refugee', 'crisis'}
+SCENARIO_ID = 'auditable_edge_socnoc'
+
+
+def _collect_narrative(scenario: dict) -> str:
+    """Recursively collect all string leaf values from a scenario dict."""
+    parts: list[str] = []
+
+    def _walk(obj: object) -> None:
+        if isinstance(obj, str):
+            parts.append(obj)
+        elif isinstance(obj, dict):
+            for v in obj.values():
+                _walk(v)
+        elif isinstance(obj, (list, tuple)):
+            for item in obj:
+                _walk(item)
+
+    _walk(scenario)
+    return ' '.join(parts)
+
+
+class AuditableEdgeSocnocScenarioV1Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.pack = DemoScenarioPack()
+        self.runner = DemoScenarioRunner()
+
+    # ------------------------------------------------------------------
+    # 1. Scenario is present and has the required top-level keys
+    # ------------------------------------------------------------------
+    def test_scenario_is_registered_in_pack(self) -> None:
+        scenarios = self.pack.scenarios()
+        self.assertIn(SCENARIO_ID, scenarios,
+                      f"'{SCENARIO_ID}' not found in DemoScenarioPack.scenarios()")
+
+    def test_scenario_has_required_keys(self) -> None:
+        scenario = self.pack.scenarios()[SCENARIO_ID]
+        for key in ('description', 'demo', 'events', 'scoring'):
+            self.assertIn(key, scenario,
+                          f"Expected key '{key}' missing from scenario '{SCENARIO_ID}'")
+
+    # ------------------------------------------------------------------
+    # 2. Runner produces the correct execution metadata
+    # ------------------------------------------------------------------
+    def test_runner_execution_mode_is_deterministic_replay(self) -> None:
+        result = self.runner.run(SCENARIO_ID)
+        execution = result.get('execution', {})
+        self.assertEqual(execution.get('mode'), 'deterministic_replay',
+                         f"Expected execution.mode='deterministic_replay', got {execution.get('mode')!r}")
+
+    def test_runner_ai_used_is_false(self) -> None:
+        result = self.runner.run(SCENARIO_ID)
+        execution = result.get('execution', {})
+        self.assertIs(execution.get('ai_used'), False,
+                      f"Expected execution.ai_used=False, got {execution.get('ai_used')!r}")
+
+    # ------------------------------------------------------------------
+    # 3. Explanation carries required audit fields
+    # ------------------------------------------------------------------
+    def test_explanation_rejected_actions_is_non_empty(self) -> None:
+        result = self.runner.run(SCENARIO_ID)
+        explanation = result.get('explanation', {})
+        rejected_actions = explanation.get('rejected_actions')
+        self.assertTrue(
+            isinstance(rejected_actions, list) and len(rejected_actions) > 0,
+            f"Expected non-empty explanation.rejected_actions, got {rejected_actions!r}",
+        )
+
+    def test_explanation_why_not_others_is_non_empty(self) -> None:
+        result = self.runner.run(SCENARIO_ID)
+        explanation = result.get('explanation', {})
+        why_not_others = explanation.get('why_not_others')
+        self.assertTrue(
+            isinstance(why_not_others, list) and len(why_not_others) > 0,
+            f"Expected non-empty explanation.why_not_others, got {why_not_others!r}",
+        )
+
+    def test_explanation_release_condition_is_non_empty(self) -> None:
+        result = self.runner.run(SCENARIO_ID)
+        explanation = result.get('explanation', {})
+        release_condition = explanation.get('release_condition', '')
+        self.assertTrue(
+            isinstance(release_condition, str) and release_condition.strip(),
+            f"Expected non-empty explanation.release_condition, got {release_condition!r}",
+        )
+
+    def test_explanation_config_hash_is_non_empty(self) -> None:
+        result = self.runner.run(SCENARIO_ID)
+        explanation = result.get('explanation', {})
+        config_hash = explanation.get('config_hash', '')
+        self.assertTrue(
+            isinstance(config_hash, str) and config_hash.strip(),
+            f"Expected non-empty explanation.config_hash, got {config_hash!r}",
+        )
+
+    def test_explanation_policy_profile_is_non_empty(self) -> None:
+        result = self.runner.run(SCENARIO_ID)
+        explanation = result.get('explanation', {})
+        policy_profile = explanation.get('policy_profile', '')
+        self.assertTrue(
+            isinstance(policy_profile, str) and policy_profile.strip(),
+            f"Expected non-empty explanation.policy_profile, got {policy_profile!r}",
+        )
+
+    # ------------------------------------------------------------------
+    # 4. Narrative text contains no forbidden words
+    # ------------------------------------------------------------------
+    def test_narrative_contains_no_forbidden_words(self) -> None:
+        scenario = self.pack.scenarios()[SCENARIO_ID]
+        narrative = _collect_narrative(scenario).lower()
+        found = [w for w in FORBIDDEN_WORDS if w in narrative]
+        self.assertEqual(
+            found, [],
+            f"Forbidden word(s) found in '{SCENARIO_ID}' narrative: {found}",
+        )
+
+    # ------------------------------------------------------------------
+    # 5. disaster_phishing_demo is still defined (not removed from pack)
+    # ------------------------------------------------------------------
+    def test_disaster_phishing_demo_still_in_pack(self) -> None:
+        scenarios = self.pack.scenarios()
+        self.assertIn('disaster_phishing_demo', scenarios,
+                      "'disaster_phishing_demo' was removed from DemoScenarioPack — it must remain defined")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements **CFP issue 06** — a deterministic replay scenario `auditable_edge_socnoc` framed for a **privacy-sensitive, regulated, local-first edge segment**. Drives a high-confidence SOC **bounded reversible-control** decision (`action=throttle`) with non-empty rejected alternatives + a release condition, whose explanation carries `config_hash` / `policy_profile` — so the auditable decision record and audit-chain walk can be shown end to end.

> Stacked on #279 (05) → #278 (03+04) → #276 (02). Merge in that order.

## Changes
- **`py/azazel_edge/demo/scenarios.py`** — appended the scenario at the END of `scenarios()` (existing insertion order preserved, so index-based pack tests stay valid). Neutral regulated/auditable narrative; **no disaster/shelter/evacuation/emergency framing**.
- **`demos/concepts/auditable-edge-socnoc.yaml`** — registered `auditable_edge_socnoc` in `stage_order` + `scenarios`; replaced the `disaster_phishing_demo` reference in this auditable concept pack (its definition in `scenarios.py` is untouched and remains a valid id).
- **`tests/test_auditable_edge_socnoc_scenario_v1.py`** (new) — asserts the scenario exists, runs as `deterministic_replay` with `ai_used=False`, produces non-empty `rejected_actions` / `release_condition` / `config_hash` / `policy_profile`, uses no forbidden framing words, and that `disaster_phishing_demo` remains defined.

## Decision values (deterministic)
`throttle` (bounded reversible control) · `release_condition=no_repeated_failures_for_300_seconds` · `config_hash` non-empty · `policy_profile=soc-policy-default-v1` · `rejected_actions=[observe, notify, redirect, isolate]` · `execution.mode=deterministic_replay` · `ai_used=False`.

## Validation
`python3.10 -m unittest tests.test_auditable_edge_socnoc_scenario_v1 tests.test_demo_scenario_pack_v1 -v` → 14 tests, all pass (existing pack test unbroken).

## Acceptance criteria (issue 06)
- [x] Runs fully offline, reports `deterministic_replay` + `ai_used=false`.
- [x] Explanation has non-empty rejected alternatives + release condition + `config_hash` + `policy_profile`.
- [x] No disaster/shelter/emergency framing.
- [x] No existing scenario id renamed/removed; `disaster_phishing_demo` still valid.
- [x] Concept yaml lists `auditable_edge_socnoc` in `stage_order` + `scenarios`.
- [x] Test covers the scenario.
- [ ] CFP Demo Plan reference — tracked separately (CFP draft is in the docs branch, PR #274).

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
