### PR TITLE
chore: Fabric pin を v0.3.0 タグへ切替

### DIFF
--- a/requirements/fabric.txt
+++ b/requirements/fabric.txt
@@ -9,6 +9,6 @@
 # environment with GitHub credentials for 01rabbit/Azazel-Fabric (developer
 # machine, provisioned appliance). CI intentionally does not install this file.
 #
-# Import namespace: azazel_fabric. Pinned to the exact commit merged to main
-# (v0.3.0 pending tag); switch to @v0.3.0 once the tag is published.
-azazel-fabric @ git+https://github.com/01rabbit/Azazel-Fabric.git@ce357af727ca2d7ddd3c108bd6843c682b4dee8b
+# Import namespace: azazel_fabric. Tag-pinned per Azazel-Fabric
+# design-principles.md §6.
+azazel-fabric @ git+https://github.com/01rabbit/Azazel-Fabric.git@v0.3.0


### PR DESCRIPTION
## Summary

v0.3.0 タグ発行を受け、`requirements/fabric.txt` の pin をコミット固定(`@ce357af7…`)からタグ(`@v0.3.0`)へ切替。同一コミットを指すため解決結果は不変。古い「タグ発行待ち」コメントも整理。

## Type of change

- [x] chore — build/CI/config

## Checklist

- [x] `PYTHONPATH=. pytest -q` passes — 対象テスト(fabric adapters 12本 + runtime dependency contract)13 passed。`azazel_fabric` 0.3.0 のインストール解決を確認
- [x] Related documentation updated in this PR — 変更はpinファイル内コメントのみで完結
- [x] Deterministic First principle not violated — 依存解決先の表記変更のみ
- [x] Raspberry Pi constraints not broken
- [x] No changes to `installer/`, `systemd/`, `security/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94)_