### PR TITLE
fix: graceful gh-cli fallback in bhusa_status; fix freeze_check returncode guard

### DIFF
--- a/py/azazel_edge/bhusa_freeze_check.py
+++ b/py/azazel_edge/bhusa_freeze_check.py
@@ -143,7 +143,7 @@ def _run_booth_verify(args: argparse.Namespace) -> Dict[str, Any]:
     if not args.verify_services:
         cmd.append("--skip-services")
     result = _run_command(cmd)
-    if result.returncode != 0:
+    if result.returncode not in (0, 1):
         stderr = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         raise ValueError(f"booth verify failed: {stderr}")
     payload = _load_json(result.stdout, context="azazel-edge-bhusa-verify")

--- a/py/azazel_edge/bhusa_status.py
+++ b/py/azazel_edge/bhusa_status.py
@@ -282,9 +282,14 @@ def _build_report(args: argparse.Namespace) -> Dict[str, Any]:
         "warnings": [],
     }
     if not args.skip_github:
-        github_loaded = _load_github_issues(args.repo, links)
-        github["issues"] = github_loaded["issues"]
-        github["warnings"] = github_loaded["warnings"]
+        try:
+            github_loaded = _load_github_issues(args.repo, links)
+            github["issues"] = github_loaded["issues"]
+            github["warnings"] = github_loaded["warnings"]
+        except ValueError as exc:
+            github["warnings"].append(
+                f"gh lookup unavailable ({exc}); pass --skip-github to suppress"
+            )
 
     freeze_check: Optional[Dict[str, Any]] = None
     if args.include_freeze_check:


### PR DESCRIPTION
bhusa_status._build_report() now catches ValueError from _load_github_issues()
and appends a warning instead of raising, so CI runs without gh authentication
no longer cause bhusa_status (and every tool that calls it) to return exit 2.

bhusa_freeze_check._run_booth_verify() now treats returncode 1 as a valid
"verify ran but found issues" result rather than an unrecoverable error,
matching the bhusa_verify contract (0=pass, 1=failures, 2=exception).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KBKr1SgoRijSYkUgBmSHxH