### PR TITLE
docs: SECURITY.md追加とCONTRIBUTING整合(シリーズ統一)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Examples: `feat/decision-trust-capsule`, `fix/epd-help-crash`, `docs/readme-reor
 
 - 1 PR = 1 purpose. Do not mix unrelated changes.
 - Every PR must include:
-  - [ ] `PYTHONPATH=. pytest -q` passes
+  - [ ] `PYTHONPATH=. pytest -q` passes (baseline: 502 passing; pre-existing `bhusa` sandbox-only failures in constrained/offline environments are not your responsibility)
   - [ ] `cd rust/azazel-edge-core && cargo test` passes (if Rust touched or validation scope includes Rust)
   - [ ] Related documentation updated in the same PR
   - [ ] If API surface or runtime configuration changed, update `docs/API_REFERENCE.md` and/or `docs/CONFIGURATION.md` in the same PR
@@ -47,3 +47,11 @@ cd rust/azazel-edge-core && cargo test
 # unified helper
 bin/azazel-edge-dev test-all
 ```
+
+## Security
+
+Found a vulnerability? Report it privately per [SECURITY.md](SECURITY.md) — never via a public issue.
+
+## License
+
+By contributing, you agree your contributions are licensed under the project's [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+Azazel-Edge (AZ-01, codename `SENTINEL`) is a deception/delay gateway that faces hostile traffic by design — scapegoat surfaces exist to be probed, bound, and slowed by attackers. The boundary that matters is not those surfaces; it is the line between them and the protected segment / control plane (deterministic arbiter, nftables/tc policy, audit chain, management interfaces).
+
+## Reporting a vulnerability
+
+Report privately via **GitHub Security Advisories**:
+<https://github.com/01rabbit/Azazel-Edge/security/advisories/new>
+
+Do **not** open a public issue for a suspected vulnerability.
+
+Include: affected version or commit hash; deployment profile (e.g. field/vehicle/humanitarian, enabled feature flags); reproduction steps or a minimal PoC; observed impact and, if known, the affected component.
+
+No bounty program. Reporters are credited in the advisory unless anonymity is requested.
+
+## Response targets
+
+- Acknowledgement: within 7 days
+- Initial assessment (severity, affected versions): within 14 days
+- Fix and disclosure are coordinated with the reporter.
+
+## Scope
+
+**In scope** — anything that crosses the boundary described above:
+
+- Authentication/authorization bypass on the web UI or API (token, mTLS, RBAC role checks)
+- Escape from a scapegoat/deception surface — or from the captive portal / portal-viewer — into the protected segment or control plane
+- Bypass of nftables/tc policy enforcement
+- Audit hash-chain integrity break
+- Privilege escalation via the installer or systemd unit files
+- Secrets leakage (tokens, certificate/key material) through any endpoint, including the EPD web preview
+- Manipulation of the deterministic arbiter's decisions via crafted sensor input, where it crosses a documented security boundary
+- AI-assist (local Ollama) prompt-injection paths that cross an authority boundary — AI is assist-only; anything letting it trigger or execute an unapproved action is in scope
+
+**Out of scope**:
+
+- Attacker interaction with deception surfaces — binding, slowing, or observing attackers there is the product working as intended
+- Degraded throughput on delaying paths
+- Findings that require pre-existing root on the appliance
+
+## Supported versions
+
+Latest tagged release and `main`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   ガード付き no-op なので未導入でも動作は同一。導入時のみ射影が有効化)。
 
 ### Added
+- Added `SECURITY.md` (private GitHub Security Advisory reporting process, response targets, and appliance-flavored in/out-of-scope boundary between scapegoat/deception surfaces and the protected segment / control plane). Aligned `CONTRIBUTING.md` with a "Security" section pointing to it and a "License" section (MIT), and updated the pytest checklist line with the current baseline (502 passing; known `bhusa` sandbox-only failures in constrained/offline environments).
 - Azazel-Fabric adoption — Phase 3 (2026-07-10): Edge now ships the three §3
   emit-alongside projections from `docs/AZAZEL_COMMON_EDGE_ADAPTER_PLAN.md` plus
   an owner-directed StatusView extension, making Edge the top consumer of the


### PR DESCRIPTION
## Summary

シリーズ統一のガバナンス文書整備(Edge分):

- **SECURITY.md**(新規): 欺瞞ゲートウェイの境界定義を明確化——「スケープゴート面は攻撃されるのが前提。守るべき境界は保護セグメント/制御プレーン」。in-scope: 認証認可バイパス/欺瞞面・captive・portal-viewerからの脱出/nftables・tcバイパス/監査チェーン完全性/installer・systemd権限昇格/EPDプレビュー含む秘密漏えい/アービタ操作/権限境界を越えるOllamaプロンプト注入。out-of-scope: 欺瞞面への攻撃者干渉(=製品の意図)等
- **CONTRIBUTING.md**: 本ファイルはシリーズの温度感基準のため軽微な整合のみ(Security/License節の追記、pytest基準線注記)

## Type of change

- [x] docs — documentation only

## Checklist

- [ ] `PYTHONPATH=. pytest -q` passes — docsのみのため未実行
- [x] Related documentation updated in this PR(CHANGELOG)
- [x] Deterministic First principle not violated
- [x] Raspberry Pi constraints not broken
- [x] No changes to `installer/`, `systemd/`, `security/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94)_