### PR TITLE
webui: unify Topo-Lite and Node Fleet panel design with the rest of the dashboard

### DIFF
--- a/azazel_edge_web/static/style.css
+++ b/azazel_edge_web/static/style.css
@@ -233,152 +233,178 @@ body[data-audience="professional"] .temp-only {
     background: linear-gradient(145deg, rgba(57, 42, 20, 0.42), rgba(24, 27, 34, 0.88));
 }
 
-/* Aggregator fleet counters */
+/* Aggregator fleet panel — shares the standard panel/tile visual language */
+.aggregator-panel {
+    padding: 22px 24px 24px;
+    margin-top: 18px;
+}
+
 .aggregator-counters {
-    display: flex;
-    gap: 1rem;
-    margin: 0.75rem 0;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 12px;
+    margin-top: 14px;
 }
 
 .aggregator-counter {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 0.5rem 1rem;
-    border: 1px solid var(--line-soft, #ddd);
-    border-radius: 6px;
-    min-width: 5rem;
+    min-width: 0;
+    padding: 14px;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: linear-gradient(145deg, rgba(167, 199, 214, 0.1), rgba(13, 20, 26, 0.88));
+    box-shadow: var(--shadow-sm);
 }
 
 .aggregator-counter.agg-warn {
-    border-color: var(--accent-amber, #e8a000);
+    background: linear-gradient(145deg, rgba(224, 164, 88, 0.14), rgba(13, 20, 26, 0.88));
+    border-color: rgba(224, 164, 88, 0.28);
 }
 
 .aggregator-counter.agg-crit {
-    border-color: var(--accent-red, #c0392b);
+    background: linear-gradient(145deg, rgba(228, 109, 93, 0.16), rgba(13, 20, 26, 0.88));
+    border-color: rgba(228, 109, 93, 0.3);
 }
 
 .agg-count-num {
-    font-size: 1.8rem;
-    font-weight: 700;
-    line-height: 1;
+    display: block;
+    font-size: clamp(1.7rem, 3.2vw, 2.3rem);
+    line-height: 1.05;
+    font-family: var(--font-mono);
+    color: var(--text-main);
 }
 
 .agg-count-label {
-    font-size: 0.75rem;
-    color: var(--text-soft, #666);
-    margin-top: 0.25rem;
+    display: block;
+    font-size: 0.74rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-soft);
+    margin-top: 10px;
 }
 
 /* Node list */
 .aggregator-node-list {
     list-style: none;
-    margin: 0;
+    margin: 14px 0 0;
     padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
+    display: grid;
+    gap: 10px;
 }
 
 .aggregator-node-row {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.5rem 0.75rem;
-    border-left: 3px solid var(--line-soft, #ddd);
-    border-radius: 4px;
-    background: rgba(255, 255, 255, 0.05);
+    padding: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-left-width: 4px;
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.03);
+    box-shadow: var(--shadow-sm);
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 10px;
 }
 
 .aggregator-node-row.status-ok {
-    border-left-color: var(--accent-green, #27ae60);
+    border-left-color: rgba(127, 211, 155, 0.95);
 }
 
 .aggregator-node-row.status-warn {
-    border-left-color: var(--accent-amber, #e8a000);
+    border-left-color: rgba(224, 164, 88, 0.95);
 }
 
 .aggregator-node-row.status-crit {
-    border-left-color: var(--accent-red, #c0392b);
+    border-left-color: rgba(228, 109, 93, 0.95);
 }
 
 .agg-node-identity {
     display: flex;
-    gap: 0.5rem;
+    gap: 8px;
     align-items: baseline;
     flex-wrap: wrap;
 }
 
 .agg-node-label {
-    font-weight: 600;
+    font-weight: 700;
+    overflow-wrap: anywhere;
 }
 
 .agg-node-site {
     font-size: 0.8rem;
-    color: var(--text-soft, #666);
+    color: var(--text-soft);
 }
 
 .agg-node-status {
     display: flex;
-    gap: 0.5rem;
+    gap: 8px;
     align-items: center;
     flex-wrap: wrap;
     font-size: 0.82rem;
 }
 
 .agg-freshness-badge {
-    padding: 0.1rem 0.4rem;
-    border-radius: 3px;
-    font-size: 0.75rem;
-    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
+    font-family: var(--font-mono);
+    border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .agg-freshness-fresh {
-    background: #d4edda;
-    color: #155724;
+    background: rgba(127, 211, 155, 0.14);
+    border-color: rgba(127, 211, 155, 0.24);
+    color: rgba(214, 247, 223, 0.95);
 }
 
 .agg-freshness-stale {
-    background: #fff3cd;
-    color: #856404;
+    background: rgba(224, 164, 88, 0.14);
+    border-color: rgba(224, 164, 88, 0.28);
+    color: rgba(255, 234, 207, 0.96);
 }
 
 .agg-freshness-offline {
-    background: #f8d7da;
-    color: #721c24;
+    background: rgba(228, 109, 93, 0.16);
+    border-color: rgba(228, 109, 93, 0.28);
+    color: rgba(255, 213, 213, 0.96);
 }
 
 .agg-tag {
-    padding: 0.1rem 0.4rem;
-    border-radius: 3px;
-    font-size: 0.75rem;
-    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-family: var(--font-mono);
+    border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .agg-tag-quarantine {
-    background: #f8d7da;
-    color: #721c24;
+    background: rgba(228, 109, 93, 0.16);
+    border-color: rgba(228, 109, 93, 0.28);
+    color: rgba(255, 213, 213, 0.96);
 }
 
 .agg-lastseen {
-    color: var(--text-soft, #888);
-    font-size: 0.75rem;
+    color: var(--text-soft);
+    font-size: 0.76rem;
+    font-family: var(--font-mono);
 }
 
 .aggregator-node-placeholder {
-    color: var(--text-soft, #888);
-    font-style: italic;
-    padding: 0.5rem 0;
+    color: var(--text-dim);
+    padding: 4px 0;
 }
 
 .aggregator-last-updated {
-    font-size: 0.75rem;
-    color: var(--text-soft, #888);
-    margin-top: 0.5rem;
+    font-size: 0.76rem;
+    color: var(--text-soft);
+    margin-top: 12px;
 }
 
 .panel {
@@ -1085,7 +1111,7 @@ body[data-audience="professional"] .temp-only {
 }
 
 .topolite-nav-panel {
-    padding: 18px 20px;
+    padding: 22px 24px 24px;
     margin-bottom: 14px;
 }
 
@@ -1107,6 +1133,7 @@ body[data-audience="professional"] .temp-only {
 
 .topolite-single-screen {
     margin-top: 18px;
+    padding: 22px 24px 24px;
 }
 
 .topolite-single-grid {

--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -1012,15 +1012,15 @@
             </details>
         </section>
 
-        <section class="panel" id="aggregatorPanel" hidden>
+        <section class="panel aggregator-panel" id="aggregatorPanel" hidden>
             <div class="panel-heading">
-                <div class="panel-title-group">
+                <div>
                     <div class="panel-kicker">{{ tr('dashboard.aggregator_kicker', 'Multi-Node') }}</div>
-                    <h2 class="panel-title">{{ tr('dashboard.aggregator_title', 'Node Fleet Status') }}</h2>
+                    <h2>{{ tr('dashboard.aggregator_title', 'Node Fleet Status') }}</h2>
                 </div>
-                <p class="panel-note" id="aggregatorPanelNote">
+                <div class="panel-note" id="aggregatorPanelNote">
                     {{ tr('dashboard.aggregator_note', 'Aggregated freshness and risk posture across registered nodes.') }}
-                </p>
+                </div>
             </div>
 
             <div class="aggregator-counters" id="aggregatorCounters">


### PR DESCRIPTION
## Summary

Follow-up to #301: the "Topo-Lite / Visual triage in one screen" panel and the "Multi-Node / Node Fleet Status" panel used their own spacing, heading markup, and light-theme badge colors, so they visibly clashed with every other panel. This unifies both with the standard panel design language. Presentation only — no ids or JS-generated class names changed.

- **Topo-Lite single-screen panel** (`#topoliteSingleScreen`) and the Topo-Lite nav panel had no / smaller padding; both now use the standard `22px 24px 24px` panel padding
- **Node Fleet heading** rewritten to the shared `panel-heading` structure (kicker + `h2` + `panel-note`), removing the `panel-title-group`/`panel-title` classes that had no CSS definitions
- **Fleet counters** restyled as tone-tinted tiles (mono numerals, uppercase letter-spaced labels) matching the client-identity tiles
- **Node rows** now use the shared card pattern: `--radius-md`, soft border with a 4px tone-colored left edge, `--shadow-sm`
- **Freshness / quarantine badges** converted from light-theme colors (`#d4edda`, `#fff3cd`, `#f8d7da` — illegible on the dark theme) to the dark pill-badge pattern used by every other badge on the page

## Type of change

- [ ] feat — new feature
- [x] fix — bug fix
- [ ] refactor — no behavior change
- [ ] docs — documentation only
- [ ] test — tests only
- [ ] chore — build/CI/config
- [ ] security — security fix

## Checklist

- [x] `PYTHONPATH=. pytest -q` passes — UI/i18n/aggregator suites pass (42 tests); the pre-existing `tests/test_bhusa_*` environment failures reproduce identically on `origin/main` and are unrelated
- [ ] Related documentation updated in this PR — none needed (visual-only change)
- [x] Deterministic First principle not violated (AI is assist, not primary decision-maker) — CSS/markup only
- [x] Raspberry Pi constraints not broken (memory, aarch64 compatibility) — no new dependencies, no JS changes
- [x] No changes to `installer/`, `systemd/`, `security/` without explicit justification below — none touched

## Notes for reviewers

- Verified in a real Chromium with sample fleet rows injected (fresh/stale/offline + quarantine tag): counters, node rows, and badges now match the client-identity tile/row/badge patterns; Topo-Lite panel heading and padding align with neighboring panels
- `app.js` emits `aggregator-node-row status-{ok,warn,crit}`, `agg-freshness-{fresh,stale,offline}`, and `agg-tag-quarantine` — all class names kept; only their CSS changed

## Related issues

Refs #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Z2SUieAnXujJ6djyywukP

---
_Generated by [Claude Code](https://claude.ai/code/session_015Z2SUieAnXujJ6djyywukP)_