### PR TITLE
chore: Azazel-Fabric v0.4.0採用 — audit射影をヘルパへ委譲

### DIFF
--- a/docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md
+++ b/docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md
@@ -27,6 +27,23 @@
 > The §8 open questions are resolved as-implemented (see §8). The design body
 > below is retained as the authority for the projection mappings.
 
+> **2026-07-11 status update — pin bumped to v0.4.0; audit adapter now
+> delegates to `azazel_fabric.audit`.** `requirements/fabric.txt` is pinned at
+> the `v0.4.0` tag. The §3.3 AuditEvent projection
+> (`py/azazel_edge/audit/fabric_adapter.py`) no longer hand-rolls the
+> `AuditEvent(...)` envelope or calls `model_dump_json()` directly — it
+> delegates envelope construction to `azazel_fabric.audit.project_audit_event`
+> (v0.4.0) and serialization to `azazel_fabric.audit.to_jsonl_line`, passing
+> Edge's own `chain_hash`-based `event_id` through explicitly so the shared
+> helper's `make_event_id` convention never overrides it. The hash-chain write
+> path (`P0AuditLogger`) and its `verify_chain()` are untouched. The field set
+> on the emitted `AuditEvent` is unchanged; line formatting changed from
+> Pydantic's `model_dump_json()` to `to_jsonl_line`'s sorted-key/compact JSON
+> (content-identical, not byte-identical — see `docs/CHANGELOG.md`). The §3.1
+> DecisionExplanation and §3.2 TrustCapsule projections, and the StatusView
+> path, are unchanged by this update — v0.4.0 does not add a schema-shape
+> helper for those.
+
 Status: **Design note / proposal — now implemented (Phase 3, 2026-07-10).** The
 plan below defined the adapters; they are now built as described. This was the
 deliverable for Issue 5 in `Azazel-Common/docs/issue-breakdown.md`, implementing

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,21 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Azazel-Fabric の pin を `v0.3.0` → `v0.4.0` に更新(`requirements/fabric.txt`)。
+  `py/azazel_edge/audit/fabric_adapter.py` の AuditEvent 射影を、v0.4.0 で追加
+  された `azazel_fabric.audit.project_audit_event`/`to_jsonl_line` に委譲する
+  よう小さくリファクタ(ドロップイン、挙動変更ゼロ)。`event_id` は従来どおり
+  Edge 側の `chain_hash`(フォールバック `trace_id:kind`)規約を明示的に渡すため
+  `project_audit_event` の `make_event_id` デフォルトには委譲しない。ハッシュ
+  チェーン書込み経路(`P0AuditLogger`)は無変更。emit されるフィールド集合は
+  不変だが、シリアライズが Pydantic の `model_dump_json()`(挿入順・空白区切り)
+  から `to_jsonl_line`(キーソート・コンパクト区切り)に変わり、
+  `<name>.fabric.jsonl` の行はバイト同一ではなくなった(内容は意味的に同一。
+  このストリームを行位置/バイト比較で読むコンシューマは存在しない)。
+  `tests/test_fabric_adapters_v1.py` の `ApiStateStatusViewTests` を
+  `azazel_fabric.testing.make_status_view` で簡素化(StatusView のマッピング
+  ロジック自体は `StatusViewTests` で別途検証済みのため、API 読み戻しテストは
+  Edge 独自のスナップショット変換に依存しない汎用フィクスチャへ切替)。
 - Azazel-Fabric の pin をオプションの `requirements/fabric.txt` に分離(Fabric
   リポジトリは private のため、無認証環境 = CI では解決不能。全統合点は
   ガード付き no-op なので未導入でも動作は同一。導入時のみ射影が有効化)。

--- a/py/azazel_edge/audit/fabric_adapter.py
+++ b/py/azazel_edge/audit/fabric_adapter.py
@@ -8,6 +8,23 @@ shared ``azazel_fabric.schema.AuditEvent`` envelope and appended to a
 
 The shared package is imported optionally: if ``azazel_fabric`` is not
 installed this is a safe no-op. No function here ever raises into its caller.
+
+**v0.4.0 update:** the projection now delegates to
+``azazel_fabric.audit.project_audit_event`` (envelope construction) and
+``azazel_fabric.audit.to_jsonl_line`` (serialization) instead of hand-rolling
+an ``AuditEvent(...)`` call and ``model_dump_json()``. This is a pure
+plumbing change: the ``event_id`` convention below (``chain_hash``, falling
+back to ``trace_id:kind``) is passed explicitly to ``project_audit_event``,
+so it is *not* overridden by that helper's own ``make_event_id`` default —
+Edge's chain-hash-based id scheme is unchanged. The field set on the emitted
+``AuditEvent`` is unchanged. The one observable difference is serialization
+formatting: ``to_jsonl_line`` writes compact, key-sorted JSON
+(``json.dumps(..., sort_keys=True, separators=(",", ":"))``) where the
+previous code used Pydantic's default ``model_dump_json()`` (insertion-order
+keys, space-padded separators). Line content is semantically identical
+(same keys, same values) — no consumer parses these lines positionally or by
+byte comparison, so this is treated as within "drop-in, zero behavior
+change."
 """
 
 from __future__ import annotations
@@ -20,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 try:  # optional dependency — pinned in requirements/runtime.txt, absent is fine
     from azazel_fabric.schema import AuditEvent
+    from azazel_fabric.audit import project_audit_event, to_jsonl_line
 
     HAVE_AZAZEL_FABRIC = True
 except Exception:  # pragma: no cover - exercised only when the dep is absent
@@ -45,6 +63,12 @@ def build_audit_event(record: Dict[str, Any]) -> "Optional[AuditEvent]":
     in ``AuditEvent.payload`` (Fabric does not model a hash chain);
     ``config_hash``/``hmac`` stay ``None`` (not on the base record). Returns
     ``None`` if Fabric is not installed.
+
+    Envelope construction delegates to ``azazel_fabric.audit.project_audit_event``
+    (v0.4.0). Edge's own ``event_id`` is computed here and passed through
+    explicitly, so ``project_audit_event``'s ``make_event_id`` default (a
+    ``product:event_type:timestamp`` convention) never applies — Edge keeps its
+    chain-hash-based id scheme.
     """
     if not HAVE_AZAZEL_FABRIC:
         return None
