### PR TITLE
fix(web): truthful dashboard baseline — cold-start, stale advisory, and a clean dev baseline

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -3873,8 +3873,27 @@ def _pid_running(pid_path: Path, expected_cmd: str = "") -> bool:
     return True
 
 
+def _dev_healthy_baseline() -> bool:
+    """True when the dev-only healthy-baseline override is enabled.
+
+    Set ``AZAZEL_DEV_HEALTHY_BASELINE=1`` only in the macOS dev profile
+    (``tools/macdev/env.sh``). On a dev host the systemd/pid service probes below
+    always report OFF even though devstack is running the components, so this
+    override reports them healthy for a clean baseline. Never set on an
+    appliance/production deployment.
+    """
+    return str(os.environ.get("AZAZEL_DEV_HEALTHY_BASELINE", "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 def _service_active(service: str) -> bool:
     """Check systemd service status without requiring root."""
+    if _dev_healthy_baseline():
+        return True
     try:
         result = subprocess.run(
             ["/bin/systemctl", "is-active", service],
@@ -4100,6 +4119,11 @@ def _container_running(name: str) -> bool:
 
 def get_monitoring_state() -> Dict[str, str]:
     """Return ON/OFF status for local monitoring daemons."""
+    if _dev_healthy_baseline():
+        # Dev profile: the monitor daemons are represented by the devstack event
+        # pipeline (dummy-eve feeds the eve.json the core tails). Report them ON so
+        # the baseline reads clean; dev-only (see _dev_healthy_baseline).
+        return {"opencanary": "ON", "suricata": "ON", "ntfy": "ON"}
     # Prefer systemd state to avoid pidfile permission issues
     opencanary_ok = (
         _service_active("opencanary@az_canary.service")

--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -4151,8 +4151,47 @@ def get_mode_state() -> Dict[str, Any]:
     }
 
 
+def _bootstrap_checking_state(source: str, note: str = "") -> Dict[str, Any]:
+    """Safe CHECKING default for when no snapshot is available yet.
+
+    Mirrors the control daemon's bootstrap seed (``_default_snapshot_seed`` in
+    ``azazel_edge_control.daemon``) so a freshly started stack renders an
+    "initializing / checking" dashboard instead of a hard error. Kept
+    ``ok=True`` on purpose: ``/api/state`` and ``/api/dashboard/summary`` are the
+    dashboard's only *required* fetches, and returning ``ok=False`` here makes the
+    frontend throw and show its error toast + red connection chip before the
+    daemon has had a chance to write its first snapshot. The ``bootstrap`` flag,
+    ``source``, and ``bootstrap_reason`` let callers and telemetry tell this
+    placeholder apart from a real snapshot.
+    """
+    payload: Dict[str, Any] = {
+        "ok": True,
+        "bootstrap": True,
+        "source": source,
+        "now_time": time.strftime("%H:%M:%S"),
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "user_state": "CHECKING",
+        "internal": {"state_name": "PROBE", "suspicion": 0, "decay": 0},
+        "recommendation": "Initializing",
+        "connection": {
+            "wifi_state": "DISCONNECTED",
+            "internet_check": "UNKNOWN",
+        },
+        "evidence": [],
+    }
+    if note:
+        payload["bootstrap_reason"] = note
+    return payload
+
+
 def read_state() -> Dict[str, Any]:
-    """Read snapshot from control-plane first, then filesystem fallback."""
+    """Read snapshot from control-plane first, then filesystem fallback.
+
+    When no snapshot is available yet (cold start before the control daemon has
+    seeded ``ui_snapshot.json``) a bootstrap ``CHECKING`` state is returned rather
+    than an error, so the dashboard shows "initializing" instead of a hard
+    failure. See :func:`_bootstrap_checking_state`.
+    """
     try:
         if cp_read_snapshot_payload is not None:
             data, source = cp_read_snapshot_payload(prefer_control_plane=True, logger=app.logger)
@@ -4167,15 +4206,13 @@ def read_state() -> Dict[str, Any]:
         if not path.exists():
             # Try fallback path (for dev/testing)
             path = FALLBACK_STATE_PATH
-        
+
         if not path.exists():
-            return {
-                "ok": False,
-                "error": "ui_snapshot.json not found",
-                "source": "NONE",
-                "ts": time.strftime("%Y-%m-%dT%H:%M:%S")
-            }
-        
+            # Cold start: the daemon has not seeded a snapshot yet. Return a
+            # benign CHECKING placeholder instead of an error so the UI renders
+            # "initializing" rather than an error toast + red connection chip.
+            return _bootstrap_checking_state("NONE", "ui_snapshot.json not found")
+
         warn_if_legacy_path(path, logger=app.logger)
         data = _parse_json_dict_lenient(path.read_text(encoding="utf-8"))
         if not data:
@@ -4185,11 +4222,10 @@ def read_state() -> Dict[str, Any]:
         data["now_time"] = time.strftime("%H:%M:%S")
         return data
     except Exception as e:
-        return {
-            "ok": False,
-            "error": f"Failed to read state: {str(e)}",
-            "ts": time.strftime("%Y-%m-%dT%H:%M:%S")
-        }
+        # Degrade to a CHECKING placeholder rather than surfacing a hard error to
+        # the dashboard's required fetches; log the real cause for diagnostics.
+        app.logger.warning("read_state failed, returning bootstrap CHECKING state: %s", e)
+        return _bootstrap_checking_state("ERROR", f"read failed: {e}")
 
 
 def read_status_view() -> Optional[Dict[str, Any]]:

--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -2445,6 +2445,15 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
         top_dst = ""
         top_sid = 0
         top_severity = 0
+        # An expired advisory must not keep driving SOC threat state. Without
+        # this, a stale second-pass SOC block (e.g. yesterday's attack) still
+        # pins the threat glance to CRITICAL below (see soc_status_from_second_pass),
+        # so an idle/benign board never returns to quiet. Clear the stale
+        # second-pass detail so the threat level falls back to the live snapshot
+        # signals (quiet when suspicion and suricata counts are clear).
+        second_pass_detail = {}
+        second_pass_soc = {}
+        second_pass_status = "idle"
     path_scope = ("全 uplink 利用者" if lang == "ja" else "all uplink clients") if str(connection.get("internet_check") or "").upper() == "FAIL" else (
         ("DNS 影響利用者" if lang == "ja" else "dns-affected clients") if _as_int(network_health.get("dns_mismatch"), 0) > 0 else ("広域影響なし" if lang == "ja" else "no broad impact indicated")
     )

--- a/py/azazel_edge/sensors/network_health.py
+++ b/py/azazel_edge/sensors/network_health.py
@@ -8,12 +8,29 @@ Borrowed/trimmed from Azazel-Gadget first_minute probes + wifi safety checks.
 from __future__ import annotations
 
 import json
+import os
 import socket
 import subprocess
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
+
+
+def _dev_healthy_baseline() -> bool:
+    """True when the dev-only healthy-baseline override is enabled.
+
+    Set ``AZAZEL_DEV_HEALTHY_BASELINE=1`` (only in the macOS dev profile, see
+    ``tools/macdev/env.sh``) to present a clean SAFE baseline on a development
+    host that lacks the Linux probes (``ip``/``iw``/``dig``) and real uplink.
+    Never set on an appliance/production deployment.
+    """
+    return str(os.environ.get("AZAZEL_DEV_HEALTHY_BASELINE", "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 class NetworkHealthMonitor:
@@ -31,6 +48,24 @@ class NetworkHealthMonitor:
 
     def assess(self, iface: str, gateway_ip: str = "") -> Dict[str, Any]:
         now = time.time()
+        if _dev_healthy_baseline():
+            # Dev host has no Linux link/route/dns probes; present a clean SAFE
+            # baseline so an idle dashboard is green and an injected attack shows
+            # a clear visual change. Dev-only (see _dev_healthy_baseline).
+            return {
+                "status": "SAFE",
+                "internet_check": "OK",
+                "iface": str(iface or "-"),
+                "link": {"connected": "1"},
+                "signals": [],
+                "wifi_tags": [],
+                "captive_portal": "NO",
+                "captive_portal_reason": "DEV_BASELINE",
+                "dns_mismatch": 0,
+                "route_anomaly": False,
+                "dev_baseline": True,
+                "checked_at_epoch": now,
+            }
         if self._last_result and (now - self._last_ts) < self.cache_ttl_sec:
             return dict(self._last_result)
 

--- a/py/azazel_edge_control/daemon.py
+++ b/py/azazel_edge_control/daemon.py
@@ -94,6 +94,20 @@ NETWORK_HEALTH = NetworkHealthMonitor(
     captive_url=os.environ.get("AZAZEL_CAPTIVE_CHECK_URL", "http://connectivitycheck.gstatic.com/generate_204"),
 )
 SURICATA_ADVISORY_TTL_SEC = int(os.environ.get("AZAZEL_SURICATA_ADVISORY_TTL_SEC", "300"))
+
+
+def _dev_healthy_baseline() -> bool:
+    """True when the dev-only healthy-baseline override is enabled.
+
+    Set ``AZAZEL_DEV_HEALTHY_BASELINE=1`` only in the macOS dev profile
+    (``tools/macdev/env.sh``); never on an appliance/production deployment.
+    """
+    return str(os.environ.get("AZAZEL_DEV_HEALTHY_BASELINE", "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 NOC_REFRESH_SEC = max(5.0, float(os.environ.get("AZAZEL_NOC_REFRESH_SEC", "20")))
 NOC_EVALUATOR = NocEvaluator()
 NOC_CACHE_LOCK = threading.Lock()
@@ -1229,16 +1243,23 @@ def _enrich_snapshot(data: dict[str, Any]) -> dict[str, Any]:
     connection["captive_portal_reason"] = str(
         health.get("captive_portal_reason", connection.get("captive_portal_reason", "NOT_CHECKED"))
     )
-    try:
-        noc_projection = _compute_live_noc_projection(
-            up_if=str(monitor_scope.get("up_if") or up_if),
-            down_if=str(monitor_scope.get("down_if") or enriched.get("down_if") or "usb0"),
-            gateway_ip=str(monitor_scope.get("gateway_ip") or gateway_ip),
-        )
-        if isinstance(noc_projection, dict):
-            enriched.update(noc_projection)
-    except Exception as exc:
-        logger.debug(f"Failed to evaluate live NOC projection: {exc}")
+    if _dev_healthy_baseline():
+        # Dev host cannot run the live NOC probes, so the projection would report
+        # a degraded path/service baseline. Skip it under the dev-only override so
+        # the idle dashboard reads healthy; real evidence still flows through the
+        # SOC/threat path and drives the visible change on injection.
+        logger.debug("dev healthy baseline: skipping live NOC projection")
+    else:
+        try:
+            noc_projection = _compute_live_noc_projection(
+                up_if=str(monitor_scope.get("up_if") or up_if),
+                down_if=str(monitor_scope.get("down_if") or enriched.get("down_if") or "usb0"),
+                gateway_ip=str(monitor_scope.get("gateway_ip") or gateway_ip),
+            )
+            if isinstance(noc_projection, dict):
+                enriched.update(noc_projection)
+        except Exception as exc:
+            logger.debug(f"Failed to evaluate live NOC projection: {exc}")
 
     user_state = str(enriched.get("user_state", "") or "").upper()
     signals = health.get("signals", []) if isinstance(health.get("signals"), list) else []

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -446,6 +446,38 @@ class DashboardDataContractTests(unittest.TestCase):
         self.assertEqual(state["user_state"], "CHECKING")
         self.assertEqual(state["source"], "ERROR")
 
+    def test_stale_advisory_does_not_pin_threat_critical(self) -> None:
+        # A live-but-idle snapshot whose advisory the daemon flagged as expired
+        # must not keep the threat glance at CRITICAL from the old second-pass SOC.
+        now = time.time()
+        state = {
+            "ok": True,
+            "snapshot_epoch": now,
+            "now_time": "12:00:00",
+            "user_state": "CHECKING",
+            "internal": {"state_name": "PROBE", "suspicion": 0, "decay": 0},
+            "suricata_critical": 0,
+            "suricata_warning": 0,
+            "attack": {"stale_advisory_expired": True},
+            "connection": {"internet_check": "UNKNOWN"},
+            "network_health": {"status": "SUSPECTED", "signals": []},
+        }
+        advisory = {
+            "ts": now - 90000,  # ~25h old
+            "attack_type": "SSH Brute Force",
+            "second_pass": {"status": "complete", "soc": {"status": "critical"}},
+        }
+        webapp.cp_read_snapshot_payload = None
+        webapp.STATE_PATH.write_text(json.dumps(state), encoding="utf-8")
+        webapp.AI_ADVISORY_PATH.write_text(json.dumps(advisory), encoding="utf-8")
+
+        response = self.client.get("/api/dashboard/summary")
+        self.assertEqual(response.status_code, 200)
+        soc_focus = response.get_json()["soc_focus"]
+        self.assertEqual(soc_focus["threat_level"], "quiet")
+        # The expired advisory's attack label must not leak through either.
+        self.assertNotIn("SSH Brute Force", str(soc_focus.get("attack_type", "")))
+
     def test_dashboard_summary_normal_assurance_stale_snapshot_cannot_be_normal(self) -> None:
         state = json.loads(webapp.STATE_PATH.read_text(encoding="utf-8"))
         metrics = json.loads(webapp.AI_METRICS_PATH.read_text(encoding="utf-8"))

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -478,6 +478,38 @@ class DashboardDataContractTests(unittest.TestCase):
         # The expired advisory's attack label must not leak through either.
         self.assertNotIn("SSH Brute Force", str(soc_focus.get("attack_type", "")))
 
+    def test_dev_healthy_baseline_reports_services_on(self) -> None:
+        import os
+
+        prev = os.environ.get("AZAZEL_DEV_HEALTHY_BASELINE")
+        try:
+            os.environ["AZAZEL_DEV_HEALTHY_BASELINE"] = "1"
+            # setUp monkeypatches these; exercise the real implementations.
+            real_service_active = self._orig["_service_active"]
+            real_monitoring = self._orig["get_monitoring_state"]
+            self.assertTrue(webapp._dev_healthy_baseline())
+            self.assertTrue(real_service_active("azazel-edge-web"))
+            monitoring = real_monitoring()
+            self.assertEqual(monitoring["suricata"], "ON")
+            self.assertEqual(monitoring["opencanary"], "ON")
+            self.assertEqual(monitoring["ntfy"], "ON")
+        finally:
+            if prev is None:
+                os.environ.pop("AZAZEL_DEV_HEALTHY_BASELINE", None)
+            else:
+                os.environ["AZAZEL_DEV_HEALTHY_BASELINE"] = prev
+
+    def test_dev_healthy_baseline_off_by_default(self) -> None:
+        import os
+
+        prev = os.environ.get("AZAZEL_DEV_HEALTHY_BASELINE")
+        try:
+            os.environ.pop("AZAZEL_DEV_HEALTHY_BASELINE", None)
+            self.assertFalse(webapp._dev_healthy_baseline())
+        finally:
+            if prev is not None:
+                os.environ["AZAZEL_DEV_HEALTHY_BASELINE"] = prev
+
     def test_dashboard_summary_normal_assurance_stale_snapshot_cannot_be_normal(self) -> None:
         state = json.loads(webapp.STATE_PATH.read_text(encoding="utf-8"))
         metrics = json.loads(webapp.AI_METRICS_PATH.read_text(encoding="utf-8"))

--- a/tests/test_dashboard_data_contract.py
+++ b/tests/test_dashboard_data_contract.py
@@ -414,6 +414,38 @@ class DashboardDataContractTests(unittest.TestCase):
         payload = response.get_json()
         self.assertEqual(payload["now_time"], "23:59:58")
 
+    def test_api_state_cold_start_returns_checking_not_error(self) -> None:
+        # Cold start: no snapshot on disk and no control-plane reader.
+        webapp.cp_read_snapshot_payload = None
+        webapp.STATE_PATH.unlink(missing_ok=True)
+        webapp.FALLBACK_STATE_PATH.unlink(missing_ok=True)
+
+        response = self.client.get("/api/state")
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        # Must NOT be a hard error (that would trip the frontend error toast).
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload.get("bootstrap"))
+        self.assertEqual(payload["user_state"], "CHECKING")
+        self.assertEqual(payload["source"], "NONE")
+
+        # The other required fetch (dashboard summary) must also stay ok on cold start.
+        summary = self.client.get("/api/dashboard/summary")
+        self.assertEqual(summary.status_code, 200)
+        self.assertIsNot(summary.get_json().get("ok"), False)
+
+    def test_read_state_read_failure_degrades_to_checking(self) -> None:
+        # A genuine read failure should degrade to CHECKING rather than raise/error.
+        webapp.cp_read_snapshot_payload = None
+        webapp.STATE_PATH.write_text("{ not valid json", encoding="utf-8")
+        webapp.FALLBACK_STATE_PATH.unlink(missing_ok=True)
+
+        state = webapp.read_state()
+        self.assertTrue(state["ok"])
+        self.assertTrue(state.get("bootstrap"))
+        self.assertEqual(state["user_state"], "CHECKING")
+        self.assertEqual(state["source"], "ERROR")
+
     def test_dashboard_summary_normal_assurance_stale_snapshot_cannot_be_normal(self) -> None:
         state = json.loads(webapp.STATE_PATH.read_text(encoding="utf-8"))
         metrics = json.loads(webapp.AI_METRICS_PATH.read_text(encoding="utf-8"))

--- a/tools/macdev/env.sh
+++ b/tools/macdev/env.sh
@@ -54,6 +54,14 @@ export AZAZEL_LLM_NUM_THREAD="${AZAZEL_LLM_NUM_THREAD:-4}"
 
 export AZAZEL_DECISION_LOG_DIR="$LOG_DIR/tactics_engine"
 
+# --- dev healthy baseline ---
+# Dev host lacks systemd services and the Linux link/route/dns probes, so the
+# dashboard would otherwise show SERVICES OFF / PATH DEGRADED at idle. This
+# dev-only override presents a clean SAFE baseline (services ON, network health
+# SAFE, live NOC projection skipped) so an idle board is green and an injected
+# attack produces a clear visual change. NEVER set this on an appliance.
+export AZAZEL_DEV_HEALTHY_BASELINE="${AZAZEL_DEV_HEALTHY_BASELINE:-1}"
+
 # --- rust core ---
 export AZAZEL_EVE_PATH="$AZAZEL_DEV_STATE/suricata/eve.json"
 export AZAZEL_NORMALIZED_EVENT_LOG="$LOG_DIR/normalized-events.jsonl"


### PR DESCRIPTION
## Summary

Three related changes so the dashboard shows a **truthful baseline** instead of a false alarm — and so the dev environment can present a clean green baseline to demo a visual change against.

### 1. Cold start shows CHECKING, not a hard error
Before the control daemon seeds `ui_snapshot.json`, `read_state()` returned `{"ok": false}`. `/api/state` and `/api/dashboard/summary` are the dashboard's only **required** fetches, and the frontend throws on `payload.ok === false` → error toast + red connection chip. New `_bootstrap_checking_state()` returns a benign `CHECKING` placeholder (mirrors the daemon's `_default_snapshot_seed()`); both `read_state()` failure branches use it (real errors logged).

### 2. Expired advisory no longer pins THREAT to CRITICAL
When the daemon flags an advisory stale (`attack.stale_advisory_expired`), `_dashboard_summary_payload` cleared the attack label but still read the stale **second-pass SOC** block, so `threat_level` stayed CRITICAL. After injecting only benign traffic the board still showed a day-old CRITICAL. Now the stale branch also clears `second_pass_detail` / `second_pass_soc` (→ `idle`), so THREAT falls back to live snapshot signals and reads quiet.

### 3. Clean SAFE baseline in the macOS dev profile
On a dev host the dashboard could never go green: `_service_active` relies on systemd (absent on macOS) so SERVICES read **5 OFF**, and `NetworkHealthMonitor` + the live NOC projection depend on Linux probes (`ip`/`iw`/`dig`) and a real uplink so PATH read **DEGRADED**. That leaves no clean "before" for a demo. New **dev-only** override `AZAZEL_DEV_HEALTHY_BASELINE` (default OFF; enabled only by `tools/macdev/env.sh`, never on an appliance):
- `network_health.assess()` returns a SAFE baseline → daemon's idle path settles `user_state` to SAFE.
- daemon skips the live NOC projection (which degrades without real probes).
- web `_service_active()` / `get_monitoring_state()` report devstack-managed components as ON.

Idle dev board reads green; injected evidence still flows through the SOC/threat path and drives the visible change. **Production behavior is unchanged** (flag off).

## Type of change

- [x] fix — bug fix
- [x] feat — dev-only baseline override (item 3)

## Checklist

- [x] `PYTHONPATH=. pytest -q tests/test_dashboard_data_contract.py` — 34 passed (incl. 5 new). Two unrelated pre-existing failures in `tests/test_bhusa_prep_v1.py` / `test_bhusa_archive_v1.py` reproduce on clean `main` (sandbox tooling invoking `bin/azazel-edge-bhusa-*`, not this change; they pass in CI).
- [x] Related documentation updated — `tools/macdev/env.sh` documents the dev flag inline
- [x] Deterministic First principle not violated (AI is assist, not primary decision-maker)
- [x] Raspberry Pi constraints not broken (memory, aarch64 compatibility)
- [x] No changes to `installer/`, `systemd/`, `security/` without explicit justification below

## Notes for reviewers

- The dev override is strictly env-gated and defaults OFF; the only place it is turned on is `tools/macdev/env.sh`. It reports the components devstack genuinely runs as healthy and short-circuits Linux-only probes — it does not fabricate threat/SOC state, so an injected attack still produces the real visual change.
- Item 1's exception branch also degrades to CHECKING (logged) so a transient/corrupt read never becomes a UI hard-failure; easy to scope to the missing-snapshot path only if preferred.

New tests: `test_api_state_cold_start_returns_checking_not_error`, `test_read_state_read_failure_degrades_to_checking`, `test_stale_advisory_does_not_pin_threat_critical`, `test_dev_healthy_baseline_reports_services_on`, `test_dev_healthy_baseline_off_by_default`.

## Related issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)