### PR TITLE
fix(ci): stabilize BHUSA Python tooling tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,14 @@ jobs:
           pip install -r requirements/runtime.txt
           pip install pytest
 
+      - name: Normalize local tooling permissions
+        run: |
+          chmod +x bin/azazel-edge-* || true
+
       - name: Run tests
         run: |
           . .venv/bin/activate
-          PYTHONPATH=. pytest -q
+          PYTHONPATH=.:py pytest -q
 
   test-rust:
     name: Rust tests
@@ -65,6 +69,8 @@ jobs:
     if: github.event_name == 'pull_request' && vars.ENABLE_DEPENDENCY_REVIEW == 'true'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Review dependency changes
         uses: actions/dependency-review-action@v4
         with:


### PR DESCRIPTION
## Summary
- add an explicit chmod normalization step for `bin/azazel-edge-*` wrappers before Python tests
- run pytest with `PYTHONPATH=.:py` so root-level and `py/` package imports are both available in CI
- add checkout to the optional dependency-review job so the action has repository contents when enabled

## Why
Recent BHUSA closeout tooling added tests that execute local `bin/azazel-edge-bhusa-*` wrappers. In a fresh GitHub Actions checkout, CI should not depend on implicit executable-bit or import-path assumptions. This PR makes the workflow deterministic for the added tooling tests.

## Testing
- Not run locally: repository clone is unavailable from this execution environment.
- Change is limited to GitHub Actions workflow hardening.