### PR TITLE
fix(web): cache Mattermost reachability to keep dashboard responsive

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -314,6 +314,11 @@ def _read_mattermost_command_tokens() -> List[str]:
 
 MATTERMOST_COMMAND_TOKENS = _read_mattermost_command_tokens()
 MATTERMOST_TIMEOUT_SEC = float(os.environ.get("AZAZEL_MATTERMOST_TIMEOUT_SEC", "8"))
+# The reachability ping runs on the dashboard hot path (every refresh, from
+# multiple endpoints). Keep its timeout short and cache the result so an
+# unreachable Mattermost cannot saturate the web worker threads.
+MATTERMOST_PING_TIMEOUT_SEC = float(os.environ.get("AZAZEL_MATTERMOST_PING_TIMEOUT_SEC", "2"))
+MATTERMOST_PING_CACHE_TTL_SEC = float(os.environ.get("AZAZEL_MATTERMOST_PING_CACHE_TTL_SEC", "15"))
 MATTERMOST_FETCH_LIMIT = int(os.environ.get("AZAZEL_MATTERMOST_FETCH_LIMIT", "40"))
 DASHBOARD_SNAPSHOT_STALE_SEC = float(os.environ.get("AZAZEL_DASHBOARD_SNAPSHOT_STALE_SEC", "30"))
 DASHBOARD_AI_STALE_SEC = float(os.environ.get("AZAZEL_DASHBOARD_AI_STALE_SEC", "120"))
@@ -4540,19 +4545,47 @@ def _mattermost_mode() -> str:
     return "disabled"
 
 
-def _mattermost_ping() -> tuple[bool, Dict[str, Any]]:
+def _mattermost_ping_uncached() -> tuple[bool, Dict[str, Any]]:
     try:
         req = Request(
             f"{MATTERMOST_BASE_URL}/api/v4/system/ping",
             headers={"Accept": "application/json"},
             method="GET",
         )
-        with urlopen(req, timeout=MATTERMOST_TIMEOUT_SEC) as resp:
+        with urlopen(req, timeout=MATTERMOST_PING_TIMEOUT_SEC) as resp:
             payload_raw = resp.read().decode("utf-8", errors="replace")
         payload = json.loads(payload_raw) if payload_raw else {}
         return True, payload if isinstance(payload, dict) else {}
     except Exception as e:
         return False, {"error": str(e)}
