### PR TITLE
feat(dev): macOS one-shot dev stack launcher + injector demo menu

### DIFF
--- a/bin/azazel-edge-devstack
+++ b/bin/azazel-edge-devstack
@@ -1,0 +1,459 @@
+#!/usr/bin/env bash
+# azazel-edge-devstack: one-shot macOS dev-runtime launcher.
+# Brings up the full Azazel dev stack (control daemon, AI agent, rust core, web)
+# with one command, and can tear it down or report status. macOS dev only --
+# all state lives under $AZAZEL_DEV_STATE, never the Linux appliance paths.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --- colors / markers -------------------------------------------------------
+if [[ -t 1 ]]; then
+  C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'
+  C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_CYAN=$'\033[36m'
+else
+  C_RESET=""; C_BOLD=""; C_GREEN=""; C_RED=""; C_YELLOW=""; C_CYAN=""
+fi
+OK="${C_GREEN}✓${C_RESET}"; BAD="${C_RED}✗${C_RESET}"; WAIT="${C_YELLOW}…${C_RESET}"
+
+info() { printf '%s\n' "${C_CYAN}$*${C_RESET}"; }
+warn() { printf '%s\n' "${C_YELLOW}WARN:${C_RESET} $*" >&2; }
+err()  { printf '%s\n' "${C_RED}ERROR:${C_RESET} $*" >&2; }
+
+# --- environment ------------------------------------------------------------
+# env.sh sets every AZAZEL_* var, PYTHONPATH and the dev state dir. It only sets
+# env, it starts nothing. It also unsets its own RUN_DIR/LOG_DIR locals, so we
+# re-derive ours from $AZAZEL_DEV_STATE below.
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/tools/macdev/env.sh"
+
+# Dev override: env.sh does NOT set AZAZEL_MATTERMOST_HOST, so the web app / AI
+# agent would default to the appliance IP 172.16.0.254. In dev Mattermost runs
+# on OrbStack at localhost:8065 -- point at it unless the user already chose.
+export AZAZEL_MATTERMOST_HOST="${AZAZEL_MATTERMOST_HOST:-127.0.0.1}"
+
+RUN_DIR="${AZAZEL_DEV_STATE}/run"
+LOG_DIR="${AZAZEL_DEV_STATE}/log"
+DEVSTACK_RUN="${RUN_DIR}/devstack"
+DEVSTACK_LOG="${LOG_DIR}/devstack"
+mkdir -p "${DEVSTACK_RUN}" "${DEVSTACK_LOG}" "${AZAZEL_DEV_STATE}/suricata"
+
+VENV_PY="${ROOT_DIR}/.venv/bin/python"
+RUST_CORE_DIR="${ROOT_DIR}/rust/azazel-edge-core"
+RUST_CORE_BIN="${RUST_CORE_DIR}/target/release/azazel-edge-core"
+MM_COMPOSE="${ROOT_DIR}/security/docker-compose.mattermost.yml"
+MM_URL="http://localhost:8065"
+MM_PING="${MM_URL}/api/v4/system/ping"
+
+# Long-running components, in startup order. dummy-eve is opt-in (--inject).
+COMPONENTS=(control-daemon ai-agent rust-core web dummy-eve)
+
+# --- pid / process helpers --------------------------------------------------
+pid_file() { printf '%s/%s.pid' "${DEVSTACK_RUN}" "$1"; }
+log_file() { printf '%s/%s.log' "${DEVSTACK_LOG}" "$1"; }
+
+# is_running <name> -- true if the recorded PID is alive.
+is_running() {
+  local pf; pf="$(pid_file "$1")"
+  [[ -f "${pf}" ]] || return 1
+  local pid; pid="$(cat "${pf}" 2>/dev/null || true)"
+  [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null
+}
+
+comp_pid() { cat "$(pid_file "$1")" 2>/dev/null || true; }
+
+# start_component <name> <log> <cmd...> -- launch detached, record PID.
+start_component() {
+  # Args: <name> <log> <cmd...>. The <log> arg is redundant (lf is derived from
+  # <name>) but callers pass it for readability, so drop both before running the
+  # command -- otherwise the log path leaks into "$@" and nohup tries to exec it.
+  local name="$1"; shift 2
+  local lf; lf="$(log_file "${name}")"
+  if is_running "${name}"; then
+    printf '  %s %-14s already running (pid %s)\n' "${OK}" "${name}" "$(comp_pid "${name}")"
+    return 0
+  fi
+  : >"${lf}"
+  # Detach so the component survives this launcher exiting and the controlling
+  # terminal closing: nohup ignores SIGHUP, </dev/null frees stdin, disown drops
+  # it from the job table. Grandchild keeps running as a background daemon.
+  #
+  # Freshly-created log files can occasionally be denied for the first write
+  # right after truncation (seen under some sandboxed/managed shells); retry
+  # the launch a couple of times with a short backoff before giving up.
+  local attempt pid
+  for attempt in 1 2 3; do
+    nohup "$@" >>"${lf}" 2>&1 </dev/null &
+    pid=$!
+    disown "${pid}" 2>/dev/null || true
+    sleep 0.3
+    if kill -0 "${pid}" 2>/dev/null; then
+      echo "${pid}" >"$(pid_file "${name}")"
+      printf '  %s %-14s started (pid %s)\n' "${WAIT}" "${name}" "${pid}"
+      return 0
+    fi
+    if (( attempt < 3 )); then
+      sleep 0.5
+    fi
+  done
+  err "${name}: failed to start after ${attempt} attempts, see ${lf}"
+  return 1
+}
+
+# stop_component <name> -- TERM then KILL, remove pid file.
+stop_component() {
+  local name="$1"
+  if ! is_running "${name}"; then
+    rm -f "$(pid_file "${name}")"
+    printf '  %s %-14s not running\n' "${BAD}" "${name}"
+    return 0
+  fi
+  local pid; pid="$(comp_pid "${name}")"
+  kill "${pid}" 2>/dev/null || true
+  for _ in $(seq 1 20); do
+    kill -0 "${pid}" 2>/dev/null || break
+    sleep 0.25
+  done
+  if kill -0 "${pid}" 2>/dev/null; then
+    kill -9 "${pid}" 2>/dev/null || true
+  fi
+  rm -f "$(pid_file "${name}")"
+  printf '  %s %-14s stopped (was pid %s)\n' "${OK}" "${name}" "${pid}"
+}
+
+# --- readiness waiters (all with timeout) -----------------------------------
+# wait_for_socket <path> <timeout_s>
+wait_for_socket() {
+  local path="$1" timeout="$2" waited=0
+  while [[ ! -S "${path}" ]]; do
+    sleep 0.25; waited=$((waited + 1))
+    if (( waited >= timeout * 4 )); then return 1; fi
+  done
+  return 0
+}
+
+# wait_for_tcp <host> <port> <timeout_s>
+wait_for_tcp() {
+  local host="$1" port="$2" timeout="$3" waited=0
+  while ! (exec 3<>"/dev/tcp/${host}/${port}") 2>/dev/null; do
+    exec 3>&- 2>/dev/null || true
+    sleep 0.25; waited=$((waited + 1))
+    if (( waited >= timeout * 4 )); then return 1; fi
+  done
+  exec 3>&- 2>/dev/null || true
+  return 0
+}
+
+# wait_for_http <url> <timeout_s> -- 2xx/3xx counts as up.
+wait_for_http() {
+  local url="$1" timeout="$2" waited=0 code
+  while :; do
+    code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 3 "${url}" 2>/dev/null || echo 000)"
+    [[ "${code}" =~ ^[23] ]] && return 0
+    sleep 1; waited=$((waited + 1))
+    if (( waited >= timeout )); then return 1; fi
+  done
+}
+
+http_ok() {
+  local url="$1" code
+  code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 3 "${url}" 2>/dev/null || echo 000)"
+  [[ "${code}" =~ ^[23] ]]
+}
+
+# --- docker / mattermost ----------------------------------------------------
+docker_ready() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info >/dev/null 2>&1
+}
+
+mattermost_up() { http_ok "${MM_PING}"; }
+
+ensure_mattermost() {
+  if mattermost_up; then
+    printf '  %s %-14s already up (%s)\n' "${OK}" "mattermost" "${MM_URL}"
+    return 0
+  fi
+  if ! docker_ready; then
+    warn "docker unavailable -- skipping Mattermost; continuing with azazel-only stack."
+    return 0
+  fi
+  printf '  %s %-14s starting via docker compose…\n' "${WAIT}" "mattermost"
+  MATTERMOST_SITE_URL="${MM_URL}" \
+  MATTERMOST_ALLOWED_UNTRUSTED_INTERNAL_CONNECTIONS="host.docker.internal" \
+    "${ROOT_DIR}/bin/azazel-edge-compose" -f "${MM_COMPOSE}" up -d >/dev/null 2>&1 || {
+      warn "docker compose up failed -- continuing without Mattermost."
+      return 0
+    }
+  if wait_for_http "${MM_PING}" 90; then
+    printf '  %s %-14s ready (%s)\n' "${OK}" "mattermost" "${MM_URL}"
+  else
+    warn "Mattermost did not become ready within 90s -- continuing anyway."
+  fi
+}
+
+# --- ollama check (never managed, only probed) ------------------------------
+OLLAMA_TAGS="${AZAZEL_OLLAMA_ENDPOINT%/}/api/tags"
+OLLAMA_MODEL="qwen3.5:2b"
+
+check_ollama() {
+  local body
+  body="$(curl -fsS --max-time 3 "${OLLAMA_TAGS}" 2>/dev/null || true)"
+  if [[ -z "${body}" ]]; then
+    warn "ollama not reachable at ${AZAZEL_OLLAMA_ENDPOINT} -- AI agent will degrade."
+    warn "  start it with:  open -a Ollama"
+    return 1
+  fi
+  printf '  %s %-14s reachable (%s)\n' "${OK}" "ollama" "${AZAZEL_OLLAMA_ENDPOINT}"
+  if ! grep -q "${OLLAMA_MODEL}" <<<"${body}"; then
+    warn "ollama model '${OLLAMA_MODEL}' not present -- pull it with:  ollama pull ${OLLAMA_MODEL}"
+  fi
+  return 0
+}
+
+ollama_status() { curl -fsS --max-time 3 "${OLLAMA_TAGS}" >/dev/null 2>&1; }
+
+# --- preflight --------------------------------------------------------------
+preflight() {
+  info "${C_BOLD}Preflight${C_RESET}"
+  # venv
+  if [[ ! -x "${VENV_PY}" ]]; then
+    printf '  %s %-14s missing -- running bootstrap…\n' "${WAIT}" "venv"
+    "${ROOT_DIR}/bin/azazel-edge-dev" bootstrap
+  fi
+  printf '  %s %-14s %s\n' "${OK}" "venv" "${VENV_PY}"
+
+  # rust core build
+  if [[ ! -x "${RUST_CORE_BIN}" ]]; then
+    printf '  %s %-14s not built -- cargo build --release (may take minutes)…\n' "${WAIT}" "rust-core"
+    ( cd "${RUST_CORE_DIR}" && cargo build --release )
+  fi
+  printf '  %s %-14s %s\n' "${OK}" "rust-core" "${RUST_CORE_BIN}"
+
+  # ollama (warn-only)
+  check_ollama || true
+
+  # mattermost (we own its lifecycle)
+  ensure_mattermost
+  echo
+}
+
+# --- launchers for each component -------------------------------------------
+launch_control_daemon() {
+  start_component control-daemon "$(log_file control-daemon)" \
+    "${ROOT_DIR}/bin/azazel-edge-control-daemon"
+  if wait_for_socket "${AZAZEL_CONTROL_SOCKET}" 15; then
+    printf '  %s %-14s socket ready\n' "${OK}" "control-daemon"
+  else
+    err "control-daemon socket ${AZAZEL_CONTROL_SOCKET} not ready within 15s"
+    return 1
+  fi
+}
+
+launch_ai_agent() {
+  start_component ai-agent "$(log_file ai-agent)" \
+    "${ROOT_DIR}/bin/azazel-edge-ai-agent"
+  if wait_for_socket "${AZAZEL_AI_SOCKET}" 20; then
+    printf '  %s %-14s socket ready\n' "${OK}" "ai-agent"
+  else
+    warn "ai-agent socket ${AZAZEL_AI_SOCKET} not ready within 20s (ollama may be down) -- continuing"
+  fi
+}
+
+launch_rust_core() {
+  # Dev safe-mode env for the rust core (matches systemd/azazel-edge-core.service).
+  AZAZEL_DEFENSE_DRY_RUN=true \
+  AZAZEL_DEFENSE_ENFORCE=false \
+  AZAZEL_DEFENSE_ENFORCE_LEVEL=advisory \
+  AZAZEL_FORWARD_AI=true \
+  AZAZEL_FORWARD_LOG=true \
+    start_component rust-core "$(log_file rust-core)" "${RUST_CORE_BIN}"
+}
+
+launch_web() {
+  start_component web "$(log_file web)" "${ROOT_DIR}/bin/azazel-edge-web"
+  if wait_for_tcp "${AZAZEL_WEB_HOST}" "${AZAZEL_WEB_PORT}" 20; then
+    printf '  %s %-14s listening on %s:%s\n' "${OK}" "web" "${AZAZEL_WEB_HOST}" "${AZAZEL_WEB_PORT}"
+  else
+    err "web did not accept on ${AZAZEL_WEB_HOST}:${AZAZEL_WEB_PORT} within 20s"
+    return 1
+  fi
+}
+
+launch_dummy_eve() {
+  # Continuous benign-noise + periodic attack bursts, writing to the dev eve.json.
+  start_component dummy-eve "$(log_file dummy-eve)" \
+    "${ROOT_DIR}/bin/azazel-edge-dummy-eve" --eve-path "${AZAZEL_EVE_PATH}" stream
+}
+
+# --- summary ----------------------------------------------------------------
+read_web_token() {
+  [[ -s "${AZAZEL_WEB_TOKEN_FILE}" ]] && tr -d '[:space:]' <"${AZAZEL_WEB_TOKEN_FILE}"
+}
+
+print_summary() {
+  local token; token="$(read_web_token || true)"
+  local dash="http://${AZAZEL_WEB_HOST}:${AZAZEL_WEB_PORT}/"
+  [[ -n "${token}" ]] && dash="${dash}?token=${token}"
+  echo
+  info "${C_BOLD}Azazel dev stack${C_RESET}"
+  printf '  %-12s %s\n' "Dashboard:" "${dash}"
+  printf '  %-12s %s\n' "Mattermost:" "${MM_URL}"
+  if ollama_status; then
+    printf '  %-12s %s (%s up%s)\n' "Ollama:" "${AZAZEL_OLLAMA_ENDPOINT}" "${C_GREEN}" "${C_RESET}"
+  else
+    printf '  %-12s %s (%sdown%s)\n' "Ollama:" "${AZAZEL_OLLAMA_ENDPOINT}" "${C_YELLOW}" "${C_RESET}"
+  fi
+  echo "  Components:"
+  local c
+  for c in "${COMPONENTS[@]}"; do
+    if is_running "${c}"; then
+      printf '    %s %-14s pid %s\n' "${OK}" "${c}" "$(comp_pid "${c}")"
+    else
+      printf '    %s %-14s stopped\n' "${BAD}" "${c}"
+    fi
+  done
+}
+
+# --- subcommands ------------------------------------------------------------
+cmd_up() {
+  local inject=0 all=0
+  for a in "$@"; do
+    case "${a}" in
+      --inject) inject=1 ;;
+      --all) all=1 ;;
+      *) err "unknown flag for up: ${a}"; exit 2 ;;
+    esac
+  done
+
+  preflight
+  # --all means also (re)start external deps -- restart Mattermost if requested.
+  if (( all )) && docker_ready; then
+    info "--all: (re)starting Mattermost"
+    MATTERMOST_SITE_URL="${MM_URL}" \
+    MATTERMOST_ALLOWED_UNTRUSTED_INTERNAL_CONNECTIONS="host.docker.internal" \
+      "${ROOT_DIR}/bin/azazel-edge-compose" -f "${MM_COMPOSE}" up -d >/dev/null 2>&1 || true
+    wait_for_http "${MM_PING}" 90 || warn "Mattermost not ready after --all restart"
+  fi
+
+  info "${C_BOLD}Starting components${C_RESET}"
+  launch_control_daemon
+  launch_ai_agent
+  launch_rust_core
+  launch_web
+  if (( inject )); then
+    launch_dummy_eve
+  fi
+
+  print_summary
+}
+
+cmd_down() {
+  local all=0
+  for a in "$@"; do
+    case "${a}" in
+      --all) all=1 ;;
+      *) err "unknown flag for down: ${a}"; exit 2 ;;
+    esac
+  done
+  info "${C_BOLD}Stopping components${C_RESET}"
+  # Reverse startup order.
+  local c
+  for (( i=${#COMPONENTS[@]}-1; i>=0; i-- )); do
+    c="${COMPONENTS[$i]}"
+    stop_component "${c}"
+  done
+  # By default leave Mattermost + ollama running. --all also stops Mattermost.
+  if (( all )); then
+    if docker_ready; then
+      info "--all: stopping Mattermost"
+      "${ROOT_DIR}/bin/azazel-edge-compose" -f "${MM_COMPOSE}" down >/dev/null 2>&1 \
+        && printf '  %s %-14s stopped\n' "${OK}" "mattermost" \
+        || warn "docker compose down failed"
+    else
+      warn "docker unavailable -- cannot stop Mattermost"
+    fi
+  fi
+  # ollama is never touched.
+}
+
+cmd_status() {
+  info "${C_BOLD}Azazel dev stack status${C_RESET}"
+  local c
+  for c in "${COMPONENTS[@]}"; do
+    if is_running "${c}"; then
+      printf '  %s %-14s running (pid %s)\n' "${OK}" "${c}" "$(comp_pid "${c}")"
+    else
+      printf '  %s %-14s stopped\n' "${BAD}" "${c}"
+    fi
+  done
+  echo "  --- external ---"
+  if ollama_status; then
+    printf '  %s %-14s reachable (%s)\n' "${OK}" "ollama" "${AZAZEL_OLLAMA_ENDPOINT}"
+  else
+    printf '  %s %-14s unreachable (%s)\n' "${BAD}" "ollama" "${AZAZEL_OLLAMA_ENDPOINT}"
+  fi
+  if mattermost_up; then
+    printf '  %s %-14s reachable (%s)\n' "${OK}" "mattermost" "${MM_URL}"
+  else
+    printf '  %s %-14s unreachable (%s)\n' "${BAD}" "mattermost" "${MM_URL}"
+  fi
+}
+
+cmd_restart() {
+  cmd_down
+  echo
+  cmd_up "$@"
+}
+
+cmd_logs() {
+  local comp="${1:-}"
+  if [[ -z "${comp}" ]]; then
+    info "Available logs (${DEVSTACK_LOG}):"
+    local f
+    for f in "${DEVSTACK_LOG}"/*.log; do
+      [[ -e "${f}" ]] || { echo "  (none yet)"; break; }
+      printf '  %s\n' "$(basename "${f}" .log)"
+    done
+    return 0
+  fi
+  local lf; lf="$(log_file "${comp}")"
+  if [[ ! -f "${lf}" ]]; then
+    err "no log for component '${comp}' (looked at ${lf})"
+    return 1
+  fi
+  info "== ${comp} (${lf}) =="
+  tail -n 200 "${lf}"
+}
+
+usage() {
+  cat <<EOF
+${C_BOLD}azazel-edge-devstack${C_RESET} -- one-shot macOS dev-runtime launcher
+
+Usage:
+  azazel-edge-devstack up [--inject] [--all]   Bring up the stack (default cmd)
+  azazel-edge-devstack down [--all]            Stop azazel processes (--all also Mattermost)
+  azazel-edge-devstack status                  Show component + ollama/Mattermost state
+  azazel-edge-devstack restart [--inject]      down then up
+  azazel-edge-devstack logs [component]        Tail a component log (or list logs)
+
+  --inject   also start dummy-eve test-event injector
+  --all      up: (re)start external deps; down: also stop Mattermost (never ollama)
+EOF
+}
+
+main() {
+  local cmd="${1:-up}"
+  shift || true
+  case "${cmd}" in
+    up)       cmd_up "$@" ;;
+    down)     cmd_down "$@" ;;
+    status)   cmd_status "$@" ;;
+    restart)  cmd_restart "$@" ;;
+    logs)     cmd_logs "$@" ;;
+    -h|--help|help) usage ;;
+    *) err "unknown command: ${cmd}"; usage; exit 2 ;;
+  esac
+}
+
+main "$@"

--- a/bin/azazel-edge-injector
+++ b/bin/azazel-edge-injector
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# azazel-edge-injector -- self-contained test-event injection tool + demo menu.
+#
+# Runs standalone (no devstack required): it sources the macOS dev environment
+# itself, so the fabricated Suricata EVE alerts land on the dev eve.json that
+# azazel-edge-core tails. Two modes:
+#
+#   azazel-edge-injector                 # interactive menu (demo / test screen)
+#   azazel-edge-injector <dummy-eve args># pass-through CLI, e.g.
+#                                        #   azazel-edge-injector emit --scenario port_scan --count 5
+#                                        #   azazel-edge-injector list
+#
+# For a live demo, start the pipeline first (bin/azazel-edge-devstack up), then
+# drive attacks from this menu and watch the real dashboard react.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --- self-contained environment --------------------------------------------
+# env.sh sets AZAZEL_EVE_PATH, PYTHONPATH, the dev state dir, etc. Sourcing it
+# here is what makes the tool work on its own.
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/tools/macdev/env.sh"
+
+EVE_PATH="${AZAZEL_EVE_PATH}"
+RUN_DIR="${AZAZEL_DEV_STATE}/run"
+LOG_DIR="${AZAZEL_DEV_STATE}/log"
+STREAM_PID="${RUN_DIR}/injector-stream.pid"
+STREAM_LOG="${LOG_DIR}/injector-stream.log"
+DUMMY_EVE="${ROOT_DIR}/bin/azazel-edge-dummy-eve"
+WEB_URL="http://${AZAZEL_WEB_HOST:-127.0.0.1}:${AZAZEL_WEB_PORT:-8084}"
+mkdir -p "${RUN_DIR}" "${LOG_DIR}" "$(dirname "${EVE_PATH}")"
+
+# --- colors -----------------------------------------------------------------
+if [[ -t 1 ]]; then
+  C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'
+  C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_CYAN=$'\033[36m'
+else
+  C_RESET=""; C_BOLD=""; C_GREEN=""; C_RED=""; C_YELLOW=""; C_CYAN=""
+fi
+
+# --- pass-through CLI mode --------------------------------------------------
+# Any argument => act as a thin standalone wrapper around dummy-eve (which
+# already has list/emit/flow/stream subcommands), with the dev eve path wired
+# in. This is the "works on its own" entrypoint for scripted/CI use.
+if (( $# > 0 )); then
+  exec "${DUMMY_EVE}" --eve-path "${EVE_PATH}" "$@"
+fi
+
+# --- helpers (menu mode) ----------------------------------------------------
+eve_count() { [[ -f "${EVE_PATH}" ]] && wc -l <"${EVE_PATH}" | tr -d ' ' || echo 0; }
+
+stream_running() {
+  [[ -f "${STREAM_PID}" ]] || return 1
+  local pid; pid="$(cat "${STREAM_PID}" 2>/dev/null || true)"
+  [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null
+}
+
+pipeline_up() { curl -fsS -o /dev/null --max-time 2 "${WEB_URL}" 2>/dev/null; }
+
+pause() { read -r -p "  ${C_CYAN}Enter to continue…${C_RESET} " _; }
+
+# List scenarios as a numbered array; fills SCEN_IDS / SCEN_DESC.
+declare -a SCEN_IDS=() SCEN_DESC=()
+load_scenarios() {
+  SCEN_IDS=(); SCEN_DESC=()
+  local id rest
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    id="${line%% *}"; rest="${line#"${id}"}"
+    SCEN_IDS+=("${id}")
+    SCEN_DESC+=("$(printf '%s' "${rest}" | sed 's/^ *//')")
+  done < <("${DUMMY_EVE}" list 2>/dev/null)
+}
+
+# --- menu actions -----------------------------------------------------------
+act_list() {
+  printf '\n%sScenarios%s\n' "${C_BOLD}" "${C_RESET}"
+  "${DUMMY_EVE}" list
+  echo
+  pause
+}
+
+act_emit() {
+  load_scenarios
+  echo
+  printf '%sPick a scenario to fire%s\n' "${C_BOLD}" "${C_RESET}"
+  local i
+  for i in "${!SCEN_IDS[@]}"; do
+    printf '  %2d) %-14s %s\n' "$((i + 1))" "${SCEN_IDS[$i]}" "${SCEN_DESC[$i]}"
+  done
+  local choice; read -r -p "  number (blank=cancel): " choice
+  [[ -z "${choice}" ]] && return 0
+  if ! [[ "${choice}" =~ ^[0-9]+$ ]] || (( choice < 1 || choice > ${#SCEN_IDS[@]} )); then
+    printf '  %sinvalid selection%s\n' "${C_RED}" "${C_RESET}"; return 0
+  fi
+  local scen="${SCEN_IDS[$((choice - 1))]}"
+  local count; read -r -p "  how many events [5]: " count; count="${count:-5}"
+  printf '  %sfiring%s %s x%s -> %s\n' "${C_YELLOW}" "${C_RESET}" "${scen}" "${count}" "${EVE_PATH}"
+  "${DUMMY_EVE}" --eve-path "${EVE_PATH}" emit --scenario "${scen}" --count "${count}" --interval 0.3
+  echo; pause
+}
+
+act_flow() {
+  echo
+  printf '%sStaged attack flow%s (benign -> recon -> scan -> c2 -> exfil)\n' "${C_BOLD}" "${C_RESET}"
+  local count; read -r -p "  events per stage [5]: " count; count="${count:-5}"
+  local hold; read -r -p "  pause between stages (s) [4]: " hold; hold="${hold:-4}"
+  printf '  %srunning flow…%s (watch %s)\n' "${C_YELLOW}" "${C_RESET}" "${WEB_URL}"
+  "${DUMMY_EVE}" --eve-path "${EVE_PATH}" flow --count "${count}" --hold "${hold}"
+  echo; pause
+}
+
+act_stream_start() {
+  if stream_running; then
+    printf '  %sstream already running (pid %s)%s\n' "${C_YELLOW}" "$(cat "${STREAM_PID}")" "${C_RESET}"
+    pause; return 0
+  fi
+  : >"${STREAM_LOG}"
+  nohup "${DUMMY_EVE}" --eve-path "${EVE_PATH}" stream >>"${STREAM_LOG}" 2>&1 </dev/null &
+  local pid=$!; disown "${pid}" 2>/dev/null || true
+  echo "${pid}" >"${STREAM_PID}"
+  printf '  %sstream started%s (pid %s) -- benign noise + periodic attack bursts\n' \
+    "${C_GREEN}" "${C_RESET}" "${pid}"
+  pause
+}
+
+act_stream_stop() {
+  if ! stream_running; then
+    printf '  %sno stream running%s\n' "${C_YELLOW}" "${C_RESET}"; rm -f "${STREAM_PID}"; pause; return 0
+  fi
+  local pid; pid="$(cat "${STREAM_PID}")"
+  kill "${pid}" 2>/dev/null || true
+  for _ in $(seq 1 12); do kill -0 "${pid}" 2>/dev/null || break; sleep 0.25; done
+  kill -9 "${pid}" 2>/dev/null || true
+  rm -f "${STREAM_PID}"
+  printf '  %sstream stopped%s (was pid %s)\n' "${C_GREEN}" "${C_RESET}" "${pid}"
+  pause
+}
+
+act_tail() {
+  echo
+  if [[ ! -s "${EVE_PATH}" ]]; then
+    printf '  %seve.json is empty%s (%s)\n' "${C_YELLOW}" "${C_RESET}" "${EVE_PATH}"; pause; return 0
+  fi
+  printf '%sLast events%s (%s)\n' "${C_BOLD}" "${C_RESET}" "${EVE_PATH}"
+  tail -n 8 "${EVE_PATH}" | while IFS= read -r line; do
+    printf '%s\n' "${line}" | "${ROOT_DIR}/.venv/bin/python" -c \
+      'import sys,json;
+[print("  {:<12} sid={} {}".format(d.get("attack_type","?"), d.get("alert",{}).get("signature_id","?"), d.get("alert",{}).get("signature",""))) for d in [json.loads(sys.stdin.read())]]' \
+      2>/dev/null || printf '  %s\n' "${line:0:100}"
+  done
+  echo; pause
+}
+
+act_reset() {
+  read -r -p "  truncate ${EVE_PATH}? [y/N] " yn
+  if [[ "${yn}" =~ ^[Yy]$ ]]; then : >"${EVE_PATH}"; printf '  %seve.json reset%s\n' "${C_GREEN}" "${C_RESET}"; fi
+  pause
+}
+
+print_header() {
+  clear 2>/dev/null || true
+  local st="stopped" stc="${C_RED}"
+  stream_running && { st="running (pid $(cat "${STREAM_PID}"))"; stc="${C_GREEN}"; }
+  local pl="down" plc="${C_YELLOW}"
+  pipeline_up && { pl="up"; plc="${C_GREEN}"; }
+  printf '%s╭─ Azazel-Edge Injector ─ demo / test control panel ─╮%s\n' "${C_BOLD}" "${C_RESET}"
+  printf '   eve.json : %s  (%s events)\n' "${EVE_PATH}" "$(eve_count)"
+  printf '   stream   : %s%s%s\n' "${stc}" "${st}" "${C_RESET}"
+  printf '   pipeline : %s%s%s  (dashboard %s)\n' "${plc}" "${pl}" "${C_RESET}" "${WEB_URL}"
+  if ! pipeline_up; then
+    printf '   %shint: run `bin/azazel-edge-devstack up` so injected events reach the dashboard%s\n' \
+      "${C_YELLOW}" "${C_RESET}"
+  fi
+  printf '%s╰────────────────────────────────────────────────────╯%s\n' "${C_BOLD}" "${C_RESET}"
+}
+
+menu() {
+  while :; do
+    print_header
+    cat <<EOF
+
+  ${C_BOLD}1${C_RESET}) シナリオ一覧を表示            (list)
+  ${C_BOLD}2${C_RESET}) 単発シナリオを発火            (emit)
+  ${C_BOLD}3${C_RESET}) 攻撃フローを実行              (staged flow)
+  ${C_BOLD}4${C_RESET}) 連続ストリームを開始          (background)
+  ${C_BOLD}5${C_RESET}) 連続ストリームを停止
+  ${C_BOLD}6${C_RESET}) eve.json の直近イベントを表示
+  ${C_BOLD}7${C_RESET}) eve.json をリセット
+  ${C_BOLD}q${C_RESET}) 終了
+EOF
+    local sel; read -r -p $'\n  > ' sel
+    case "${sel}" in
+      1) act_list ;;
+      2) act_emit ;;
+      3) act_flow ;;
+      4) act_stream_start ;;
+      5) act_stream_stop ;;
+      6) act_tail ;;
+      7) act_reset ;;
+      q|Q) echo "  bye"; break ;;
+      *) : ;;
+    esac
+  done
+}
+
+menu

