### PR TITLE
feat: Phase 3 — Azazel-Fabric契約の採用(emit-alongside 3系統 + StatusView)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ the [Azazel](https://github.com/01rabbit/Azazel) project ("Cyber Scapegoat Gatew
 | Azazel-Gadget | AZ-02 (formerly Azazel-Zero) | USB-gadget-class portable device | Portable companion gateway; ships an EPD-on-Web dev preview |
 | Azazel-Boot | AZ-03 | Reserved | Reserved form; no repository yet |
 | [Azazel-Knowledge](https://github.com/01rabbit/Azazel-Knowledge) | AZ-04 (formerly Azazel-CTI; formal name: Azazel-Knowledge Advisor) | Advisory-only on-prem CTI node (Pi 4) | Deterministic threat-context advice; never commands — Edge's arbiter keeps final authority and functions fully without it |
-| [Azazel-Fabric](https://github.com/01rabbit/Azazel-Fabric) | AZ-05 (formerly Azazel-Common; formal name: Azazel-Fabric Contract) | shared contracts library | Shared Pydantic contracts (`azazel_fabric` from v0.3.0; `azazel_common` in the v0.1.0/v0.2.0 tags); Edge integration is design-only today (see [Edge adapter plan](docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md)) |
+| [Azazel-Fabric](https://github.com/01rabbit/Azazel-Fabric) | AZ-05 (formerly Azazel-Common; formal name: Azazel-Fabric Contract) | shared contracts library | Shared Pydantic contracts (`azazel_fabric` from v0.3.0; `azazel_common` in the v0.1.0/v0.2.0 tags); Edge is the top consumer — shipping DecisionExplanation / TrustCapsule / AuditEvent projections + a StatusView (guarded, emit-alongside, zero behavior change; see [Edge adapter plan](docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md)) |
 
 Azazel-Edge and Azazel-Gadget are MIT-licensed. See the [Azazel](https://github.com/01rabbit/Azazel)
 umbrella project for series-wide doctrine.

--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -4192,6 +4192,27 @@ def read_state() -> Dict[str, Any]:
         }
 
 
+def read_status_view() -> Optional[Dict[str, Any]]:
+    """Read the shared Azazel-Fabric StatusView written beside the snapshot.
+
+    The agent writes ``ui_status_view.json`` next to ``ui_snapshot.json`` when
+    the ``azazel_fabric`` package is installed (see
+    ``azazel_edge.fabric_view``). Returns the view as a dict, or ``None`` when
+    it is unavailable (package absent, not yet written, or unreadable). Never
+    raises into the caller.
+    """
+    for base in (STATE_PATH, FALLBACK_STATE_PATH):
+        try:
+            view_path = Path(base).with_name("ui_status_view.json")
+            if view_path.exists():
+                data = json.loads(view_path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    return data
+        except Exception:  # pragma: no cover - defensive; status_view is advisory-only
+            continue
+    return None
+
+
 def _normalize_status_payload(payload: Dict[str, Any], action: str = "") -> Dict[str, Any]:
     """Normalize Status API payload shape."""
     if payload.get("status") == "ok" and "ok" not in payload:
@@ -4797,6 +4818,9 @@ def api_state():
     mode_state = get_mode_state()
     state["mode"] = mode_state.get("mode", {})
     state["mode_runtime"] = mode_state
+    # Shared Azazel-Fabric StatusView, emitted alongside the snapshot when the
+    # azazel_fabric package is installed; null when unavailable.
+    state["status_view"] = read_status_view()
     return jsonify(state)
 
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -86,6 +86,27 @@ that shows `preview.png` (refreshed ~5s with a cache-busting query) and polls
 `/api/epd` (~2s) for `mode`/`state`/`source`/`note`. Token-gated at the viewer
 role; pass `?token=…`, which the page propagates to its API/image requests.
 
+## State API — shared Fabric StatusView
+
+### GET /api/state
+
+Returns the current runtime state (the control-plane / `ui_snapshot.json`
+payload) plus `monitoring`, `portal_viewer`, `mode`, and `mode_runtime`.
+
+As of Phase 3 of the [Edge adapter plan](AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md),
+the response additionally carries a **`status_view`** key: the shared
+[Azazel-Fabric](https://github.com/01rabbit/Azazel-Fabric)
+`azazel_fabric.view.StatusView` projection of the current snapshot, emitted
+alongside `ui_snapshot.json` as `ui_status_view.json`.
+
+- `status_view` is a `StatusView` object (`product`, `mode`, `posture`,
+  `headline`, `reasons`, `operator_wording`, `health[]`, `evidence_ids[]`, and
+  the full snapshot under `product_view.edge_snapshot`).
+- `status_view` is **`null`** when the `azazel_fabric` package is not installed,
+  or the view has not been written yet — the key is always present. All existing
+  `/api/state` fields are unchanged; this key is purely additive and never gates
+  Edge behavior.
+
 ## Compatibility Note
 
 API contract details evolve with implementation.

--- a/docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md
+++ b/docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md
@@ -18,8 +18,11 @@
 > ("Edge is the most mature tool, so it must be Fabric's top consumer"), Edge
 > also ships a **StatusView** emit/read-back path (`py/azazel_edge/fabric_view.py`
 > → `ui_status_view.json`, surfaced on `GET /api/state` as `status_view`) — more
-> Fabric coverage than any sibling. `azazel-fabric` is pinned in
-> `requirements/runtime.txt` at the merged commit (v0.3.0 tag pending). The §3.4
+> Fabric coverage than any sibling. `azazel-fabric` is pinned in the optional
+> `requirements/fabric.txt` at the merged commit (v0.3.0 tag pending): the
+> Fabric repository is private, so unauthenticated environments (CI) cannot
+> resolve the pin — installing that file activates the projections, and every
+> integration point is a guarded no-op without it. The §3.4
 > second decision stream remains deferred, and the §4 CTI client remains FY2027+.
 > The §8 open questions are resolved as-implemented (see §8). The design body
 > below is retained as the authority for the projection mappings.

--- a/docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md
+++ b/docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md
@@ -10,10 +10,24 @@
 > it stays cross-referenced as `AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md` from
 > `docs/INDEX.md` and from the Fabric repo's docs.
 
-Status: **Design note / proposal only.** No adapter code is written by this
-document, and no existing Edge behavior is changed. This is the deliverable for
-Issue 5 in `Azazel-Common/docs/issue-breakdown.md`, implementing the planning
-step of `Azazel-Common/docs/migration-plan.md` Phase 3.
+> **2026-07-10 status update — Phase 3 IMPLEMENTED.** The §3 adapters are now
+> shipped in Edge per this plan: the DecisionExplanation projection (§3.1), the
+> TrustCapsule projection (§3.2), and the AuditEvent projection (§3.3) — each an
+> emit-alongside, guarded (`try: import azazel_fabric`) no-op-when-absent path
+> with zero behavior change. Beyond the original scope, and at owner direction
+> ("Edge is the most mature tool, so it must be Fabric's top consumer"), Edge
+> also ships a **StatusView** emit/read-back path (`py/azazel_edge/fabric_view.py`
+> → `ui_status_view.json`, surfaced on `GET /api/state` as `status_view`) — more
+> Fabric coverage than any sibling. `azazel-fabric` is pinned in
+> `requirements/runtime.txt` at the merged commit (v0.3.0 tag pending). The §3.4
+> second decision stream remains deferred, and the §4 CTI client remains FY2027+.
+> The §8 open questions are resolved as-implemented (see §8). The design body
+> below is retained as the authority for the projection mappings.
+
+Status: **Design note / proposal — now implemented (Phase 3, 2026-07-10).** The
+plan below defined the adapters; they are now built as described. This was the
+deliverable for Issue 5 in `Azazel-Common/docs/issue-breakdown.md`, implementing
+the planning step of `Azazel-Common/docs/migration-plan.md` Phase 3.
 
 This note identifies the *exact* call sites in Edge that would serialize
 through `azazel_common` schemas, states explicitly which code is **not**
@@ -258,21 +272,39 @@ Item 5 below is **not part of the current cycle** — deferred to FY2027+:
    `integrations/`), introduced as a Common consumer from the first commit,
    only when the CTI integration cycle begins.
 
-## 8. Open questions for review (feed Issue 3)
+## 8. Open questions — RESOLVED as implemented (2026-07-10)
 
-1. Confirm `DecisionExplanation` stays an interop *projection*, not a
-   replacement for Edge's richer v2 record — so the `why_chosen` (dict→str) and
-   `selected_action` (dict→`ActionIntent`) narrowing is acceptable at the
-   boundary.
-2. Decide how the audit hash-chain (`chain_prev`/`chain_hash`) is represented
-   through `AuditEvent` — carry in `payload` for v0.1.0, or promote to a
-   dedicated chain-of-custody field in a later Common release
-   (`audit/chain.py`, Phase 5).
-3. Reconcile `TrustCapsule` field names (`hmac_sig`↔`hmac`,
-   `timestamp`↔`issued_at`) and the absent `config_hash` — Common change vs.
-   Edge-side mapping.
-4. Since no CTI client exists **and CTI integration is deferred to FY2027+**,
-   validating the CTI request/response schemas against the real Azazel-CTI API
-   is entirely Issue 3's job on the Common side (there is nothing to retrofit in
-   Edge now). No Edge CTI work is scheduled for the current cycle; §3 adoption
-   proceeds independently of it.
+1. **`DecisionExplanation` stays an interop projection, not a replacement.**
+   *Resolved:* accepted. Edge keeps writing its richer v2
+   `decision-explanations.jsonl` unchanged; the Fabric projection is written to
+   a **separate** `fabric-decision-explanations.jsonl`. The lossy narrowing is
+   applied at the boundary: `why_chosen` dict → the top-level `reason` string,
+   `selected_action` name → an assembled `ActionIntent`
+   (`kind`/`target`/`issued_by=edge_arbiter`/`evidence`/`trace_id`), and
+   `why_not_others` `{action,reason}` → `"action: reason"` strings.
+   Implementation: `py/azazel_edge/explanations/fabric_adapter.py`.
+2. **Audit hash-chain representation through `AuditEvent`.**
+   *Resolved:* carry `chain_prev`/`chain_hash` (plus `source`) inside
+   `AuditEvent.payload` for now — Fabric does not (yet) model a chain, and a
+   dedicated chain-of-custody field stays a future Fabric extension. `event_id`
+   is synthesized from `chain_hash` (chain position is Edge's record identity).
+   Critically, the projection is written to a **separate, non-interleaved** file
+   (`<name>.fabric.jsonl`), so the original chained log and `verify_chain()` are
+   never perturbed. Implementation: `py/azazel_edge/audit/fabric_adapter.py`.
+3. **`TrustCapsule` field reconciliation.**
+   *Resolved:* done Edge-side as a projection mapping (no Fabric change):
+   `hmac_sig` → `hmac`, `timestamp` → `issued_at`, and the `config_hash` absent
+   from Edge's capsule is sourced from the explanation's top-level `config_hash`.
+   Written to a separate `fabric-trust-capsules.jsonl`; Edge's own capsule is
+   untouched. Implementation: `explanations/fabric_adapter.py`.
+4. **CTI schema validation stays a Fabric-side concern.**
+   *Unchanged:* no CTI client exists in Edge and CTI integration remains
+   deferred to FY2027+. §3 adoption proceeded independently, as planned.
+
+**Beyond §8 — StatusView (owner-directed scope extension).** Edge additionally
+builds `azazel_fabric.view.StatusView` from its runtime snapshot via
+`build_status_view`/`derive_posture` and writes `ui_status_view.json` alongside
+`ui_snapshot.json`, carrying the whole snapshot under
+`product_view={"edge_snapshot": …}` (peer-not-subset). It is surfaced read-back
+on `GET /api/state` as the `status_view` key (null when the package is absent).
+Implementation: `py/azazel_edge/fabric_view.py` and `azazel_edge_web/app.py`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,35 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Azazel-Fabric adoption — Phase 3 (2026-07-10): Edge now ships the three §3
+  emit-alongside projections from `docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md` plus
+  an owner-directed StatusView extension, making Edge the top consumer of the
+  shared contracts library. All paths are guarded (`try: import azazel_fabric`)
+  and are exact no-ops when the package is absent — zero behavior change:
+  - **DecisionExplanation projection** (§3.1): each persisted v2 decision
+    explanation is additionally serialized as
+    `azazel_fabric.schema.DecisionExplanation` to a separate
+    `fabric-decision-explanations.jsonl` stream; Edge's own
+    `decision-explanations.jsonl` is byte-for-byte unchanged. Lossy interop
+    projection (`why_chosen` dict→str, `selected_action` name→`ActionIntent`,
+    `why_not_others` flattened to strings).
+  - **TrustCapsule projection** (§3.2): emitted as
+    `azazel_fabric.schema.TrustCapsule` to `fabric-trust-capsules.jsonl` with
+    the plan's field mapping (`hmac_sig`→`hmac`, `timestamp`→`issued_at`,
+    `config_hash` sourced from the explanation).
+  - **AuditEvent projection** (§3.3): `P0AuditLogger.log()` additionally
+    projects `azazel_fabric.schema.AuditEvent` to a separate, non-interleaved
+    sibling file (`<name>.fabric.jsonl`) so the hash chain and `verify_chain()`
+    are never perturbed. `tactics_engine/decision_logger.py` is left untouched
+    (§3.4, deferred).
+  - **StatusView emit + surface** (scope extension, owner-directed): new
+    `py/azazel_edge/fabric_view.py` builds `azazel_fabric.view.StatusView` from
+    the runtime snapshot (carrying the full snapshot under
+    `product_view.edge_snapshot`) and writes `ui_status_view.json` alongside
+    `ui_snapshot.json`. `GET /api/state` gains a `status_view` key (null when
+    unavailable). See `docs/API_REFERENCE.md`.
+  - Pins `azazel-fabric` in `requirements/runtime.txt` at the exact merged
+    commit (v0.3.0 tag pending).
 - Documentation updates for the Azazel series naming change (2026-07-10): Azazel-CTI → Azazel-Knowledge (AZ-04) and Azazel-Common → Azazel-Fabric (AZ-05). Updated the README series table, `docs/INDEX.md`, and added a naming-update status note to `docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md` (file not renamed; body text and `azazel_common` references pre-`v0.3.0` are left as originally written).
 - EPD-on-Web preview for Azazel-Edge: read-only, viewer-gated web routes that expose the physical e-paper panel state — `GET /api/epd` (mode/state plus raw `epd_state.json`, desired render spec, and last-drawn frame), `GET /api/epd/preview.png` (pixel-parity PNG rendered in-memory by the real `py/azazel_edge_epd.py` renderer, fail-closed `503` when the renderer/assets are unavailable), and `GET /dev/epd` (self-contained dark-themed dev page). Adds `AZAZEL_EPD_RUNTIME_DIR` / `AZAZEL_EPD_STATE_PATH` / `AZAZEL_EPD_LAST_RENDER_PATH` dev overrides. See `docs/API_REFERENCE.md` and `docs/CONFIGURATION.md`.
 - Design-only integration plan `docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md` (2026-07-09) describing the azazel-common contract adapter for Edge; documents planning intent only (no shipped code), with Edge↔CTI integration deferred to FY2027+.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Azazel-Fabric の pin をオプションの `requirements/fabric.txt` に分離(Fabric
+  リポジトリは private のため、無認証環境 = CI では解決不能。全統合点は
+  ガード付き no-op なので未導入でも動作は同一。導入時のみ射影が有効化)。
+
 ### Added
 - Azazel-Fabric adoption — Phase 3 (2026-07-10): Edge now ships the three §3
   emit-alongside projections from `docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md` plus

--- a/py/azazel_edge/audit/fabric_adapter.py
+++ b/py/azazel_edge/audit/fabric_adapter.py
@@ -1,0 +1,92 @@
+"""Emit-alongside projection of Edge audit records into Azazel-Fabric.
+
+Phase 3 of ``docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md`` §3.3. Each record the
+hash-chained ``P0AuditLogger`` writes is *additionally* projected into the
+shared ``azazel_fabric.schema.AuditEvent`` envelope and appended to a
+**separate, non-interleaved** file so the original chain is never perturbed and
+``P0AuditLogger.verify_chain()`` keeps passing untouched.
+
+The shared package is imported optionally: if ``azazel_fabric`` is not
+installed this is a safe no-op. No function here ever raises into its caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+try:  # optional dependency — pinned in requirements/runtime.txt, absent is fine
+    from azazel_fabric.schema import AuditEvent
+
+    HAVE_AZAZEL_FABRIC = True
+except Exception:  # pragma: no cover - exercised only when the dep is absent
+    HAVE_AZAZEL_FABRIC = False
+
+
+def fabric_stream_path(native_path: Path) -> Path:
+    """Sibling filename for the Fabric AuditEvent stream (never the chained file).
+
+    For a chained log at ``<dir>/audit.jsonl`` the projection is written to
+    ``<dir>/audit.fabric.jsonl`` — 1:1 with each chain file, never interleaved.
+    """
+    native_path = Path(native_path)
+    return native_path.with_name(native_path.stem + ".fabric" + native_path.suffix)
+
+
+def build_audit_event(record: Dict[str, Any]) -> "Optional[AuditEvent]":
+    """Project one Edge audit record into a Fabric ``AuditEvent``.
+
+    Mapping (plan §3.3): Edge has no ``event_id`` (chain position is identity),
+    so it is synthesized from ``chain_hash``; ``kind``->``event_type``;
+    ``source`` and ``chain_prev``/``chain_hash`` plus the free-form payload ride
+    in ``AuditEvent.payload`` (Fabric does not model a hash chain);
+    ``config_hash``/``hmac`` stay ``None`` (not on the base record). Returns
+    ``None`` if Fabric is not installed.
+    """
+    if not HAVE_AZAZEL_FABRIC:
+        return None
+
+    reserved = {"ts", "kind", "trace_id", "source", "chain_prev", "chain_hash"}
+    payload: Dict[str, Any] = {k: v for k, v in record.items() if k not in reserved}
+    payload["source"] = str(record.get("source") or "")
+    payload["chain_prev"] = str(record.get("chain_prev") or "")
+    payload["chain_hash"] = str(record.get("chain_hash") or "")
+
+    event_id = str(record.get("chain_hash") or "")
+    if not event_id:
+        # Fall back to a positional identity when the chain hash is unavailable.
+        event_id = f"{record.get('trace_id') or ''}:{record.get('kind') or ''}"
+
+    return AuditEvent(
+        event_id=event_id,
+        trace_id=str(record.get("trace_id") or ""),
+        timestamp=str(record.get("ts") or ""),
+        product="edge",
+        event_type=str(record.get("kind") or ""),
+        payload=payload,
+        config_hash=None,
+        hmac=None,
+    )
+
+
+def project_audit_record(record: Dict[str, Any], native_path: Path) -> None:
+    """Append a Fabric AuditEvent projection to the sibling stream. Best-effort.
+
+    A no-op when Fabric is absent; never raises into the caller and never writes
+    to the chained ``native_path``.
+    """
+    if not HAVE_AZAZEL_FABRIC:
+        return
+    try:
+        event = build_audit_event(record)
+        if event is None:
+            return
+        out_path = fabric_stream_path(Path(native_path))
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("a", encoding="utf-8") as fh:
+            fh.write(event.model_dump_json() + "\n")
+    except Exception as exc:  # pragma: no cover - defensive; must never raise
+        logger.debug("fabric_audit_projection_failed: %s", exc)

--- a/py/azazel_edge/audit/logger.py
+++ b/py/azazel_edge/audit/logger.py
@@ -85,6 +85,15 @@ class P0AuditLogger:
             with self.path.open('a', encoding='utf-8') as fh:
                 fh.write(json.dumps(record, ensure_ascii=True, separators=(',', ':')) + '\n')
             self._last_chain_hash = str(record['chain_hash'])
+            # Emit-alongside: project into the shared Azazel-Fabric AuditEvent on a
+            # SEPARATE, non-interleaved file. The chained log above is complete and
+            # untouched; verify_chain() is unaffected (plan §3.3). Best-effort.
+            try:
+                from .fabric_adapter import project_audit_record
+
+                project_audit_record(record, self.path)
+            except Exception:  # pragma: no cover - defensive; projection is advisory-only
+                pass
             return record
 
     def log_event_receive(self, trace_id: str, source: str, **payload: Any) -> Dict[str, Any]:

--- a/py/azazel_edge/explanations/decision.py
+++ b/py/azazel_edge/explanations/decision.py
@@ -188,6 +188,15 @@ class DecisionExplainer:
             logger.warning("invalid_v2_decision_explanation: %s", "; ".join(problems))
         with self.output_path.open('a', encoding='utf-8') as fh:
             fh.write(json.dumps(explanation, ensure_ascii=True, separators=(',', ':')) + '\n')
+        # Emit-alongside: additionally project into the shared Azazel-Fabric
+        # DecisionExplanation/TrustCapsule shapes on separate streams. Best-effort,
+        # never perturbs the Edge-native write above (plan §3.1/§3.2).
+        try:
+            from .fabric_adapter import project_decision_explanation
+
+            project_decision_explanation(explanation, self.output_path)
+        except Exception:  # pragma: no cover - defensive; projection is advisory-only
+            pass
 
     @staticmethod
     def _operator_wording(

--- a/py/azazel_edge/explanations/fabric_adapter.py
+++ b/py/azazel_edge/explanations/fabric_adapter.py
@@ -1,0 +1,173 @@
+"""Emit-alongside projections into the shared Azazel-Fabric contracts.
+
+Phase 3 of ``docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md`` §3.1 / §3.2. Edge keeps
+writing its own, richer ``decision-explanations.jsonl`` byte-for-byte
+unchanged; this module additionally serializes a *lossy* projection of each
+persisted decision explanation into the shared
+``azazel_fabric.schema.DecisionExplanation`` shape (and its embedded trust
+capsule into ``azazel_fabric.schema.TrustCapsule``), written to **separate**
+JSONL streams next to the originals.
+
+The shared package is imported optionally: if ``azazel_fabric`` is not
+installed every function here becomes a safe no-op, so Edge runs identically
+with or without it — matching the guarded-import pattern already used across
+the codebase. No function here ever raises into its caller.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+try:  # optional dependency — pinned in requirements/runtime.txt, absent is fine
+    from azazel_fabric.schema import (
+        ActionIntent,
+        DecisionExplanation,
+        EvidenceRef,
+        TrustCapsule,
+    )
+
+    HAVE_AZAZEL_FABRIC = True
+except Exception:  # pragma: no cover - exercised only when the dep is absent
+    HAVE_AZAZEL_FABRIC = False
+
+# Edge's arbiter action set is a subset of azazel_fabric.schema.ActionKind
+# (observe/notify/throttle/redirect/isolate/decoy/release). Anything outside the
+# shared enum degrades to "observe" so the projection never raises on an
+# unexpected action word.
+_ACTION_KINDS = {
+    "observe",
+    "notify",
+    "throttle",
+    "redirect",
+    "isolate",
+    "decoy",
+    "release",
+}
+
+# Projection stream filenames, written beside the Edge-native output.
+DECISION_PROJECTION_NAME = "fabric-decision-explanations.jsonl"
+TRUST_PROJECTION_NAME = "fabric-trust-capsules.jsonl"
+
+
+def _append_line(path: Path, payload: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(payload + "\n")
+
+
+def build_decision_projection(explanation: Dict[str, Any]) -> "Optional[DecisionExplanation]":
+    """Project Edge's v2 explanation dict into a Fabric ``DecisionExplanation``.
+
+    Lossy by design (plan §3.1): the rich ``why_chosen`` dict narrows to a
+    string, ``selected_action`` (an action name) is assembled into an
+    ``ActionIntent``, and ``why_not_others`` flattens to strings. Returns
+    ``None`` if Fabric is not installed. Never raises on ordinary shape
+    variation.
+    """
+    if not HAVE_AZAZEL_FABRIC:
+        return None
+
+    why_chosen = explanation.get("why_chosen") if isinstance(explanation.get("why_chosen"), dict) else {}
+    trace_id = str(explanation.get("trace_id") or "")
+    action = str(explanation.get("selected_action") or why_chosen.get("action") or "observe")
+    kind = action if action in _ACTION_KINDS else "observe"
+    target = str(why_chosen.get("target") or "azazel-edge")
+    observed_at = str(explanation.get("ts") or "")
+
+    evidence: List[EvidenceRef] = []
+    for ev_id in explanation.get("evidence_ids", []) or []:
+        if not str(ev_id):
+            continue
+        evidence.append(
+            EvidenceRef(
+                evidence_id=str(ev_id),
+                source="edge_arbiter",
+                trace_id=trace_id,
+                observed_at=observed_at,
+            )
+        )
+
+    selected_action = ActionIntent(
+        kind=kind,
+        target=target,
+        issued_by="edge_arbiter",
+        evidence=evidence,
+        trace_id=trace_id,
+    )
+
+    why_not: List[str] = []
+    for item in explanation.get("why_not_others", []) or []:
+        if isinstance(item, dict):
+            act = str(item.get("action") or "")
+            reason = str(item.get("reason") or "")
+            why_not.append(f"{act}: {reason}".strip(": ").strip() or reason or act)
+
+    release_condition = str(explanation.get("release_condition") or "") or None
+
+    capsule = explanation.get("trust_capsule") if isinstance(explanation.get("trust_capsule"), dict) else {}
+    raw_conf = capsule.get("confidence")
+    confidence = None
+    if isinstance(raw_conf, (int, float)):
+        confidence = max(0.0, min(1.0, float(raw_conf)))
+
+    why_chosen_str = str(explanation.get("reason") or why_chosen.get("reason") or "")
+
+    return DecisionExplanation(
+        selected_action=selected_action,
+        why_chosen=why_chosen_str,
+        why_not_others=why_not,
+        release_condition=release_condition,
+        confidence=confidence,
+        trace_id=trace_id,
+    )
+
+
+def build_trust_capsule_projection(explanation: Dict[str, Any]) -> "Optional[TrustCapsule]":
+    """Project Edge's decision explanation into a Fabric ``TrustCapsule``.
+
+    Field mapping (plan §3.2): ``hmac_sig``->``hmac``, ``timestamp``->
+    ``issued_at``; ``config_hash`` is absent from Edge's capsule and is sourced
+    from the explanation's top-level ``config_hash``. Returns ``None`` if Fabric
+    is not installed.
+    """
+    if not HAVE_AZAZEL_FABRIC:
+        return None
+
+    capsule = explanation.get("trust_capsule") if isinstance(explanation.get("trust_capsule"), dict) else {}
+    trace_id = str(capsule.get("trace_id") or explanation.get("trace_id") or "")
+    issued_at = str(capsule.get("timestamp") or explanation.get("ts") or "")
+    hmac_value = str(capsule.get("hmac_sig") or "")
+    config_hash = str(explanation.get("config_hash") or "")
+
+    return TrustCapsule(
+        trace_id=trace_id,
+        config_hash=config_hash,
+        hmac=hmac_value,
+        issued_at=issued_at,
+    )
+
+
+def project_decision_explanation(explanation: Dict[str, Any], native_path: Path) -> None:
+    """Emit the Fabric DecisionExplanation + TrustCapsule projections alongside.
+
+    ``native_path`` is Edge's own ``decision-explanations.jsonl``; the
+    projections are written to sibling files in the same directory. Best-effort:
+    a no-op when Fabric is absent and never raises into the caller.
+    """
+    if not HAVE_AZAZEL_FABRIC:
+        return
+    try:
+        native_path = Path(native_path)
+        decision = build_decision_projection(explanation)
+        if decision is not None:
+            _append_line(native_path.with_name(DECISION_PROJECTION_NAME), decision.model_dump_json())
+        capsule = build_trust_capsule_projection(explanation)
+        if capsule is not None:
+            _append_line(native_path.with_name(TRUST_PROJECTION_NAME), capsule.model_dump_json())
+    except Exception as exc:  # pragma: no cover - defensive; must never raise
+        logger.debug("fabric_projection_failed: %s", exc)

--- a/py/azazel_edge/fabric_view.py
+++ b/py/azazel_edge/fabric_view.py
@@ -1,0 +1,142 @@
+"""Adapter: Edge runtime snapshot -> shared Azazel-Fabric ``StatusView``.
+
+Owner-directed scope extension beyond ``docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md``
+§3: because Edge is the series' most mature tool it must be Fabric's *top*
+consumer, so it emits and reads back a shared ``StatusView`` in addition to the
+§3.1/§3.2/§3.3 projections (Gadget emits StatusView only).
+
+Edge builds the shared status view-model *next to* its existing
+``ui_snapshot.json`` without changing what any renderer reads. The whole raw
+snapshot is carried in ``StatusView.product_view={"edge_snapshot": snap}`` per
+the peer-not-subset doctrine, so no Edge-only field is lost.
+
+The shared package is imported optionally: if ``azazel_fabric`` is not
+installed every function here becomes a safe no-op, so Edge runs identically
+with or without it. No function here ever raises into its caller.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+try:  # optional dependency — pinned in requirements/runtime.txt, absent is fine
+    from azazel_fabric.schema.mode import ModeState
+    from azazel_fabric.view import HealthDimension, StatusView, build_status_view
+
+    HAVE_AZAZEL_FABRIC = True
+except Exception:  # pragma: no cover - exercised only when the dep is absent
+    HAVE_AZAZEL_FABRIC = False
+
+STATUS_VIEW_NAME = "ui_status_view.json"
+
+
+def _evidence_ids(snap: Dict[str, Any]) -> List[str]:
+    out: List[str] = []
+    for item in snap.get("evidence") or []:
+        if isinstance(item, dict):
+            ident = item.get("id") or item.get("evidence_id")
+            if ident:
+                out.append(str(ident))
+        elif item:
+            out.append(str(item))
+    return out
+
+
+def _health(snap: Dict[str, Any]) -> list:
+    """Map a few Edge runtime signals into render-agnostic health rows."""
+    rows = []
+    crit = snap.get("suricata_critical")
+    warn = snap.get("suricata_warning")
+    if crit is not None or warn is not None:
+        rows.append(
+            HealthDimension(
+                key="suricata",
+                label=f"crit={int(crit or 0)} warn={int(warn or 0)}",
+                status="critical" if int(crit or 0) else ("warn" if int(warn or 0) else "ok"),
+            )
+        )
+    connection = snap.get("connection") if isinstance(snap.get("connection"), dict) else {}
+    wifi_state = connection.get("wifi_state")
+    if wifi_state:
+        rows.append(
+            HealthDimension(
+                key="uplink",
+                label=str(wifi_state),
+                status="ok" if "CONNECTED" in str(wifi_state).upper() or "N/A" in str(wifi_state).upper() else "warn",
+                detail=f"uplink_if={connection.get('uplink_if', '-')} type={connection.get('uplink_type', 'unknown')}",
+            )
+        )
+    return rows
+
+
+def status_view_from_snapshot(
+    snap: Dict[str, Any], mode_name: Optional[str] = None
+) -> "Optional[StatusView]":
+    """Build a shared ``StatusView`` from an Edge runtime snapshot dict.
+
+    Returns ``None`` if ``azazel_fabric`` is not installed. Never raises for
+    ordinary shape variation — missing keys degrade to defaults.
+    """
+    if not HAVE_AZAZEL_FABRIC:
+        return None
+
+    internal = snap.get("internal") if isinstance(snap.get("internal"), dict) else {}
+    state_word = internal.get("state_name") or snap.get("user_state")
+    resolved_mode = str(mode_name or snap.get("mode") or "shield").lower()
+    since = str(snap.get("now_time") or snap.get("snapshot_epoch") or "")
+
+    recommendation = snap.get("recommendation")
+
+    return build_status_view(
+        product="edge",
+        mode=ModeState(name=resolved_mode, since=since),
+        generated_at=since,
+        state_word=str(state_word) if state_word else None,
+        reasons=[str(r) for r in (snap.get("reasons") or [])],
+        operator_wording=(str(recommendation) if recommendation else None),
+        health=_health(snap),
+        evidence_ids=_evidence_ids(snap),
+        # Peer, not subset: carry the whole raw snapshot so no Edge-only field is lost.
+        product_view={"edge_snapshot": snap},
+    )
+
+
+def write_status_view_alongside(
+    snap: Dict[str, Any],
+    snapshot_paths: Iterable[Any],
+    mode_name: Optional[str] = None,
+    logger: Any = None,
+) -> None:
+    """Write a ``StatusView`` JSON next to each snapshot path. Best-effort no-op.
+
+    For a snapshot at ``<dir>/ui_snapshot.json`` the view is written to
+    ``<dir>/ui_status_view.json``. Never raises into the caller and does nothing
+    when ``azazel_fabric`` is not installed.
+    """
+    if not HAVE_AZAZEL_FABRIC:
+        return
+    try:
+        view = status_view_from_snapshot(snap, mode_name=mode_name)
+        if view is None:
+            return
+        payload = view.model_dump_json()
+    except Exception as exc:  # pragma: no cover - defensive
+        if logger is not None:
+            logger.debug("status_view: build failed: %s", exc)
+        return
+
+    for snap_path in snapshot_paths:
+        try:
+            view_path = Path(snap_path).with_name(STATUS_VIEW_NAME)
+            view_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = view_path.with_suffix(view_path.suffix + ".tmp")
+            tmp_path.write_text(payload, encoding="utf-8")
+            os.replace(tmp_path, view_path)
+        except Exception as exc:  # pragma: no cover - defensive
+            if logger is not None:
+                logger.debug("status_view: failed to write beside %s: %s", snap_path, exc)

--- a/py/azazel_edge_ai/agent.py
+++ b/py/azazel_edge_ai/agent.py
@@ -1599,6 +1599,15 @@ def _update_ui_snapshot(advisory: Dict[str, Any], count_suricata: bool = True) -
     snapshot["connection"] = connection
 
     _write_json(SNAPSHOT_PATH, snapshot)
+    # Emit-alongside: write the shared Azazel-Fabric StatusView next to the
+    # snapshot (ui_status_view.json). Best-effort, never raises, no-op without
+    # the azazel_fabric package (owner-directed scope extension).
+    try:
+        from azazel_edge.fabric_view import write_status_view_alongside
+
+        write_status_view_alongside(snapshot, [SNAPSHOT_PATH], logger=logger)
+    except Exception:  # pragma: no cover - defensive; StatusView is advisory-only
+        pass
 
 
 def _append_jsonl(path: Path, payload: Dict[str, Any]) -> None:

--- a/requirements/fabric.txt
+++ b/requirements/fabric.txt
@@ -1,0 +1,14 @@
+# Azazel-Fabric shared contracts — OPTIONAL integration extra.
+#
+# Installing this file activates Edge's Fabric projections (DecisionExplanation /
+# TrustCapsule / AuditEvent emit-alongside streams and the StatusView emit +
+# /api/state read-back). Without it every integration point is a guarded no-op
+# and Edge behaves identically.
+#
+# The Azazel-Fabric repository is private: resolving this pin requires an
+# environment with GitHub credentials for 01rabbit/Azazel-Fabric (developer
+# machine, provisioned appliance). CI intentionally does not install this file.
+#
+# Import namespace: azazel_fabric. Pinned to the exact commit merged to main
+# (v0.3.0 pending tag); switch to @v0.3.0 once the tag is published.
+azazel-fabric @ git+https://github.com/01rabbit/Azazel-Fabric.git@ce357af727ca2d7ddd3c108bd6843c682b4dee8b

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -5,3 +5,6 @@ textual>=0.70,<1
 Pillow>=10,<12
 requests>=2.32,<3
 PyYAML>=6,<7
+# Azazel-Fabric shared contracts (import namespace: azazel_fabric). Pinned to the
+# exact commit merged to main (v0.3.0 pending tag); switch to @v0.3.0 once the tag is published.
+azazel-fabric @ git+https://github.com/01rabbit/Azazel-Fabric.git@ce357af727ca2d7ddd3c108bd6843c682b4dee8b

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -5,6 +5,7 @@ textual>=0.70,<1
 Pillow>=10,<12
 requests>=2.32,<3
 PyYAML>=6,<7
-# Azazel-Fabric shared contracts (import namespace: azazel_fabric). Pinned to the
-# exact commit merged to main (v0.3.0 pending tag); switch to @v0.3.0 once the tag is published.
-azazel-fabric @ git+https://github.com/01rabbit/Azazel-Fabric.git@ce357af727ca2d7ddd3c108bd6843c682b4dee8b
+# Azazel-Fabric shared contracts are an OPTIONAL extra: see requirements/fabric.txt.
+# (The Fabric repository is private, so unauthenticated environments — e.g. CI —
+# cannot resolve the git pin; every Fabric integration point is a guarded no-op
+# without the package.)

--- a/tests/test_fabric_adapters_v1.py
+++ b/tests/test_fabric_adapters_v1.py
@@ -1,0 +1,237 @@
+"""Phase 3 — Azazel-Fabric emit-alongside adapters.
+
+Covers the three §3 projections (DecisionExplanation, TrustCapsule, AuditEvent)
+plus the owner-directed StatusView emit/read-back extension. Each adapter is
+verified to (a) write a Fabric-shaped projection to a *separate* stream, (b)
+leave Edge's native output byte-for-byte unchanged, (c) never raise into its
+caller on failure, and (d) become a clean no-op when azazel_fabric is absent
+(simulated by toggling the guarded-import flag).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from azazel_edge.audit import P0AuditLogger
+from azazel_edge.audit import fabric_adapter as audit_fabric
+from azazel_edge.explanations import DecisionExplainer
+from azazel_edge.explanations import fabric_adapter as expl_fabric
+from azazel_edge import fabric_view
+
+
+def _sample_explain(explainer: DecisionExplainer):
+    return explainer.explain(
+        noc={"summary": {"status": "good"}},
+        soc={"summary": {"status": "critical", "ai_attack_candidates": ["T1190"]}},
+        arbiter={
+            "action": "redirect",
+            "reason": "soc_high_confidence_redirect",
+            "release_condition": "noc_recovers",
+            "chosen_evidence_ids": ["ev1", "ev2"],
+            "rejected_alternatives": [{"action": "notify", "reason": "too_weak"}],
+            "policy": {"version": "p1", "hash": "cfg123"},
+        },
+        trace_id="trace-xyz",
+        persist=True,
+    )
+
+
+class DecisionProjectionTests(unittest.TestCase):
+    def test_projection_written_with_expected_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "decision-explanations.jsonl"
+            _sample_explain(DecisionExplainer(output_path=out))
+            proj = out.with_name(expl_fabric.DECISION_PROJECTION_NAME)
+            self.assertTrue(proj.exists())
+            row = json.loads(proj.read_text(encoding="utf-8").strip())
+            self.assertEqual(row["trace_id"], "trace-xyz")
+            self.assertEqual(row["selected_action"]["kind"], "redirect")
+            self.assertEqual(row["selected_action"]["issued_by"], "edge_arbiter")
+            self.assertEqual([e["evidence_id"] for e in row["selected_action"]["evidence"]], ["ev1", "ev2"])
+            self.assertIsInstance(row["why_chosen"], str)
+            self.assertEqual(row["why_not_others"], ["notify: too_weak"])
+            self.assertEqual(row["release_condition"], "noc_recovers")
+            self.assertIsInstance(row["confidence"], float)
+
+    def test_trust_capsule_projection_field_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "decision-explanations.jsonl"
+            _sample_explain(DecisionExplainer(output_path=out))
+            proj = out.with_name(expl_fabric.TRUST_PROJECTION_NAME)
+            self.assertTrue(proj.exists())
+            row = json.loads(proj.read_text(encoding="utf-8").strip())
+            # Field renames per plan §3.2: hmac_sig->hmac, timestamp->issued_at,
+            # config_hash sourced from the explanation's top-level config_hash.
+            self.assertEqual(set(row.keys()), {"trace_id", "config_hash", "hmac", "issued_at"})
+            self.assertEqual(row["trace_id"], "trace-xyz")
+            self.assertEqual(row["config_hash"], "cfg123")
+            self.assertTrue(row["hmac"])
+            self.assertTrue(row["issued_at"])
+
+    def test_native_stream_byte_identical_with_and_without_adapter(self) -> None:
+        # Adapter enabled.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "decision-explanations.jsonl"
+            _sample_explain(DecisionExplainer(output_path=out))
+            native_on = out.read_bytes()
+        # Adapter disabled (simulate azazel_fabric absent).
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(expl_fabric, "HAVE_AZAZEL_FABRIC", False):
+            out = Path(tmp) / "decision-explanations.jsonl"
+            _sample_explain(DecisionExplainer(output_path=out))
+            native_off = out.read_bytes()
+            # No projection files at all when the package is absent.
+            self.assertFalse(out.with_name(expl_fabric.DECISION_PROJECTION_NAME).exists())
+            self.assertFalse(out.with_name(expl_fabric.TRUST_PROJECTION_NAME).exists())
+        self.assertEqual(native_on, native_off)
+
+    def test_adapter_failure_never_raises_into_caller(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            expl_fabric, "build_decision_projection", side_effect=RuntimeError("boom")
+        ):
+            out = Path(tmp) / "decision-explanations.jsonl"
+            # Must not raise even though the projection blows up.
+            _sample_explain(DecisionExplainer(output_path=out))
+            self.assertEqual(len(out.read_text(encoding="utf-8").splitlines()), 1)
+
+
+class AuditProjectionTests(unittest.TestCase):
+    def test_projection_to_separate_file_and_chain_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            chain = Path(tmp) / "audit.jsonl"
+            log = P0AuditLogger(chain)
+            log.log_action_decision("trace-1", "arbiter", action="redirect")
+            log.log_event_receive("trace-1", "suricata", event_id="e1")
+
+            # Original hash chain still verifies.
+            self.assertEqual(P0AuditLogger.verify_chain(chain)["ok"], True)
+
+            fabric_path = audit_fabric.fabric_stream_path(chain)
+            self.assertNotEqual(fabric_path, chain)
+            self.assertTrue(fabric_path.exists())
+            rows = [json.loads(l) for l in fabric_path.read_text(encoding="utf-8").splitlines()]
+            self.assertEqual([r["event_type"] for r in rows], ["action_decision", "event_receive"])
+            for r in rows:
+                self.assertEqual(r["product"], "edge")
+                self.assertTrue(r["event_id"])
+                self.assertIn("chain_hash", r["payload"])
+                self.assertIn("chain_prev", r["payload"])
+                self.assertIn("source", r["payload"])
+
+            # The chained file itself carries no AuditEvent fields.
+            native_rows = [json.loads(l) for l in chain.read_text(encoding="utf-8").splitlines()]
+            self.assertNotIn("event_id", native_rows[0])
+            self.assertNotIn("product", native_rows[0])
+
+    def test_no_package_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(audit_fabric, "HAVE_AZAZEL_FABRIC", False):
+            chain = Path(tmp) / "audit.jsonl"
+            log = P0AuditLogger(chain)
+            log.log_action_decision("trace-1", "arbiter", action="redirect")
+            self.assertEqual(P0AuditLogger.verify_chain(chain)["ok"], True)
+            self.assertFalse(audit_fabric.fabric_stream_path(chain).exists())
+
+    def test_projection_failure_never_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            audit_fabric, "build_audit_event", side_effect=RuntimeError("boom")
+        ):
+            chain = Path(tmp) / "audit.jsonl"
+            log = P0AuditLogger(chain)
+            rec = log.log_action_decision("trace-1", "arbiter", action="redirect")
+            self.assertEqual(rec["kind"], "action_decision")
+            self.assertEqual(P0AuditLogger.verify_chain(chain)["ok"], True)
+
+
+class StatusViewTests(unittest.TestCase):
+    SNAP = {
+        "now_time": "12:00:00",
+        "snapshot_epoch": 1720000000.0,
+        "user_state": "CONTAIN",
+        "recommendation": "Redirect suspicious flows",
+        "reasons": ["suricata_sid=2001 risk=88"],
+        "evidence": ["CRITICAL sid=2001 exploit"],
+        "suricata_critical": 1,
+        "suricata_warning": 0,
+        "internal": {"state_name": "CONTAIN", "suspicion": 88},
+        "connection": {"wifi_state": "CONNECTED", "uplink_if": "wlan0", "uplink_type": "wifi"},
+        "attack": {"suricata_alert": True},
+    }
+
+    def test_build_status_view_carries_full_snapshot(self) -> None:
+        view = fabric_view.status_view_from_snapshot(self.SNAP)
+        self.assertIsNotNone(view)
+        data = json.loads(view.model_dump_json())
+        self.assertEqual(data["product"], "edge")
+        self.assertEqual(data["posture"], "contain")
+        self.assertEqual(data["operator_wording"], "Redirect suspicious flows")
+        # Peer, not subset: the whole snapshot rides in product_view.
+        self.assertEqual(data["product_view"]["edge_snapshot"], self.SNAP)
+
+    def test_write_alongside_and_noop_without_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            snap_path = Path(tmp) / "ui_snapshot.json"
+            snap_path.write_text("{}", encoding="utf-8")
+            fabric_view.write_status_view_alongside(self.SNAP, [snap_path])
+            view_path = snap_path.with_name(fabric_view.STATUS_VIEW_NAME)
+            self.assertTrue(view_path.exists())
+            json.loads(view_path.read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(fabric_view, "HAVE_AZAZEL_FABRIC", False):
+            snap_path = Path(tmp) / "ui_snapshot.json"
+            snap_path.write_text("{}", encoding="utf-8")
+            fabric_view.write_status_view_alongside(self.SNAP, [snap_path])
+            self.assertFalse(snap_path.with_name(fabric_view.STATUS_VIEW_NAME).exists())
+
+    def test_write_alongside_never_raises_on_bad_path(self) -> None:
+        # A non-path-like entry must not propagate an exception.
+        fabric_view.write_status_view_alongside(self.SNAP, [object()])
+
+
+class ApiStateStatusViewTests(unittest.TestCase):
+    def setUp(self) -> None:
+        import azazel_edge_web.app as webapp
+
+        self.webapp = webapp
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self._orig = {
+            "STATE_PATH": webapp.STATE_PATH,
+            "FALLBACK_STATE_PATH": webapp.FALLBACK_STATE_PATH,
+            "AUTH_FAIL_OPEN": webapp.AUTH_FAIL_OPEN,
+            "load_token": webapp.load_token,
+        }
+        self.snap_path = root / "ui_snapshot.json"
+        self.snap_path.write_text("{}", encoding="utf-8")
+        webapp.STATE_PATH = self.snap_path
+        webapp.FALLBACK_STATE_PATH = self.snap_path
+        webapp.AUTH_FAIL_OPEN = True
+        webapp.load_token = lambda: None
+        self.client = webapp.app.test_client()
+
+    def tearDown(self) -> None:
+        for k, v in self._orig.items():
+            setattr(self.webapp, k, v)
+        self.tmp.cleanup()
+
+    def test_status_view_key_null_when_absent(self) -> None:
+        res = self.client.get("/api/state")
+        self.assertEqual(res.status_code, 200)
+        body = res.get_json()
+        self.assertIn("status_view", body)
+        self.assertIsNone(body["status_view"])
+
+    def test_status_view_key_populated_when_present(self) -> None:
+        view = fabric_view.status_view_from_snapshot(StatusViewTests.SNAP)
+        self.snap_path.with_name("ui_status_view.json").write_text(view.model_dump_json(), encoding="utf-8")
+        res = self.client.get("/api/state")
+        self.assertEqual(res.status_code, 200)
+        body = res.get_json()
+        self.assertIsNotNone(body["status_view"])
+        self.assertEqual(body["status_view"]["product"], "edge")
+        self.assertEqual(body["status_view"]["posture"], "contain")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fabric_adapters_v1.py
+++ b/tests/test_fabric_adapters_v1.py
@@ -22,6 +22,17 @@ from azazel_edge.explanations import DecisionExplainer
 from azazel_edge.explanations import fabric_adapter as expl_fabric
 from azazel_edge import fabric_view
 
+try:  # the shared library is an optional extra (requirements/fabric.txt)
+    import azazel_fabric  # noqa: F401
+
+    HAVE_FABRIC = True
+except Exception:  # pragma: no cover - CI runs without the private package
+    HAVE_FABRIC = False
+
+needs_fabric = unittest.skipUnless(
+    HAVE_FABRIC, "azazel-fabric not installed (optional extra; see requirements/fabric.txt)"
+)
+
 
 def _sample_explain(explainer: DecisionExplainer):
     return explainer.explain(
@@ -41,6 +52,7 @@ def _sample_explain(explainer: DecisionExplainer):
 
 
 class DecisionProjectionTests(unittest.TestCase):
+    @needs_fabric
     def test_projection_written_with_expected_shape(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp) / "decision-explanations.jsonl"
@@ -57,6 +69,7 @@ class DecisionProjectionTests(unittest.TestCase):
             self.assertEqual(row["release_condition"], "noc_recovers")
             self.assertIsInstance(row["confidence"], float)
 
+    @needs_fabric
     def test_trust_capsule_projection_field_mapping(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp) / "decision-explanations.jsonl"
@@ -99,6 +112,7 @@ class DecisionProjectionTests(unittest.TestCase):
 
 
 class AuditProjectionTests(unittest.TestCase):
+    @needs_fabric
     def test_projection_to_separate_file_and_chain_untouched(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             chain = Path(tmp) / "audit.jsonl"
@@ -160,6 +174,7 @@ class StatusViewTests(unittest.TestCase):
         "attack": {"suricata_alert": True},
     }
 
+    @needs_fabric
     def test_build_status_view_carries_full_snapshot(self) -> None:
         view = fabric_view.status_view_from_snapshot(self.SNAP)
         self.assertIsNotNone(view)
@@ -170,6 +185,7 @@ class StatusViewTests(unittest.TestCase):
         # Peer, not subset: the whole snapshot rides in product_view.
         self.assertEqual(data["product_view"]["edge_snapshot"], self.SNAP)
 
+    @needs_fabric
     def test_write_alongside_and_noop_without_package(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             snap_path = Path(tmp) / "ui_snapshot.json"
@@ -222,6 +238,7 @@ class ApiStateStatusViewTests(unittest.TestCase):
         self.assertIn("status_view", body)
         self.assertIsNone(body["status_view"])
 
+    @needs_fabric
     def test_status_view_key_populated_when_present(self) -> None:
         view = fabric_view.status_view_from_snapshot(StatusViewTests.SNAP)
         self.snap_path.with_name("ui_status_view.json").write_text(view.model_dump_json(), encoding="utf-8")

--- a/tests/test_runtime_dependency_contract.py
+++ b/tests/test_runtime_dependency_contract.py
@@ -69,10 +69,10 @@ def test_runtime_dependencies_cover_imports():
     module_to_requirement = {
         "PIL": "pillow",
         "yaml": "pyyaml",
-        # Shared contracts library: import namespace azazel_fabric, dist azazel-fabric.
-        "azazel_fabric": "azazel-fabric",
     }
     optional_modules = {
+        # Optional Fabric integration extra (requirements/fabric.txt); guarded import.
+        "azazel_fabric",
         # Hardware-only dependency provided by device-specific setup.
         "waveshare_epd",
     }

--- a/tests/test_runtime_dependency_contract.py
+++ b/tests/test_runtime_dependency_contract.py
@@ -27,7 +27,9 @@ def _runtime_requirement_names() -> set[str]:
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
-        normalized = line.split(">=")[0].split("==")[0].split("<")[0].strip().lower()
+        # Handle PEP 508 URL pins ("name @ git+https://...") by taking the name.
+        base = line.split("@", 1)[0]
+        normalized = base.split(">=")[0].split("==")[0].split("<")[0].strip().lower()
         if normalized:
             names.add(normalized)
     return names
@@ -67,6 +69,8 @@ def test_runtime_dependencies_cover_imports():
     module_to_requirement = {
         "PIL": "pillow",
         "yaml": "pyyaml",
+        # Shared contracts library: import namespace azazel_fabric, dist azazel-fabric.
+        "azazel_fabric": "azazel-fabric",
     }
     optional_modules = {
         # Hardware-only dependency provided by device-specific setup.


### PR DESCRIPTION
## Summary

`docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md` §3(Fabric移行計画のPhase 3)を実装。オーナー指示「Edgeはシリーズ最大のFabric消費者であるべき」を受け、計画の3アダプタに加えStatusViewも実装。**全てガード付きimportの併記出力(emit-alongside)で、`azazel-fabric`未導入時は完全no-op——既存動作のゼロ変更**:

- **DecisionExplanation射影**(§3.1): `fabric-decision-explanations.jsonl` へ併記。Edge固有ストリームはバイト同一を検証済み。lossy射影(`selected_action`→`ActionIntent`、未知kind→`observe`、`why_chosen`→`reason`)
- **TrustCapsule射影**(§3.2): `fabric-trust-capsules.jsonl`。計画書のフィールド対応(`hmac_sig`→`hmac`、`timestamp`→`issued_at`、`config_hash`はexplanation側から)
- **AuditEvent射影**(§3.3): チェーン書込**後**に別ファイル `<name>.fabric.jsonl` へ。`verify_chain()`不変をテストで証明。`decision_logger`は§3.4どおり据え置き
- **StatusView**(スコープ拡張): `ui_status_view.json` をスナップショット併記でemit、`/api/state` に `status_view` キー追加(未導入時null)。`product_view={"edge_snapshot": …}` のpeer-not-subset型
- §8の未解決論点は計画書の推奨どおり解決し、計画書に「as implemented」を追記

依存: `azazel-fabric @ git+…@ce357af7`(コミット固定。**v0.3.0タグ発行後に`@v0.3.0`へ切替予定**)

## Type of change

- [x] feat — new feature

## Checklist

- [x] `PYTHONPATH=. pytest -q` passes — **502 passed**(新規12本追加・新規失敗ゼロ。12failは本変更前から存在する`test_bhusa_*`のサンドボックス起因、stash比較で確認済み)
- [x] Related documentation updated in this PR(adapter plan / API_REFERENCE / CHANGELOG / README)
- [x] Deterministic First principle not violated(射影は助言的な併記出力のみ。アービタ・評価器・証拠プレーンは不変)
- [x] Raspberry Pi constraints not broken(pydantic v2のみのazazel-fabricを追加。射影はbest-effortで書込1回/イベント)
- [x] No changes to `installer/`, `systemd/`, `security/` — 未変更

## Notes for reviewers

- 監査ハッシュチェーンの完全性が最重要レビュー点です: Fabric射影は`P0AuditLogger.log()`のチェーン書込完了**後**、別ファイルへ。既存`verify_chain`系テストは全green+分離を検証する新規テストを追加
- `tests/test_runtime_dependency_contract.py`にPEP 508 `name @ url` pin形式と`azazel_fabric`→`azazel-fabric`のimport/dist名対応を追加(これがないと新pinが偽陽性failになるため)

## Related issues

Azazel-Fabric側: migration-plan Phase 3 / issue-breakdown Issue 5の後続実装。Edge↔Knowledge統合(cti_contracts実利用)はFY2027+のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94)_