+
+
+_MATTERMOST_PING_LOCK = threading.Lock()
+_MATTERMOST_PING_CACHE: Dict[str, Any] = {"ts": 0.0, "value": (False, {"error": "not_checked"})}
+
+
+def _mattermost_ping(force: bool = False) -> tuple[bool, Dict[str, Any]]:
+    """Reachability ping with a short TTL cache.
+
+    Called on every dashboard refresh from several endpoints; without caching
+    an unreachable Mattermost would block a worker thread per request and
+    saturate the web server. Refresh is single-flight: while one thread probes,
+    concurrent callers return the last cached value instead of piling up.
+    """
+    now = time.time()
+    cache = _MATTERMOST_PING_CACHE
+    if not force and (now - float(cache.get("ts") or 0.0)) < MATTERMOST_PING_CACHE_TTL_SEC:
+        return cache["value"]
+    if not _MATTERMOST_PING_LOCK.acquire(blocking=False):
+        # Another thread is already refreshing; serve the last known value.
+        return cache["value"]
+    try:
+        value = _mattermost_ping_uncached()
+        cache["value"] = value
+        cache["ts"] = time.time()
+        return value
+    finally:
+        _MATTERMOST_PING_LOCK.release()
 
 
 def _mattermost_api_request(method: str, path: str, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/tests/test_mattermost_ping_cache_v1.py
+++ b/tests/test_mattermost_ping_cache_v1.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import unittest
+
+from azazel_edge_web import app as webapp
+
+
+class MattermostPingCacheV1Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._orig_uncached = webapp._mattermost_ping_uncached
+        self._orig_cache = dict(webapp._MATTERMOST_PING_CACHE)
+        self._orig_ttl = webapp.MATTERMOST_PING_CACHE_TTL_SEC
+        # Force a cold cache for each test.
+        webapp._MATTERMOST_PING_CACHE["ts"] = 0.0
+        webapp._MATTERMOST_PING_CACHE["value"] = (False, {"error": "not_checked"})
+
+    def tearDown(self) -> None:
+        webapp._mattermost_ping_uncached = self._orig_uncached
+        webapp._MATTERMOST_PING_CACHE.clear()
+        webapp._MATTERMOST_PING_CACHE.update(self._orig_cache)
+        webapp.MATTERMOST_PING_CACHE_TTL_SEC = self._orig_ttl
+
+    def _install_counter(self, value):
+        self.calls = 0
+
+        def fake():
+            self.calls += 1
+            return value
+
+        webapp._mattermost_ping_uncached = fake
+
+    def test_ping_result_is_cached_within_ttl(self) -> None:
+        webapp.MATTERMOST_PING_CACHE_TTL_SEC = 300
+        self._install_counter((True, {"status": "OK"}))
+        first = webapp._mattermost_ping()
+        for _ in range(9):
+            webapp._mattermost_ping()
+        self.assertEqual(first, (True, {"status": "OK"}))
+        self.assertEqual(self.calls, 1, "reachability ping must hit the network only once within the TTL")
+
+    def test_force_refresh_bypasses_cache(self) -> None:
+        webapp.MATTERMOST_PING_CACHE_TTL_SEC = 300
+        self._install_counter((True, {"status": "OK"}))
+        webapp._mattermost_ping()
+        webapp._mattermost_ping(force=True)
+        self.assertEqual(self.calls, 2, "force=True must re-probe even inside the TTL")
+
+    def test_expired_cache_triggers_refresh(self) -> None:
+        webapp.MATTERMOST_PING_CACHE_TTL_SEC = 0  # everything is immediately stale
+        self._install_counter((False, {"error": "unreachable"}))
+        webapp._mattermost_ping()
+        webapp._mattermost_ping()
+        self.assertEqual(self.calls, 2, "an expired cache must re-probe on the next call")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 問題 / Problem
Web ダッシュボードに「Dashboard refresh failed」エラーが定期的に発生。

**根本原因**（デモ削除とは無関係の潜在的な製品欠陥）:
- Mattermost 生存確認 ping (`_mattermost_ping`) が**ホットパスで同期実行**され、1リフレッシュあたり3箇所（`api_mattermost_status` / `api_dashboard_health` / summaryビルダー）で呼ばれる
- タイムアウト **8秒**・キャッシュ無し。Mattermost 未疎通時は各呼び出しがワーカースレッドを8秒占有
- 本番は gunicorn **2 workers × 4 threads = 8スロット**。数タブがリフレッシュするだけで飽和し、必須リクエスト（`/api/state`・`/api/dashboard/summary`）がタイムアウト
- Mac 開発機（Mattermost 不在）で顕在化したが、**Mattermost が落ちればどの環境でも劣化する**

## 修正 / Fix
- `_mattermost_ping` に **single-flight な TTLキャッシュ**（既定15秒）を追加。probe中の並行呼び出しは直近のキャッシュ値を返し、ネットワークに殺到しない
- 生存確認専用の**短いタイムアウト** `AZAZEL_MATTERMOST_PING_TIMEOUT_SEC`（既定2秒）を導入。実 API 呼び出し（送信/取得）は従来の8秒のまま
- Mac 用の応急処置（`tools/macdev/env.sh` の Mattermost 上書き）は製品修正で不要になったため削除

## 実測 / Measured (dev Mac, Mattermost unreachable)
| エンドポイント | 修正前 | 修正後 |
|---|---|---|
| /api/mattermost/status | 8.0s | ~0.01s |
| /api/dashboard/health | 8.0s | ~0.01s |
| /api/state | 0.3s | 0.3s |
| /api/dashboard/summary | 0.3s | 0.3s |

最悪でも「15秒に1回・最大2秒」に低減（従来: 毎リクエスト8秒）。

## テスト / Tests
- 新規 `tests/test_mattermost_ping_cache_v1.py`（TTL内は1回だけ probe / `force=True` で再probe / TTL失効で再probe）
- フルスイート **489 passed**
- ブラウザで28秒監視しコンソールエラーゼロを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)