### PR TITLE
fix(soc/ui): stop benign background traffic from falsely escalating the booth appliance

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -2544,7 +2544,15 @@ def _dashboard_summary_payload(state: Dict[str, Any], metrics: Dict[str, Any], a
             "current_uplink": str(state.get("up_if") or ""),
             "internet_reachability": str(connection.get("internet_check") or ""),
             "direct_critical_count": _as_int(state.get("suricata_critical"), 0),
+            # Lifetime counter, kept for audit - never decreases. UI tone must
+            # NOT use this field; see deferred_recent below.
             "deferred_count": _as_int(metrics.get("deferred_count"), 0),
+            # Windowed/decaying view of deferred_count (agent.py FIX A) - ages
+            # back to zero after a dwell once new deferrals stop, so a queue-
+            # full burst during an attack does not pin the "Deferred" pill to
+            # caution for the rest of the process life. This is what app.js
+            # should key the pill TONE on.
+            "deferred_recent": _as_int(state.get("deferred_recent"), 0),
             "ai_contribution_rate": _as_float((ai_governance.get("rates") or {}).get("ai_contribution"), 0.0),
             "ai_fallback_rate": _as_float((ai_governance.get("rates") or {}).get("fallback"), 0.0),
             "stale_warning": stale_warning,

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -1615,6 +1615,7 @@ function summarizePathState(summary) {
 }
 
 function summarizeCorrelationState(correlation) {
+    const hasData = !!correlation && typeof correlation === 'object' && Object.keys(correlation).length > 0;
     const status = String(correlation?.status || 'unknown').toLowerCase();
     const reasonCount = Array.isArray(correlation?.reasons) ? correlation.reasons.length : 0;
     if (['confirmed', 'correlated', 'active', 'matched'].includes(status)) {
@@ -1625,6 +1626,18 @@ function summarizeCorrelationState(correlation) {
     }
     if (['none', 'clear', 'normal', 'idle'].includes(status)) {
         return { tone: 'status-safe', value: status.toUpperCase() };
+    }
+    // FIX C: no correlation data at all (empty/missing correlation object, or
+    // an explicit "unknown" status - the two are indistinguishable from the
+    // caller) means "no correlation among threats", which is a GOOD state on
+    // a benign board, not an unknown/degraded one. Read it as SAFE/NONE so a
+    // fully benign board can settle the SOC glance to NORMAL instead of being
+    // stuck at neutral forever. This does not hide real attacks: threat_level
+    // elevated/critical drives socThreat to status-danger/caution, which
+    // still wins strongestTone(socThreat.tone, socCorrelation.tone, ...) in
+    // the SOC glance headline regardless of what this cell reads.
+    if (!hasData || status === 'unknown') {
+        return { tone: 'status-safe', value: 'NONE' };
     }
     return { tone: 'status-neutral', value: status.toUpperCase() };
 }
@@ -1752,7 +1765,13 @@ function updateCommandStrip(summary, health, failures = []) {
     setPillTone('stripRisk', toneForRisk(summary.risk?.user_state, summary.risk?.suspicion).replace('status-', ''));
     setPillTone('stripInternet', summarizePathState(summary).tone.replace('status-', ''));
     setPillTone('stripCritical', Number(strip.direct_critical_count || 0) > 0 ? 'danger' : 'safe');
-    setPillTone('stripDeferred', Number(strip.deferred_count || 0) > 0 ? 'caution' : 'safe');
+    // FIX A: deferred_count is a lifetime monotonic counter (never decreases),
+    // so keying tone off it would pin this pill to caution forever after the
+    // first LLM-queue-full event. deferred_recent is the windowed/decaying
+    // view of the same signal (agent.py `_update_ui_snapshot`); it ages back
+    // to zero once queue-full pressure stops, so the pill reflects CURRENT
+    // pressure, not history. deferred_count is still shown as text for audit.
+    setPillTone('stripDeferred', Number(strip.deferred_recent || 0) > 0 ? 'caution' : 'safe');
     const queueDepth = Number(health.queue?.depth || 0);
     const queueCapacity = Number(health.queue?.capacity || 0);
     const queueRatio = queueCapacity > 0 ? queueDepth / queueCapacity : 0;

--- a/bin/azazel-edge-devstack
+++ b/bin/azazel-edge-devstack
@@ -418,6 +418,48 @@ cmd_restart() {
   cmd_up "$@"
 }
 
+# cmd_reset -- deterministic clean slate for demo takes.
+# Stops the stack, purges every piece of ACCUMULATED runtime state that would
+# otherwise make a re-run non-identical (snapshot counters, the TTL-held
+# advisory, lifetime metrics, the normalized-event log, trend history, the eve
+# feed, and the /tmp CLI-replay artifacts), then brings the stack back up to a
+# verified-green baseline. Idempotent: the starting point is the same no matter
+# what the previous take left behind. Auth token, policy and captive registry
+# are intentionally preserved so the dashboard URL/token stays valid.
+# Pass-through flags (e.g. --inject / --all) are forwarded to the final `up`.
+cmd_reset() {
+  info "${C_BOLD}Resetting dev stack to a clean baseline${C_RESET}"
+  cmd_down
+  echo
+  info "${C_BOLD}Purging accumulated runtime state${C_RESET}"
+  # Files whose contents drift between runs and change what the live board shows.
+  local f
+  for f in \
+      "${AZAZEL_UI_SNAPSHOT:-}" \
+      "${AZAZEL_AI_ADVISORY:-}" \
+      "${AZAZEL_AI_METRICS:-}" \
+      "${AZAZEL_NORMALIZED_EVENT_LOG:-}" \
+      "${AZAZEL_DASHBOARD_TRENDS_PATH:-}"; do
+    if [[ -n "${f}" && -e "${f}" ]]; then
+      rm -f "${f}" && printf '  %s removed %s\n' "${OK}" "$(basename "${f}")"
+    fi
+  done
+  # Empty (do not delete) the eve feed so the rust core's tail-follow keeps its
+  # inode when it restarts and reads a clean, zero-event file.
+  if [[ -n "${AZAZEL_EVE_PATH:-}" ]]; then
+    : >"${AZAZEL_EVE_PATH}" && printf '  %s emptied %s\n' "${OK}" "$(basename "${AZAZEL_EVE_PATH}")"
+  fi
+  # On-camera CLI audit/explanation artifacts (deterministic-replay writes here).
+  rm -f /tmp/azazel-edge-demo-*.jsonl 2>/dev/null || true
+  printf '  %s /tmp CLI-replay artifacts cleared\n' "${OK}"
+  # Per-attendee triage sessions.
+  if [[ -n "${AZAZEL_TRIAGE_SESSION_DIR:-}" && -d "${AZAZEL_TRIAGE_SESSION_DIR}" ]]; then
+    rm -f "${AZAZEL_TRIAGE_SESSION_DIR}"/* 2>/dev/null || true
+  fi
+  echo
+  cmd_up "$@"
+}
+
 cmd_logs() {
   local comp="${1:-}"
   if [[ -z "${comp}" ]]; then
@@ -447,6 +489,7 @@ Usage:
   azazel-edge-devstack down [--all]            Stop azazel processes (--all also Mattermost)
   azazel-edge-devstack status                  Show component + ollama/Mattermost state
   azazel-edge-devstack restart [--inject]      down then up
+  azazel-edge-devstack reset [--inject] [--all]  Clean slate: down, purge runtime state, up (deterministic baseline)
   azazel-edge-devstack logs [component]        Tail a component log (or list logs)
 
   --inject   also start dummy-eve test-event injector
@@ -462,6 +505,7 @@ main() {
     down)     cmd_down "$@" ;;
     status)   cmd_status "$@" ;;
     restart)  cmd_restart "$@" ;;
+    reset)    cmd_reset "$@" ;;
     logs)     cmd_logs "$@" ;;
     -h|--help|help) usage ;;
     *) err "unknown command: ${cmd}"; usage; exit 2 ;;

--- a/py/azazel_edge/evaluators/soc.py
+++ b/py/azazel_edge/evaluators/soc.py
@@ -303,6 +303,30 @@ class SocEvaluator:
             return self._evaluate_unlocked(events, sot_diff=sot_diff)
 
     @staticmethod
+    def _is_benign_background_payload(payload: Dict[str, Any]) -> bool:
+        """
+        True for a SOC payload that is ordinary background traffic: a benign
+        classtype, first-pass risk below the auto-dismiss floor, and no AZAZEL
+        deception SID. Such an event carries no threat signal and must not seed
+        threat-shaped state (incidents, exposure expansion). Non-SOC evidence
+        (e.g. flow_min) is never classified benign here -- only suricata alerts
+        carry the category/sid/risk needed to judge this.
+        """
+        if str(payload.get('source') or '') != 'suricata_eve':
+            return False
+        attrs = payload.get('attrs', {}) if isinstance(payload.get('attrs'), dict) else {}
+        category = str(attrs.get('category') or '').strip().lower()
+        try:
+            sid = int(attrs.get('sid') or 0)
+        except (TypeError, ValueError):
+            sid = 0
+        try:
+            risk = int(attrs.get('risk_score') or payload.get('severity') or 0)
+        except (TypeError, ValueError):
+            risk = 0
+        return category in _BENIGN_CATEGORIES and risk < _INCIDENT_RISK_FLOOR and sid not in DECEPTION_SIDS
+
+    @staticmethod
     def _has_deception_signal(payloads: List[Dict[str, Any]]) -> bool:
         for payload in payloads:
             attrs = payload.get('attrs', {}) if isinstance(payload.get('attrs'), dict) else {}
@@ -800,38 +824,40 @@ class SocEvaluator:
         if self.ti_feed is not None and len(getattr(self.ti_feed, 'indicators', [])) <= 0:
             ti_status = 'empty'
 
+        # suricata_eve is the PRIMARY/required visibility source. flow_min and
+        # syslog_min are architecturally optional in this deployment: the dummy-eve
+        # generator and the live pipeline never emit them, so their absence is
+        # "not applicable", not a coverage gap. Visibility is judged on the primary
+        # source only -- absent optional sources must not manufacture a caution on
+        # every (benign) board. A real gap (stale or genuinely-absent SOC evidence)
+        # still downgrades below 'good'.
+        soc_stale = 'suricata_eve' in stale_sources
         if soc_count == 0 and flow_count == 0 and syslog_count == 0:
             status = 'blind'
             reasons.append('no_soc_or_flow_or_syslog_evidence')
+        elif soc_count == 0:
+            # No primary SOC evidence, even though an optional source produced data.
+            status = 'degraded'
+            missing_sources.append('suricata_eve')
+            reasons.append('missing_suricata_evidence')
+        elif soc_stale:
+            # Primary evidence present but stale -- a genuine visibility gap.
+            status = 'partial'
         else:
-            if soc_count == 0:
-                missing_sources.append('suricata_eve')
-                reasons.append('missing_suricata_evidence')
-            if flow_count == 0:
-                missing_sources.append('flow_min')
-                reasons.append('missing_flow_evidence')
-            if syslog_count == 0:
-                missing_sources.append('syslog_min')
-                reasons.append('missing_syslog_evidence')
-            if stale_sources:
-                reasons.extend(f'stale_{name}' for name in stale_sources)
-            if ti_status == 'unconfigured':
-                reasons.append('ti_feed_unconfigured')
-            elif ti_status == 'empty':
-                reasons.append('ti_feed_empty')
+            status = 'good'
+            reasons.append('soc_visibility')
 
-            if soc_count > 0 and flow_count > 0 and not stale_sources:
-                status = 'good'
-                reasons.append('multi_source_visibility')
-            elif soc_count > 0 or flow_count > 0:
-                status = 'partial'
-            else:
-                status = 'degraded'
+        if stale_sources:
+            reasons.extend(f'stale_{name}' for name in stale_sources)
+        if ti_status == 'unconfigured':
+            reasons.append('ti_feed_unconfigured')
+        elif ti_status == 'empty':
+            reasons.append('ti_feed_empty')
 
-        total_sources = 3
-        present_sources = sum(1 for count in (soc_count, flow_count, syslog_count) if count > 0)
+        # Coverage/trust are keyed on the primary source and staleness only; the
+        # absence of optional sources carries no penalty.
         stale_penalty = min(40, len(stale_sources) * 15)
-        missing_penalty = min(40, (total_sources - present_sources) * 15)
+        missing_penalty = 40 if soc_count == 0 else 0
         ti_penalty = 10 if ti_status in {'unconfigured', 'empty'} else 0
         coverage_score = max(0, min(100, 100 - stale_penalty - missing_penalty - ti_penalty))
         trust_penalty = min(60, stale_penalty + missing_penalty + ti_penalty)
@@ -1236,6 +1262,13 @@ class SocEvaluator:
         expected_change = False
 
         for payload in soc_payloads + flow_payloads:
+            # Benign background destinations (clean DNS/NTP/HTTPS to the fixed pool)
+            # are not exposure risk: first contact with them must not read as
+            # "exposure expanding". Skip them so they neither count as new nor seed
+            # the seen-sets; a later real threat to the same destination is still
+            # correctly flagged as new exposure.
+            if self._is_benign_background_payload(payload):
+                continue
             attrs = payload.get('attrs', {}) if isinstance(payload.get('attrs'), dict) else {}
             src, dst = _parse_subject(str(payload.get('subject') or ''))
             dst = dst or str(attrs.get('dst_ip') or '')
@@ -1554,6 +1587,12 @@ class SocEvaluator:
         evidence_ids: List[str] = []
         for row in rows:
             score = int(row['score'])
+            # Do not populate the triage queue from benign background: with no
+            # corroborated threat there is nothing to triage, and a zero-risk row
+            # is not a work item. Suppressing these keeps the "SOC Triage Queue"
+            # tile empty on a quiet board instead of showing a benign BACKLOG.
+            if not threat_present or score <= 0:
+                continue
             item = {
                 'id': str(row['id']),
                 'kind': str(row['kind']),

--- a/py/azazel_edge/evaluators/soc.py
+++ b/py/azazel_edge/evaluators/soc.py
@@ -11,8 +11,34 @@ from typing import Any, Dict, Iterable, List, Tuple
 from azazel_edge.correlation import AdvancedCorrelator
 from azazel_edge.knowledge.attack_mapping import load_attack_mapping, map_attack_techniques
 from azazel_edge.sigma import MiniSigmaExecutor
+from azazel_edge.tactics_engine.scorer import DECEPTION_SIDS
 from azazel_edge.ti import ThreatIntelFeed, load_ti_feed
 from azazel_edge.yara import MiniYaraMatcher
+
+
+# Benign Suricata classtypes. Kept in lockstep with scorer._BENIGN_CLASSTYPES: an
+# event carrying one of these categories with NO corroborating threat signal is
+# ordinary background traffic (web browse / DNS / NTP), not a detection. Used to
+# stop benign protocol tokens ("dns_lookup" -> "dns") from being read as attack
+# technique keywords, mirroring the Tactical Engine's "detection must be EARNED"
+# stance on the second-pass side.
+_BENIGN_CATEGORIES = frozenset(
+    {
+        'not-suspicious',
+        'unknown',
+        'misc-activity',
+        'protocol-command-decode',
+        'tcp-connection',
+        'policy-violation',
+        'bad-unknown',
+        '',
+    }
+)
+
+# First-pass risk below this floor is "auto-dismiss" per scorer.py's calibration
+# (< 40 sits below the LLM advisory floor). Impact/incident machinery must not
+# manufacture active incidents from such sub-threshold background events.
+_INCIDENT_RISK_FLOOR = 40
 
 
 def _to_payloads(events: Iterable[Any]) -> List[Dict[str, Any]]:
@@ -162,8 +188,15 @@ def _in_maintenance_window(ts: datetime, windows: List[Dict[str, Any]]) -> bool:
     return False
 
 
-def _candidate_hits(text: str) -> List[str]:
-    lowered = text.lower()
+def _candidate_hits(attack_type: str, category: str) -> List[str]:
+    # Benign background traffic (category in the benign set, e.g. "not-suspicious")
+    # is NOT a detection: its attack_type is a bare protocol name ("dns_lookup",
+    # "web_browse") that would otherwise substring-collide with technique keywords
+    # ('dns' -> T1071, 'http' -> T1071). Skip keyword matching entirely for it so
+    # possibility-of-technique is never inferred from a clean protocol label.
+    if str(category or '').strip().lower() in _BENIGN_CATEGORIES:
+        return []
+    lowered = f'{attack_type} {category}'.lower()
     mapping = {
         'T1595 Active Scanning': ['scan', 'scanner', 'recon'],
         'T1110 Brute Force': ['brute', 'password', 'login attempt', 'authentication'],
@@ -269,6 +302,52 @@ class SocEvaluator:
         with self._lock:
             return self._evaluate_unlocked(events, sot_diff=sot_diff)
 
+    @staticmethod
+    def _has_deception_signal(payloads: List[Dict[str, Any]]) -> bool:
+        for payload in payloads:
+            attrs = payload.get('attrs', {}) if isinstance(payload.get('attrs'), dict) else {}
+            try:
+                sid = int(attrs.get('sid') or 0)
+            except (TypeError, ValueError):
+                sid = 0
+            if sid in DECEPTION_SIDS:
+                return True
+        return False
+
+    @staticmethod
+    def _is_threat_present(
+        suspicion: Dict[str, Any],
+        ti_matches: List[Any],
+        correlation: Dict[str, Any],
+        sigma_hits: List[Dict[str, Any]],
+        yara_hits: List[Dict[str, Any]],
+        deception_signal: bool,
+    ) -> bool:
+        """
+        Threat-presence gate (Deterministic First).
+
+        blast_radius (impact) and technique_likelihood (possibility) describe the
+        *consequence* or *potential* of an event, not whether a threat is actually
+        present. Confidence describes how sure we are about a signal we may not
+        have. None of them alone establishes threat presence. Presence is
+        established only by a corroborated threat signal: an elevated suspicion
+        score, a TI/sigma/yara hit, a correlation cluster, a high-risk signature,
+        or an AZAZEL deception SID. When none of these fire the traffic is treated
+        as benign background and the headline is capped to "low" regardless of how
+        large the impact/possibility surfaces look. Any single real corroboration
+        restores full sensitivity, so real attacks are unaffected.
+        """
+        suspicion_reasons = suspicion.get('reasons') or []
+        return bool(
+            str(suspicion.get('label') or 'low') != 'low'
+            or ti_matches
+            or sigma_hits
+            or yara_hits
+            or int(correlation.get('top_score') or 0) >= 50
+            or any(str(reason).startswith('high_risk_sid') for reason in suspicion_reasons)
+            or deception_signal
+        )
+
     def _evaluate_unlocked(self, events: Iterable[Any], sot_diff: Dict[str, Any] | None = None) -> Dict[str, Any]:
         payloads = _to_payloads(events)
         soc_payloads = [item for item in payloads if str(item.get('source') or '') == 'suricata_eve']
@@ -288,6 +367,15 @@ class SocEvaluator:
         technique_likelihood, attack_candidates, attack_techniques = self._evaluate_technique_likelihood(actionable_soc_payloads, flow_payloads, ti_matches, correlation, sigma_hits, sot_diff=sot_diff)
         asset_target_criticality = self._evaluate_asset_target_criticality(actionable_soc_payloads, flow_payloads)
         blast_radius = self._evaluate_blast_radius(actionable_soc_payloads, flow_payloads, criticality=asset_target_criticality)
+        deception_signal = self._has_deception_signal(actionable_soc_payloads)
+        threat_present = self._is_threat_present(
+            suspicion=suspicion,
+            ti_matches=ti_matches,
+            correlation=correlation,
+            sigma_hits=sigma_hits,
+            yara_hits=yara_hits,
+            deception_signal=deception_signal,
+        )
         entity_risk_state = self._evaluate_entity_risk_state(actionable_payloads)
         incident_campaign_state = self._evaluate_incident_campaign_state(actionable_soc_payloads, flow_payloads)
         exposure_change_state = self._evaluate_exposure_change_state(actionable_soc_payloads, flow_payloads)
@@ -313,14 +401,24 @@ class SocEvaluator:
             suppression_state=suppression_exception_state,
             criticality_state=asset_target_criticality,
             exposure_state=exposure_change_state,
+            threat_present=threat_present,
         )
 
-        worst = max(
-            int(suspicion['score']),
-            int(confidence['score']),
-            int(technique_likelihood['score']),
-            int(blast_radius['score']),
-        ) if payloads else 0
+        # SUMMARY status is a threat-presence headline, not a max over every
+        # surface. Impact (blast_radius), possibility (technique_likelihood) and
+        # confidence must not independently push the headline above the actual
+        # corroborated threat signal. With no threat present the headline is
+        # capped to the suspicion signal (benign background -> "low"); with any
+        # corroboration the full worst-of computation is restored unchanged.
+        if threat_present:
+            worst = max(
+                int(suspicion['score']),
+                int(confidence['score']),
+                int(technique_likelihood['score']),
+                int(blast_radius['score']),
+            ) if payloads else 0
+        else:
+            worst = int(suspicion['score']) if payloads else 0
         summary_reasons = []
         for name, dim in (
             ('suspicion', suspicion),
@@ -328,7 +426,10 @@ class SocEvaluator:
             ('technique_likelihood', technique_likelihood),
             ('blast_radius', blast_radius),
         ):
-            if dim['label'] != 'low':
+            # Suspicion always reports. The impact/possibility/confidence surfaces
+            # only decorate the headline when a threat is actually present, so a
+            # benign "low" summary is not annotated with critical blast radius.
+            if dim['label'] != 'low' and (threat_present or name == 'suspicion'):
                 summary_reasons.append(f'{name}:{dim["label"]}')
         if str(security_visibility_state.get('status') or '') != 'good':
             summary_reasons.append(f'visibility:{security_visibility_state.get("status")}')
@@ -468,8 +569,7 @@ class SocEvaluator:
         for payload in payloads:
             evidence_ids.append(str(payload.get('event_id') or ''))
             attrs = payload.get('attrs', {})
-            text = f"{attrs.get('attack_type') or ''} {attrs.get('category') or ''}"
-            hits = _candidate_hits(text)
+            hits = _candidate_hits(str(attrs.get('attack_type') or ''), str(attrs.get('category') or ''))
             if hits:
                 candidates.extend(hits)
                 score = max(score, 70)
@@ -967,6 +1067,21 @@ class SocEvaluator:
             event_id = str(payload.get('event_id') or '')
             ts = _parse_ts(payload.get('ts')) or now_ts
 
+            # Threat-presence gate for incident activation. An incident is a
+            # standing "something is happening here" marker; opening one off a
+            # sub-threshold benign background event (risk < auto-dismiss floor,
+            # no deception SID) manufactures a permanent "active campaign" from
+            # clean traffic. Only events carrying real threat signal open or
+            # refresh an incident. Corroborated attacks (risk >= floor or an
+            # AZAZEL deception SID) are unaffected.
+            category = str(attrs.get('category') or '').strip().lower()
+            try:
+                sid_val = int(attrs.get('sid') or 0)
+            except (TypeError, ValueError):
+                sid_val = 0
+            if risk < _INCIDENT_RISK_FLOOR and sid_val not in DECEPTION_SIDS and category in _BENIGN_CATEGORIES:
+                continue
+
             fingerprint = f'{src}|{dst}|{port}|{attack_type}'
             incident_id = 'inc-' + hashlib.sha256(fingerprint.encode('utf-8')).hexdigest()[:12]
             row = self._incident_store.setdefault(
@@ -1379,6 +1494,7 @@ class SocEvaluator:
         suppression_state: Dict[str, Any],
         criticality_state: Dict[str, Any],
         exposure_state: Dict[str, Any],
+        threat_present: bool = True,
     ) -> Dict[str, Any]:
         suspicion_score = int(suspicion.get('score') or 0)
         confidence_score = int(confidence.get('score') or 0)
@@ -1386,13 +1502,20 @@ class SocEvaluator:
         critical_score = int(criticality_state.get('score') or 0)
         exposure_score = int(exposure_state.get('score') or 0)
 
-        base = int(
-            (suspicion_score * 0.35)
-            + (confidence_score * 0.25)
-            + (blast_score * 0.20)
-            + (critical_score * 0.10)
-            + (exposure_score * 0.10)
-        )
+        if threat_present:
+            base = int(
+                (suspicion_score * 0.35)
+                + (confidence_score * 0.25)
+                + (blast_score * 0.20)
+                + (critical_score * 0.10)
+                + (exposure_score * 0.10)
+            )
+        else:
+            # No corroborated threat: impact/criticality/exposure describe
+            # consequence surfaces, not triage pressure. Prioritization falls back
+            # to the actual detection signals (suspicion + confidence) so benign
+            # background traffic settles to idle/backlog instead of "watch".
+            base = int((suspicion_score * 0.35) + (confidence_score * 0.25))
         if str(visibility_state.get('status') or '') == 'blind':
             base = min(100, base + 10)
         if str(suppression_state.get('status') or '') in {'heavy', 'partial-heavy'}:

--- a/py/azazel_edge_ai/agent.py
+++ b/py/azazel_edge_ai/agent.py
@@ -72,14 +72,29 @@ SURICATA_COUNT_DECAY_WINDOW_SEC = max(1.0, float(os.environ.get("AZAZEL_SURICATA
 # Hard ceiling so a sustained event storm still cannot grow the tallies without
 # bound (decay reclaims them once activity subsides).
 SURICATA_COUNT_MAX = max(1, int(os.environ.get("AZAZEL_SURICATA_COUNT_MAX", "99")))
+# The lifetime METRICS["deferred_count"] counter never resets (see _metrics_inc
+# call sites), so a single LLM-queue-full burst during an attack would pin the
+# "Deferred" strip pill to caution for the rest of the process life, including
+# all the benign traffic afterward. `deferred_recent` (persisted alongside the
+# suricata tallies in the UI snapshot) is a windowed view of the same signal:
+# it is bumped by however much the lifetime counter grew since the last
+# snapshot write, then ages back to zero after this many seconds of no new
+# deferrals - same decay shape as SURICATA_COUNT_DECAY_WINDOW_SEC, just a
+# shorter window since queue-full pressure is meant to be a transient signal.
+DEFERRED_RECENT_DECAY_WINDOW_SEC = max(1.0, float(os.environ.get("AZAZEL_DEFERRED_RECENT_DECAY_SEC", "60")))
 
 
-def _decay_suricata_count(prev: int, elapsed_sec: float) -> int:
-    """Linearly age a severity tally toward zero across the decay window."""
+def _decay_suricata_count(prev: int, elapsed_sec: float, window_sec: float = SURICATA_COUNT_DECAY_WINDOW_SEC) -> int:
+    """Linearly age a tally toward zero across a decay window.
+
+    Despite the name (kept for backward compatibility with existing callers
+    and tests), this is a generic "age a monotonic-ish counter back toward
+    zero" helper - `deferred_recent` below reuses it with a shorter window.
+    """
     value = max(0, int(prev))
     if value <= 0 or elapsed_sec <= 0:
         return min(SURICATA_COUNT_MAX, value)
-    factor = max(0.0, 1.0 - (float(elapsed_sec) / SURICATA_COUNT_DECAY_WINDOW_SEC))
+    factor = max(0.0, 1.0 - (float(elapsed_sec) / window_sec))
     # Round (not floor) so a small tally survives most of the window instead of
     # truncating to zero on the very next event; a full window of quiet still
     # reclaims it to zero (factor == 0).
@@ -1544,6 +1559,19 @@ def _update_ui_snapshot(advisory: Dict[str, Any], count_suricata: bool = True) -
         else:
             info = min(SURICATA_COUNT_MAX, info + 1)
 
+    # FIX A: windowed/decaying view of the lifetime deferred_count metric (see
+    # DEFERRED_RECENT_DECAY_WINDOW_SEC above). Age the prior recent-deferrals
+    # tally the same way the suricata tallies are aged above, then fold in
+    # however much the lifetime counter grew since the last snapshot write.
+    # This is what the "Deferred" strip pill should key its tone on - NOT the
+    # raw lifetime count, which only ever goes up.
+    with METRICS_LOCK:
+        deferred_lifetime = int(METRICS.get("deferred_count", 0) or 0)
+    prev_deferred_lifetime = int(snapshot.get("deferred_lifetime_at_snapshot", 0) or 0)
+    prev_deferred_recent = int(snapshot.get("deferred_recent", 0) or 0)
+    deferred_recent = _decay_suricata_count(prev_deferred_recent, elapsed, DEFERRED_RECENT_DECAY_WINDOW_SEC)
+    deferred_recent = min(SURICATA_COUNT_MAX, deferred_recent + max(0, deferred_lifetime - prev_deferred_lifetime))
+
     reasons = snapshot.get("reasons", [])
     if not isinstance(reasons, list):
         reasons = []
@@ -1569,6 +1597,12 @@ def _update_ui_snapshot(advisory: Dict[str, Any], count_suricata: bool = True) -
     snapshot["suricata_critical"] = critical
     snapshot["suricata_warning"] = warning
     snapshot["suricata_info"] = info
+    # FIX A (continued): persist the decayed "recent deferrals" signal plus the
+    # lifetime-count bookmark used to compute its next delta. `deferred_recent`
+    # is what UI tone should read; the lifetime `deferred_count` metric (see
+    # llm_metrics below) is kept untouched for audit.
+    snapshot["deferred_recent"] = deferred_recent
+    snapshot["deferred_lifetime_at_snapshot"] = deferred_lifetime
     snapshot["llm"] = advisory.get("llm", {})
     snapshot["ops_coach"] = advisory.get("ops_coach", {})
     snapshot["decision_pipeline"] = advisory.get("decision_pipeline", {})
@@ -1593,10 +1627,16 @@ def _update_ui_snapshot(advisory: Dict[str, Any], count_suricata: bool = True) -
         snapshot["ssid"] = f"ETH:{up_if}" if up_if != "-" else "ETH"
     else:
         snapshot["ssid"] = str(snapshot.get("ssid") or "-")
+    suricata_sid = int(advisory.get("suricata_sid", 0) or 0)
+    # FIX B: only flag an actual suricata alert (severity 1-2, sid present),
+    # not benign dummy-eve traffic (severity>=3, sid==0). Previously this was
+    # hardcoded True for every advisory including benign, which is a
+    # data-quality landmine for audit/STIX export even though no current UI
+    # tone reads this field.
     snapshot["attack"] = {
-        "suricata_alert": True,
+        "suricata_alert": bool(severity and severity <= 2 and suricata_sid),
         "suricata_severity": severity,
-        "suricata_sid": int(advisory.get("suricata_sid", 0)),
+        "suricata_sid": suricata_sid,
         "canary_target_alert": False,
         "canary_delay_active": False,
         "canary_delay_target_count": 0,

--- a/py/azazel_edge_ai/agent.py
+++ b/py/azazel_edge_ai/agent.py
@@ -63,6 +63,27 @@ METRICS_PATH = Path(os.environ.get("AZAZEL_AI_METRICS", "/run/azazel-edge/ai_met
 POLICY_PATH = Path(os.environ.get("AZAZEL_AI_POLICY", "/run/azazel-edge/ai_runtime_policy.json"))
 AI_AUDIT_PATH = Path(os.environ.get("AZAZEL_AI_AUDIT_LOG", "/var/log/azazel-edge/ai-audit.jsonl"))
 METRICS_HEARTBEAT_SEC = max(5.0, float(os.environ.get("AZAZEL_AI_METRICS_HEARTBEAT_SEC", "15")))
+# Rolling suricata severity tallies in the UI snapshot decay linearly to zero over
+# this window of no new same-severity events, so a long-running / idle booth does
+# not accumulate unbounded counts that keep the dashboard escalated. Aligned with
+# daemon.SURICATA_ADVISORY_TTL_SEC (stale-advisory TTL) so the display and the
+# tallies age out on the same clock.
+SURICATA_COUNT_DECAY_WINDOW_SEC = max(1.0, float(os.environ.get("AZAZEL_SURICATA_COUNT_DECAY_SEC", "300")))
+# Hard ceiling so a sustained event storm still cannot grow the tallies without
+# bound (decay reclaims them once activity subsides).
+SURICATA_COUNT_MAX = max(1, int(os.environ.get("AZAZEL_SURICATA_COUNT_MAX", "99")))
+
+
+def _decay_suricata_count(prev: int, elapsed_sec: float) -> int:
+    """Linearly age a severity tally toward zero across the decay window."""
+    value = max(0, int(prev))
+    if value <= 0 or elapsed_sec <= 0:
+        return min(SURICATA_COUNT_MAX, value)
+    factor = max(0.0, 1.0 - (float(elapsed_sec) / SURICATA_COUNT_DECAY_WINDOW_SEC))
+    # Round (not floor) so a small tally survives most of the window instead of
+    # truncating to zero on the very next event; a full window of quiet still
+    # reclaims it to zero (factor == 0).
+    return min(SURICATA_COUNT_MAX, int(round(value * factor)))
 LLM_ENABLED = os.environ.get("AZAZEL_LLM_ENABLED", "1") == "1"
 LLM_ENDPOINT = os.environ.get("AZAZEL_OLLAMA_ENDPOINT", "http://127.0.0.1:11434")
 LLM_MODEL_PRIMARY = os.environ.get("AZAZEL_LLM_MODEL_PRIMARY", os.environ.get("AZAZEL_LLM_MODEL", "qwen3.5:2b"))
@@ -1507,16 +1528,21 @@ def _update_ui_snapshot(advisory: Dict[str, Any], count_suricata: bool = True) -
             snapshot = {}
 
     severity = int(advisory.get("suricata_severity") or 0)
-    critical = int(snapshot.get("suricata_critical", 0) or 0)
-    warning = int(snapshot.get("suricata_warning", 0) or 0)
-    info = int(snapshot.get("suricata_info", 0) or 0)
+    # Age the prior tallies before folding in this event: counts decay toward zero
+    # over SURICATA_COUNT_DECAY_WINDOW_SEC of quiet, so idle/benign operation
+    # returns the dashboard toward "quiet" instead of ratcheting up forever.
+    prev_epoch = float(snapshot.get("snapshot_epoch") or 0.0)
+    elapsed = max(0.0, now - prev_epoch) if prev_epoch > 0 else 0.0
+    critical = _decay_suricata_count(int(snapshot.get("suricata_critical", 0) or 0), elapsed)
+    warning = _decay_suricata_count(int(snapshot.get("suricata_warning", 0) or 0), elapsed)
+    info = _decay_suricata_count(int(snapshot.get("suricata_info", 0) or 0), elapsed)
     if count_suricata:
         if severity <= 1:
-            critical += 1
+            critical = min(SURICATA_COUNT_MAX, critical + 1)
         elif severity == 2:
-            warning += 1
+            warning = min(SURICATA_COUNT_MAX, warning + 1)
         else:
-            info += 1
+            info = min(SURICATA_COUNT_MAX, info + 1)
 
     reasons = snapshot.get("reasons", [])
     if not isinstance(reasons, list):

--- a/tests/test_soc_evaluator_v1.py
+++ b/tests/test_soc_evaluator_v1.py
@@ -330,6 +330,16 @@ class SocEvaluatorV1Tests(unittest.TestCase):
         self.assertNotIn(result['triage_priority_state']['status'], {'now', 'watch'})
         self.assertEqual(int(result['incident_campaign_state']['active_count']), 0)
         self.assertNotIn('incident:active', result['summary']['reasons'])
+        # Visibility must not paint caution: flow_min/syslog_min are optional in
+        # this deployment, so soc-only evidence resolves to 'good', not 'partial'.
+        self.assertNotEqual(result['security_visibility_state']['status'], 'partial')
+        self.assertEqual(result['security_visibility_state']['status'], 'good')
+        # The triage queue must be empty on a quiet board -- no benign backlog.
+        self.assertEqual(result['triage_priority_state']['backlog'], [])
+        self.assertEqual(result['triage_priority_state']['now'], [])
+        self.assertEqual(result['triage_priority_state']['watch'], [])
+        # First contact with benign destinations is not exposure expansion.
+        self.assertNotEqual(result['exposure_change_state']['status'], 'expanding')
 
     def test_real_attack_batch_still_escalates(self) -> None:
         # Positive control: high-risk signatures must remain fully sensitive after

--- a/tests/test_soc_evaluator_v1.py
+++ b/tests/test_soc_evaluator_v1.py
@@ -307,6 +307,42 @@ class SocEvaluatorV1Tests(unittest.TestCase):
         self.assertIn('top_priority_ids', triage)
         self.assertIn(triage['status'], {'now', 'watch', 'backlog', 'idle'})
 
+    def test_benign_background_batch_stays_quiet(self) -> None:
+        # Booth demo background stream: sid=0, benign classtype, first-pass risk
+        # dampened to 25. Diversity of src/dst/service (benign fan-out) inflates
+        # blast_radius, and protocol names would collide with technique keywords,
+        # but with no corroborated threat the headline must stay quiet.
+        evaluator = SocEvaluator()
+        benign = [
+            _event('10.0.0.121->203.0.113.10:443/TCP', 25, 50, 'web_browse', 'not-suspicious', 443, 0),
+            _event('10.0.0.110->8.8.8.8:53/UDP', 25, 50, 'dns_lookup', 'not-suspicious', 53, 0),
+            _event('10.0.0.237->198.51.100.7:123/UDP', 25, 50, 'ntp_sync', 'not-suspicious', 123, 0),
+            _event('10.0.0.200->203.0.113.25:443/TCP', 25, 50, 'web_browse', 'not-suspicious', 443, 0),
+            _event('10.0.0.140->203.0.113.25:53/UDP', 25, 50, 'dns_lookup', 'not-suspicious', 53, 0),
+        ]
+        result = evaluator.evaluate(benign)
+        # Core invariant: quiet headline regardless of blast_radius/technique.
+        self.assertEqual(result['summary']['status'], 'low')
+        # Benign protocol tokens must not be read as attack techniques.
+        self.assertEqual(result['technique_likelihood']['label'], 'low')
+        self.assertNotIn('attack_keyword_match', result['technique_likelihood']['reasons'])
+        # No triage pressure and no active incident campaign from clean traffic.
+        self.assertNotIn(result['triage_priority_state']['status'], {'now', 'watch'})
+        self.assertEqual(int(result['incident_campaign_state']['active_count']), 0)
+        self.assertNotIn('incident:active', result['summary']['reasons'])
+
+    def test_real_attack_batch_still_escalates(self) -> None:
+        # Positive control: high-risk signatures must remain fully sensitive after
+        # the threat-presence gate. Same fan-out shape as the benign batch.
+        evaluator = SocEvaluator()
+        attack = [
+            _event('10.0.0.5->192.168.40.10:443/TCP', 92, 90, 'TLS C2 Beacon', 'Trojan Activity', 443, 210020),
+            _event('10.0.0.5->192.168.40.20:53/UDP', 88, 85, 'DNS Tunnel Exfil', 'Trojan Activity', 53, 210021),
+        ]
+        result = evaluator.evaluate(attack)
+        self.assertIn(result['summary']['status'], {'high', 'critical'})
+        self.assertEqual(int(result['incident_campaign_state']['active_count']) > 0, True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ui_snapshot_count_decay_v1.py
+++ b/tests/test_ui_snapshot_count_decay_v1.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from azazel_edge_ai import agent
+
+
+class UiSnapshotCountDecayV1Tests(unittest.TestCase):
+    def test_decay_helper_ages_toward_zero_and_is_bounded(self) -> None:
+        window = agent.SURICATA_COUNT_DECAY_WINDOW_SEC
+        # No elapsed time -> unchanged.
+        self.assertEqual(agent._decay_suricata_count(10, 0), 10)
+        # Half the window -> roughly halved.
+        self.assertEqual(agent._decay_suricata_count(10, window / 2.0), 5)
+        # Full window of quiet -> reclaimed to zero.
+        self.assertEqual(agent._decay_suricata_count(10, window), 0)
+        # Hard ceiling caps runaway values.
+        self.assertEqual(agent._decay_suricata_count(10_000, 0), agent.SURICATA_COUNT_MAX)
+
+    def test_idle_operation_returns_counts_toward_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            snap = Path(tmp) / "ui_snapshot.json"
+            with patch.object(agent, "SNAPSHOT_PATH", snap):
+                base = 1_000_000_000.0
+                window = agent.SURICATA_COUNT_DECAY_WINDOW_SEC
+                # Two info-severity (sev=3) benign events fired close together.
+                with patch.object(agent.time, "time", return_value=base):
+                    agent._update_ui_snapshot({"suricata_severity": 3, "ts": base})
+                with patch.object(agent.time, "time", return_value=base + 1.0):
+                    agent._update_ui_snapshot({"suricata_severity": 3, "ts": base + 1.0})
+                after_burst = json.loads(snap.read_text())["suricata_info"]
+                self.assertGreaterEqual(after_burst, 2)
+
+                # A full decay window later, one more benign event: prior tally
+                # has aged out to zero, leaving only the fresh event.
+                idle_now = base + 1.0 + window
+                with patch.object(agent.time, "time", return_value=idle_now):
+                    agent._update_ui_snapshot({"suricata_severity": 3, "ts": idle_now})
+                after_idle = json.loads(snap.read_text())["suricata_info"]
+                self.assertEqual(after_idle, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_snapshot_count_decay_v1.py
+++ b/tests/test_ui_snapshot_count_decay_v1.py
@@ -43,6 +43,41 @@ class UiSnapshotCountDecayV1Tests(unittest.TestCase):
                 after_idle = json.loads(snap.read_text())["suricata_info"]
                 self.assertEqual(after_idle, 1)
 
+    def test_deferred_recent_decays_independently_of_lifetime_counter(self) -> None:
+        """FIX A: deferred_recent (pill-tone signal) must decay to zero once
+        deferrals stop, even though METRICS['deferred_count'] (lifetime, kept
+        for audit) never decreases."""
+        orig_deferred_count = agent.METRICS.get("deferred_count", 0)
+        self.addCleanup(lambda: agent.METRICS.__setitem__("deferred_count", orig_deferred_count))
+        with tempfile.TemporaryDirectory() as tmp:
+            snap = Path(tmp) / "ui_snapshot.json"
+            with patch.object(agent, "SNAPSHOT_PATH", snap):
+                base = 2_000_000_000.0
+                window = agent.DEFERRED_RECENT_DECAY_WINDOW_SEC
+
+                # Simulate an attack burst that floods the LLM queue: bump the
+                # lifetime deferred_count metric directly, as _route_llm does.
+                with agent.METRICS_LOCK:
+                    agent.METRICS["deferred_count"] = 3
+                with patch.object(agent.time, "time", return_value=base):
+                    agent._update_ui_snapshot({"suricata_severity": 1, "ts": base}, count_suricata=False)
+                snap_data = json.loads(snap.read_text())
+                self.assertEqual(snap_data["deferred_recent"], 3)
+                self.assertEqual(snap_data["deferred_lifetime_at_snapshot"], 3)
+                # The lifetime metric itself is untouched by the snapshot write.
+                self.assertEqual(agent.METRICS["deferred_count"], 3)
+
+                # No further deferrals; a full decay window of benign/quiet
+                # operation later, deferred_recent must have aged to zero even
+                # though the lifetime counter is still 3 (pinned high forever
+                # was the bug this fixes).
+                idle_now = base + window
+                with patch.object(agent.time, "time", return_value=idle_now):
+                    agent._update_ui_snapshot({"suricata_severity": 3, "ts": idle_now}, count_suricata=False)
+                snap_data = json.loads(snap.read_text())
+                self.assertEqual(snap_data["deferred_recent"], 0)
+                self.assertEqual(agent.METRICS["deferred_count"], 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

A continuous stream of **benign** traffic — the realistic idle state of a live booth appliance during the Black Hat Arsenal demo — falsely escalated the SOC dashboard to a critical/THREAT posture. This was reproducible from a clean state (not residual), so it would surface on stage when the appliance simply sits on a normal network between attack injections. This PR removes every benign-escalation and stuck-signal path we could find.

Root causes and fixes, in the order signal flows through the pipeline:

**SOC evaluator (`py/azazel_edge/evaluators/soc.py`)** — building on the earlier threat-presence gate (`2659e83`):
- `security_visibility` treated flow/syslog absence as a visibility *gap*, so a SOC-only benign feed read as `partial`. SOC EVE is now the sole primary source; flow/syslog are optional (absence = not-applicable). Resolves to `good` when SOC evidence is present and fresh, `partial` only when stale.
- `triage_priority` populated now/watch/backlog buckets with no threat present. The bucketing loop now skips every row when not `threat_present` and any row scoring `<= 0`, so a quiet board yields empty queues.
- `exposure_change` read benign first-seen destinations (clean DNS/NTP/HTTPS) as `expanding`. A shared `_is_benign_background_payload` predicate now excludes benign SOC payloads from both new-contact counting and seen-set seeding; a later real threat to the same destination still flags.

**AI agent / snapshot (`py/azazel_edge_ai/agent.py`)** — building on the suricata-tally decay (`38a5459`):
- `deferred_recent` is a new windowed/decaying counter (default 60s, `AZAZEL_DEFERRED_RECENT_DECAY_SEC`) derived from the lifetime `deferred_count` delta. The dashboard "deferred" pill tone now reads it so a transient LLM-queue-full burst relaxes back to safe; the lifetime `deferred_count` is still shown as the audit value and never mutated.
- `attack.suricata_alert` is now `bool(severity in 1..2 and sid)` rather than hardcoded `True` for every advisory — benign dummy-eve (severity>=3, sid==0) no longer flags a false alert in the snapshot/audit/STIX surface.

**Web + frontend (`azazel_edge_web/app.py`, `azazel_edge_web/static/app.js`)**:
- `_dashboard_summary_payload` exposes `command_strip.deferred_recent` alongside the lifetime `deferred_count`.
- `summarizeCorrelationState` returns `status-safe`/`NONE` when the correlation cell is empty or unknown, instead of pinning the glance to neutral. A real attack still dominates the glance via `socThreat`, so this only lets a fully benign board settle to safe.

## Type of change

- [x] fix — bug fix
- [x] security — security fix (false-positive suppression / audit data quality)

## Checklist

- [x] `PYTHONPATH=. pytest -q` passes (verification subset: 60 passed; pre-existing `bhusa_*`/`epd_*` env failures unrelated to this change)
- [ ] Related documentation updated in this PR
- [x] Deterministic First principle not violated (AI is assist, not primary decision-maker) — deterministic replay ACTIONs unchanged: `mixed_correlation_demo`→throttle, `noc_degraded_demo`→notify, `shelter_baseline_demo`→observe
- [x] Raspberry Pi constraints not broken (memory, aarch64 compatibility) — pure-Python/JS logic changes, no new deps
- [x] No changes to `installer/`, `systemd/`, `security/` without explicit justification below

## Notes for reviewers

- The three canonical replay decisions are the load-bearing invariant; they are byte-for-byte unchanged. The fixes only affect how a **benign/idle** stream is scored, never how a real attack escalates (positive-control test `test_real_attack_batch_still_escalates` retained).
- Verified end-to-end with a 5-event benign batch through `TacticalScorer` → `DecisionLayers` → `SocEvaluator`: SUMMARY `low`, triage `backlog=0`, visibility `good`, exposure `stable`.
- No changes to restricted areas.

## Related issues

Closes #


---
_Generated by [Claude Code](https://claude.ai/code/session_01HR5NqcJwsDrwg5QCkTurYm)_