@@ -60,13 +84,13 @@ def build_audit_event(record: Dict[str, Any]) -> "Optional[AuditEvent]":
         # Fall back to a positional identity when the chain hash is unavailable.
         event_id = f"{record.get('trace_id') or ''}:{record.get('kind') or ''}"
 
-    return AuditEvent(
-        event_id=event_id,
-        trace_id=str(record.get("trace_id") or ""),
-        timestamp=str(record.get("ts") or ""),
+    return project_audit_event(
         product="edge",
         event_type=str(record.get("kind") or ""),
+        timestamp=str(record.get("ts") or ""),
+        trace_id=str(record.get("trace_id") or ""),
         payload=payload,
+        event_id=event_id,
         config_hash=None,
         hmac=None,
     )
@@ -76,7 +100,10 @@ def project_audit_record(record: Dict[str, Any], native_path: Path) -> None:
     """Append a Fabric AuditEvent projection to the sibling stream. Best-effort.
 
     A no-op when Fabric is absent; never raises into the caller and never writes
-    to the chained ``native_path``.
+    to the chained ``native_path``. Serialization delegates to
+    ``azazel_fabric.audit.to_jsonl_line`` (v0.4.0) — see the module docstring
+    for the (purely cosmetic) formatting difference from the prior
+    ``model_dump_json()`` call.
     """
     if not HAVE_AZAZEL_FABRIC:
         return
@@ -87,6 +114,6 @@ def project_audit_record(record: Dict[str, Any], native_path: Path) -> None:
         out_path = fabric_stream_path(Path(native_path))
         out_path.parent.mkdir(parents=True, exist_ok=True)
         with out_path.open("a", encoding="utf-8") as fh:
-            fh.write(event.model_dump_json() + "\n")
+            fh.write(to_jsonl_line(event) + "\n")
     except Exception as exc:  # pragma: no cover - defensive; must never raise
         logger.debug("fabric_audit_projection_failed: %s", exc)

--- a/requirements/fabric.txt
+++ b/requirements/fabric.txt
@@ -11,4 +11,4 @@
 #
 # Import namespace: azazel_fabric. Tag-pinned per Azazel-Fabric
 # design-principles.md §6.
-azazel-fabric @ git+https://github.com/01rabbit/Azazel-Fabric.git@v0.3.0
+azazel-fabric @ git+https://github.com/01rabbit/Azazel-Fabric.git@v0.4.0

--- a/tests/test_fabric_adapters_v1.py
+++ b/tests/test_fabric_adapters_v1.py
@@ -240,7 +240,14 @@ class ApiStateStatusViewTests(unittest.TestCase):
 
     @needs_fabric
     def test_status_view_key_populated_when_present(self) -> None:
-        view = fabric_view.status_view_from_snapshot(StatusViewTests.SNAP)
+        # This endpoint only needs *some* valid StatusView on disk to prove it
+        # reads back and surfaces one — the mapping from an Edge snapshot is
+        # already covered by StatusViewTests above — so build the fixture with
+        # azazel_fabric.testing.make_status_view instead of round-tripping
+        # through fabric_view's own mapping logic.
+        from azazel_fabric.testing import make_status_view
+
+        view = make_status_view(product="edge", posture="contain")
         self.snap_path.with_name("ui_status_view.json").write_text(view.model_dump_json(), encoding="utf-8")
         res = self.client.get("/api/state")
         self.assertEqual(res.status_code, 200)


### PR DESCRIPTION
## Summary

Fabric v0.4.0リリースへの追随(Phase 5の消費者側・最終ピース):

- `requirements/fabric.txt`: pin `@v0.3.0` → `@v0.4.0`
- **audit射影の委譲**: `audit/fabric_adapter.py` のエンベロープ構築を `azazel_fabric.audit.project_audit_event`、直列化を `to_jsonl_line` へ。Edgeの`event_id`規約(chain_hash由来)は明示指定で不変。**ハッシュチェーン書込経路は不変**(`verify_chain`テストgreen)
- 非動作的差分1点(CHANGELOGに記録): `<name>.fabric.jsonl` のJSONがソート済みキー・コンパクト区切りに。フィールド集合は同一で、バイト単位で読む消費者は存在しない
- tests: `/api/state`読み戻しテストのフィクスチャを`azazel_fabric.testing.make_status_view`へ(Edge自身の写像を検証するテストは意図的に据え置き——ファクトリで置換すると検証対象そのものを迂回するため)
- `paths`/`api`/`notify`は自然な採用先がないため見送り

## Type of change

- [x] chore — build/CI/config
- [x] refactor — no behavior change(audit射影の委譲)

## Checklist

- [x] `PYTHONPATH=. pytest -q` passes — フルスイート**502 passed**、12 failは既知のbhusa系サンドボックス起因(基準線と完全一致、新規失敗ゼロ)
- [x] Related documentation updated in this PR(CHANGELOG / adapter plan status note)
- [x] Deterministic First principle not violated
- [x] Raspberry Pi constraints not broken(依存追加なし)
- [x] No changes to `installer/`, `systemd/`, `security/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94)_