--- a/docs/DEV_LOCAL_STACK.md
+++ b/docs/DEV_LOCAL_STACK.md
@@ -1,0 +1,122 @@
+# Local Dev Stack Launcher
+
+## Purpose
+`bin/azazel-edge-devstack` is a one-shot launcher that brings up the full Azazel-Edge runtime on a macOS development machine (Apple Silicon). Until now, `bin/azazel-edge-dev` only covered build/test workflows (`bootstrap`, `test`, `rust-test`, `python`) — there was no single command to actually run the live services (control-daemon, AI agent, Rust core, web dashboard) wired to a local LLM and a local Mattermost instance. `azazel-edge-devstack` fills that gap: one command starts the whole pipeline in dependency order, in safe mode, against dev-local infrastructure.
+
+It wires the stack to:
+- **ollama** — the local LLM runtime, run as the macOS GUI app, serving `qwen3.5:2b` at `http://127.0.0.1:11434`.
+- **Mattermost** — run via `docker compose` on OrbStack, reachable at `http://localhost:8065`.
+
+The launcher itself does not replace `bin/azazel-edge-dev`. Use `azazel-edge-dev` to build/test; use `azazel-edge-devstack` to run.
+
+## Prerequisites
+- macOS on Apple Silicon.
+- [OrbStack](https://orbstack.dev/) (or another Docker Desktop-compatible engine) installed and running, for Mattermost.
+- Rust toolchain (`cargo`) installed, for building `rust/azazel-edge-core`.
+- Python 3 installed.
+- [Ollama](https://ollama.com/) GUI app installed and running, with the `qwen3.5:2b` model pulled:
+  ```bash
+  ollama pull qwen3.5:2b
+  ```
+
+## Quickstart
+```bash
+bin/azazel-edge-devstack up
+```
+
+This preflight-checks dependencies (creating the Python venv and building the Rust core if needed), then starts control-daemon, ai-agent, the Rust core, and the web dashboard, in that order. On success it prints a summary including:
+- the dashboard URL and its auth token
+- the Mattermost URL
+- ollama status (reachable / model present)
+
+Open the dashboard URL from the summary in a browser to see the running system. Open `http://localhost:8065` for Mattermost.
+
+To also see live pipeline data flowing through the dashboard, start the `dummy-eve` test-event injector at the same time:
+```bash
+bin/azazel-edge-devstack up --inject
+```
+
+## Command Reference
+
+| Command | Flags | Description |
+|---|---|---|
+| `up` (default) | `--inject` | Also start the `dummy-eve` test-event injector so the pipeline shows live data. |
+| | `--all` | Also (re)start external dependencies (Mattermost via OrbStack). |
+| `down` | `--all` | Stop the azazel processes. By default, Mattermost and ollama are left running; `--all` additionally stops the Mattermost containers. `down` never touches ollama. |
+| `status` | — | Show each component's state (running/stopped + PID) and ollama/Mattermost reachability. |
+| `restart` | `--inject` | Equivalent to `down` followed by `up`. |
+| `logs [component]` | — | Tail a specific component's log, or list available logs if no component is given. |
+
+`up` is idempotent: components that are already running are skipped rather than restarted.
+
+## Components and Startup Order
+`up` starts components in this order:
+
+1. **control-daemon** — coordinates runtime state and the local control socket.
+2. **ai-agent** — bridges to ollama for LLM-assisted triage/advisory output.
+3. **Rust core** (`rust/azazel-edge-core`) — event normalization and the deterministic decision loop.
+4. **web dashboard** — the operator-facing UI and API.
+
+With `--inject`, the `dummy-eve` test-event injector also starts, feeding synthetic events into the pipeline so the dashboard shows live activity.
+
+With `--all`, external dependencies (currently: Mattermost on OrbStack, via `security/docker-compose.mattermost.yml`) are also (re)started before the azazel components.
+
+The runtime runs in **safe mode**: defense enforcement is dry-run/advisory only, matching `AZAZEL_DEFENSE_DRY_RUN=true` / `AZAZEL_DEFENSE_ENFORCE_LEVEL=advisory` in `tools/macdev/env.sh`.
+
+## Injector — test/demo control panel
+`bin/azazel-edge-injector` is a **self-contained** front-end for the `dummy-eve` test-event generator. It sources the dev environment itself, so it runs standalone — no need to have `devstack` up first — and writes fabricated Suricata EVE alerts to the dev `eve.json` that the Rust core tails.
+
+Two modes:
+
+```bash
+bin/azazel-edge-injector                              # interactive menu (demo screen)
+bin/azazel-edge-injector emit --scenario port_scan --count 5   # pass-through CLI
+bin/azazel-edge-injector list                         # pass-through CLI
+```
+
+The interactive menu shows live status (eve.json event count, background-stream state, whether the pipeline/dashboard is up) and lets you: list scenarios, fire a single scenario, run a staged attack flow, start/stop a continuous background stream, view recent events, and reset `eve.json`.
+
+**Demo flow:** run `bin/azazel-edge-devstack up` first, then drive attacks from the injector menu and watch the real dashboard react — this is the intended way to demo (live pipeline injection rather than a mocked screen). Available scenarios: `recon_probe`, `port_scan`, `arp_spoof`, `dns_exfil`, `cred_harvest`, `c2_beacon`, `phishing`, `benign`. (`up --inject` starts the continuous stream automatically; the injector menu is for hands-on, scenario-by-scenario control.)
+
+## Environment
+The launcher sources `tools/macdev/env.sh`, which sets macOS-appropriate runtime paths under `~/.azazel-edge-dev` (instead of the appliance's Linux paths), `PYTHONPATH`, and the ollama endpoint. On top of that, `azazel-edge-devstack` points the stack's Mattermost integration at `127.0.0.1:8065` for local dev (the appliance default is `172.16.0.254`).
+
+State is kept under `~/.azazel-edge-dev/`:
+- PID files: `~/.azazel-edge-dev/run/devstack/`
+- Logs: `~/.azazel-edge-dev/log/devstack/`
+
+## Troubleshooting
+
+**ollama not reachable**
+Open the Ollama app: `open -a Ollama`. Then re-run `bin/azazel-edge-devstack status` to confirm.
+
+**Model `qwen3.5:2b` missing**
+```bash
+ollama pull qwen3.5:2b
+```
+Preflight only warns about a missing model — it does not block startup — but the AI agent will not produce useful output until the model is present.
+
+**Mattermost not reachable**
+Confirm OrbStack is running and the containers are up:
+```bash
+docker compose -f security/docker-compose.mattermost.yml ps
+```
+Use `bin/azazel-edge-devstack up --all` to (re)start Mattermost along with the rest of the stack.
+
+**Port already in use**
+Another process may be bound to a port the stack needs (dashboard, control socket, or Mattermost's `8065`). Check `bin/azazel-edge-devstack status` for what the launcher thinks is running, and use `lsof -i :<port>` to find the conflicting process.
+
+**Rust build is slow on first run**
+The first `up` builds `rust/azazel-edge-core` in release mode (`cargo build --release`) if no build is present, which can take several minutes. Subsequent runs reuse the existing build and start immediately.
+
+**Where are the logs?**
+```bash
+bin/azazel-edge-devstack logs            # list available logs
+bin/azazel-edge-devstack logs ai-agent   # tail a specific component
+```
+Raw log files live under `~/.azazel-edge-dev/log/devstack/`.
+
+## Related Documents
+- macOS dev environment variables: `tools/macdev/env.sh`
+- Build/test helper: `bin/azazel-edge-dev`
+- Mattermost compose definition: `security/docker-compose.mattermost.yml`

--- a/docs/DEV_LOCAL_STACK_JA.md
+++ b/docs/DEV_LOCAL_STACK_JA.md
@@ -1,0 +1,122 @@
+# ローカル開発スタック起動ツール（JA）
+
+## 目的
+`bin/azazel-edge-devstack` は、macOS（Apple Silicon）の開発機上で Azazel-Edge のランタイム全体を一括起動するためのワンショット・ランチャーです。これまで `bin/azazel-edge-dev` はビルド／テスト用途（`bootstrap`、`test`、`rust-test`、`python`）のみをカバーしており、実際に動作中のサービス（control-daemon、ai-agent、Rust コア、Web ダッシュボード）をローカル LLM とローカル Mattermost に接続した状態で起動する手段がありませんでした。`azazel-edge-devstack` はそのギャップを埋め、依存関係の順序に従ってパイプライン全体をセーフモードで一括起動します。
+
+このスタックは以下に接続します。
+- **ollama** — ローカル LLM ランタイム。macOS の GUI アプリとして動作し、`qwen3.5:2b` を `http://127.0.0.1:11434` で提供します。
+- **Mattermost** — OrbStack 上で `docker compose` により動作し、`http://localhost:8065` で到達可能です。
+
+このランチャーは `bin/azazel-edge-dev` を置き換えるものではありません。ビルド／テストには `azazel-edge-dev` を、実行には `azazel-edge-devstack` を使用してください。
+
+## 前提条件
+- Apple Silicon 搭載の macOS。
+- [OrbStack](https://orbstack.dev/)（または Docker Desktop 互換の他のエンジン）がインストールされ、起動していること（Mattermost 用）。
+- Rust ツールチェーン（`cargo`）がインストールされていること（`rust/azazel-edge-core` のビルド用）。
+- Python 3 がインストールされていること。
+- [Ollama](https://ollama.com/) GUI アプリがインストールされ起動しており、`qwen3.5:2b` モデルが取得済みであること。
+  ```bash
+  ollama pull qwen3.5:2b
+  ```
+
+## クイックスタート
+```bash
+bin/azazel-edge-devstack up
+```
+
+依存関係のプリフライトチェック（必要に応じて Python venv の作成、Rust コアのビルド）を行った後、control-daemon → ai-agent → Rust コア → Web ダッシュボードの順に起動します。成功すると、以下を含むサマリーが表示されます。
+- ダッシュボード URL と認証トークン
+- Mattermost の URL
+- ollama の状態（到達可否・モデル有無）
+
+サマリーに表示されたダッシュボード URL をブラウザで開くと、稼働中のシステムを確認できます。Mattermost は `http://localhost:8065` で開けます。
+
+パイプラインにライブデータを流してダッシュボードで確認したい場合は、`dummy-eve` テストイベント注入ツールを同時に起動します。
+```bash
+bin/azazel-edge-devstack up --inject
+```
+
+## コマンドリファレンス
+
+| コマンド | フラグ | 説明 |
+|---|---|---|
+| `up`（デフォルト） | `--inject` | `dummy-eve` テストイベント注入ツールも起動し、パイプラインにライブデータを流す。 |
+| | `--all` | 外部依存関係（OrbStack 経由の Mattermost）も（再）起動する。 |
+| `down` | `--all` | azazel のプロセスを停止する。デフォルトでは Mattermost と ollama は起動したままにする。`--all` を指定すると Mattermost コンテナも停止する。`down` は ollama には一切手を加えない。 |
+| `status` | — | 各コンポーネントの状態（起動中／停止中と PID）、および ollama／Mattermost の到達可否を表示する。 |
+| `restart` | `--inject` | `down` の後に `up` を実行するのと同等。 |
+| `logs [component]` | — | 指定したコンポーネントのログを tail する。コンポーネント未指定時は利用可能なログの一覧を表示する。 |
+
+`up` は冪等です。すでに起動しているコンポーネントは再起動せずスキップされます。
+
+## コンポーネントと起動順序
+`up` は以下の順序でコンポーネントを起動します。
+
+1. **control-daemon** — ランタイム状態とローカル制御ソケットを調整する。
+2. **ai-agent** — ollama と接続し、LLM 支援によるトリアージ／アドバイザリ出力を行う。
+3. **Rust コア**（`rust/azazel-edge-core`） — イベント正規化と決定論的な判断ループ。
+4. **Web ダッシュボード** — オペレーター向け UI・API。
+
+`--inject` を指定すると、`dummy-eve` テストイベント注入ツールも起動し、合成イベントをパイプラインに流してダッシュボードにライブな動きを表示します。
+
+`--all` を指定すると、外部依存関係（現時点では `security/docker-compose.mattermost.yml` による OrbStack 上の Mattermost）が azazel コンポーネントより先に（再）起動されます。
+
+ランタイムは**セーフモード**で動作します。防御機能はドライラン／アドバイザリのみで、`tools/macdev/env.sh` の `AZAZEL_DEFENSE_DRY_RUN=true` / `AZAZEL_DEFENSE_ENFORCE_LEVEL=advisory` に対応します。
+
+## インジェクター — テスト／デモ操作パネル
+`bin/azazel-edge-injector` は、テストイベント生成ツール `dummy-eve` の**自己完結型**フロントエンドです。開発環境（`tools/macdev/env.sh`）を自身で読み込むため、**devstack を起動していなくても単体で動作**し、Rust コアが監視する開発用 `eve.json` に模擬 Suricata EVE アラートを書き込みます。
+
+2 つのモードがあります:
+
+```bash
+bin/azazel-edge-injector                              # 対話メニュー（デモ画面）
+bin/azazel-edge-injector emit --scenario port_scan --count 5   # パススルー CLI
+bin/azazel-edge-injector list                         # パススルー CLI
+```
+
+対話メニューは、ライブ状態（eve.json のイベント数、バックグラウンドストリームの稼働状態、パイプライン／ダッシュボードの起動有無）を表示し、次の操作ができます: シナリオ一覧、単発シナリオの発火、段階的な攻撃フローの実行、連続ストリームの開始／停止、直近イベントの表示、`eve.json` のリセット。
+
+**デモの流れ:** まず `bin/azazel-edge-devstack up` を実行し、その後インジェクターのメニューから攻撃を発火して、実ダッシュボードが反応する様子を見せます。これがモック画面ではなく**ライブパイプライン注入でデモを駆動する**という意図された方法です。利用可能なシナリオ: `recon_probe`、`port_scan`、`arp_spoof`、`dns_exfil`、`cred_harvest`、`c2_beacon`、`phishing`、`benign`。（`up --inject` は連続ストリームを自動起動します。インジェクターのメニューは、シナリオ単位で手動操作したい場合に使います。）
+
+## 環境設定
+このランチャーは `tools/macdev/env.sh` を読み込み、（アプライアンスの Linux パスの代わりに）`~/.azazel-edge-dev` 配下に macOS 向けのランタイムパス、`PYTHONPATH`、ollama のエンドポイントを設定します。さらに `azazel-edge-devstack` は、ローカル開発向けにスタックの Mattermost 接続先を `127.0.0.1:8065` に向けます（アプライアンスのデフォルトは `172.16.0.254`）。
+
+状態は `~/.azazel-edge-dev/` 配下に保持されます。
+- PID ファイル: `~/.azazel-edge-dev/run/devstack/`
+- ログ: `~/.azazel-edge-dev/log/devstack/`
+
+## トラブルシューティング
+
+**ollama に到達できない**
+Ollama アプリを開きます: `open -a Ollama`。その後 `bin/azazel-edge-devstack status` で再確認してください。
+
+**モデル `qwen3.5:2b` が見つからない**
+```bash
+ollama pull qwen3.5:2b
+```
+プリフライトチェックはモデル未取得を警告するのみで起動をブロックしません。ただし、モデルが存在しない間は AI エージェントが有用な出力を生成できません。
+
+**Mattermost に到達できない**
+OrbStack が起動しており、コンテナが立ち上がっているか確認します。
+```bash
+docker compose -f security/docker-compose.mattermost.yml ps
+```
+`bin/azazel-edge-devstack up --all` で、他のコンポーネントと合わせて Mattermost を（再）起動できます。
+
+**ポートが既に使用されている**
+ダッシュボード、制御ソケット、Mattermost の `8065` など、スタックが必要とするポートを別プロセスが使用している可能性があります。`bin/azazel-edge-devstack status` でランチャーが認識している起動状況を確認し、`lsof -i :<port>` で競合しているプロセスを特定してください。
+
+**初回実行時に Rust のビルドが遅い**
+既存のビルドが存在しない場合、初回の `up` は `rust/azazel-edge-core` をリリースモードでビルドします（`cargo build --release`）。これには数分かかることがあります。2 回目以降は既存のビルドを再利用し、即座に起動します。
+
+**ログの場所**
+```bash
+bin/azazel-edge-devstack logs            # 利用可能なログの一覧
+bin/azazel-edge-devstack logs ai-agent   # 特定コンポーネントのログを tail
+```
+ログの実体は `~/.azazel-edge-dev/log/devstack/` 配下にあります。
+
+## 関連ドキュメント
+- macOS 開発環境変数: `tools/macdev/env.sh`
+- ビルド／テスト用ヘルパー: `bin/azazel-edge-dev`
+- Mattermost の compose 定義: `security/docker-compose.mattermost.yml`

--- a/docs/DOCUMENT_LANGUAGE_POLICY.md
+++ b/docs/DOCUMENT_LANGUAGE_POLICY.md
@@ -33,6 +33,8 @@ Last updated: 2026-05-13
 - `docs/MIO_PERSONA_PROFILE_JA.md` (JA)
 - `docs/OPERATOR_GUIDE.md` (EN)
 - `docs/OPERATOR_GUIDE_JA.md` (JA)
+- `docs/DEV_LOCAL_STACK.md` (EN)
+- `docs/DEV_LOCAL_STACK_JA.md` (JA)
 
 ### C. Governance charter
 - `AGENTS.md`: authoritative governance charter (English)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,6 +22,8 @@ Entry point for all documents in this directory.
 | [BENCHMARK_SCOPE_AND_HIL_PLAN.md](BENCHMARK_SCOPE_AND_HIL_PLAN.md) | Developer / Operator | Benchmark claim boundary and staged hardware-in-the-loop plan | 2026-05-14 |
 | [POST_DEMO_MAIN_INTEGRATION_104.md](POST_DEMO_MAIN_INTEGRATION_104.md) | Developer | Integration boundary between exhibition-only assets and mainline | 2026-05-11 |
 | [POST_DEMO_SOCKET_PERMISSION_MODEL_105.md](POST_DEMO_SOCKET_PERMISSION_MODEL_105.md) | Developer | Unix socket permission model decisions | - |
+| [DEV_LOCAL_STACK.md](DEV_LOCAL_STACK.md) | Developer | macOS local dev stack launcher (`bin/azazel-edge-devstack`) usage (EN) | 2026-07-03 |
+| [DEV_LOCAL_STACK_JA.md](DEV_LOCAL_STACK_JA.md) | Developer | ローカル開発スタック起動ツール利用手順（日本語版） | 2026-07-03 |
 
 ## AI Operations
 


### PR DESCRIPTION
## Overview
Adds two self-contained developer tools for running Azazel-Edge on a macOS (Apple Silicon) dev machine, plus EN/JA docs. Fills the gap where `bin/azazel-edge-dev` only covered build/test — there was no single command to launch the live services, and no hands-on way to drive the detection pipeline for testing/demos.

## What changed
- **`bin/azazel-edge-devstack`** — one-shot launcher for the full dev runtime.
  - Sources `tools/macdev/env.sh`; preflights deps (venv, Rust core build, ollama + `qwen3.5:2b`, Mattermost on OrbStack).
  - Starts `control-daemon → ai-agent → rust-core → web` in dependency order with readiness waits.
  - Subcommands: `up [--inject] [--all]`, `down [--all]`, `status`, `restart`, `logs [component]`.
  - Points Mattermost at `127.0.0.1:8065` for dev (appliance default is `172.16.0.254`); runs the core in **safe mode** (dry-run/advisory).
- **`bin/azazel-edge-injector`** — self-contained test-event injection tool + interactive demo/test menu.
  - Runs standalone (no devstack needed): sources the dev env and writes fabricated Suricata EVE alerts to the dev `eve.json`.
  - No args → menu (list / emit / staged flow / continuous stream start-stop / tail / reset) with live status; with args → pass-through CLI to `dummy-eve`.
  - Drives demos via **live pipeline injection**, matching the recent "remove demo-only screen" direction.
- **Docs** — `docs/DEV_LOCAL_STACK.md` + `docs/DEV_LOCAL_STACK_JA.md`, registered in `docs/INDEX.md` and `docs/DOCUMENT_LANGUAGE_POLICY.md`.

## Verification
- `devstack up`: all components start, dashboard serves HTTP 200, `down` tears down cleanly (0 leftover procs).
- Integrated: injecting `port_scan` x5 grew `normalized-events.jsonl` by exactly 5 (eve.json → rust-core → pipeline).
- Injector: standalone CLI + every menu action (emit / flow / stream start-alive-stop / tail / reset) verified.
- Flow routing confirmed live: ambiguity-band events (`recon_probe`/`port_scan`/`arp_spoof`, risk 75–79) route to the LLM for AI-assisted judgment; clearly benign/malicious events (`benign`, `c2_beacon`/`dns_exfil`/`cred_harvest`/`phishing`, risk ≤25 or ≥85) are decided deterministically by the decision engine.

## Reviewer notes
- macOS dev only; does not touch appliance/systemd paths. All state under `~/.azazel-edge-dev/`.
- The launcher owns Mattermost's lifecycle (via OrbStack compose) but only **probes** ollama — the ollama GUI app must be running for the AI-assist path; if it's down, ambiguous events log to `ai-deferred.jsonl` and the deterministic verdict still stands.
- No existing files modified except the two doc-index registrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)