### PR TITLE
fix(demo): calm demo-fast poll to 3s and guard injector eve-path footgun

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -310,7 +310,11 @@ def _dashboard_poll_ms() -> int:
         except (TypeError, ValueError):
             pass
     demo_fast = str(os.environ.get("AZAZEL_DEMO_FAST", "")).strip().lower() in {"1", "true", "yes", "on"}
-    return 1500 if demo_fast else 4000
+    # Matches the demo-fast snapshot cache TTL (~3s): polling faster than the data
+    # can change only doubles load on the single-process dev web server (11 fetches
+    # per refresh) and starves the heaviest endpoint (/api/dashboard/evidence),
+    # which surfaces as an OFFLINE/STALE link chip. 3s stays snappy without that.
+    return 3000 if demo_fast else 4000
 
 
 @app.context_processor

--- a/py/azazel_edge/dummy_eve.py
+++ b/py/azazel_edge/dummy_eve.py
@@ -235,6 +235,43 @@ def _default_eve_path() -> Path:
     return Path(os.environ.get("AZAZEL_EVE_PATH", "/var/log/suricata/eve.json"))
 
 
+def _resolve_eve_path(args: argparse.Namespace) -> Path:
+    """Resolve the EVE output path and guard the classic dev footgun.
+
+    When a dev stack is running but this shell never sourced ``tools/macdev/env.sh``,
+    ``AZAZEL_EVE_PATH`` is unset, so we would silently append to the default
+    ``/var/log/suricata/eve.json`` — a file the dev stack never tails — and the
+    dashboard would never react. Detect that case and tell the operator exactly
+    how to fix it, instead of failing silently.
+    """
+    if args.eve_path:
+        return Path(args.eve_path)
+    env_path = os.environ.get("AZAZEL_EVE_PATH")
+    if env_path:
+        return Path(env_path)
+
+    default = Path("/var/log/suricata/eve.json")
+    dev_candidates = []
+    dev_state = os.environ.get("AZAZEL_DEV_STATE")
+    if dev_state:
+        dev_candidates.append(Path(dev_state) / "suricata" / "eve.json")
+    dev_candidates.append(Path.home() / ".azazel-edge-dev" / "suricata" / "eve.json")
+    for candidate in dev_candidates:
+        if candidate != default and candidate.exists():
+            print(
+                f"WARNING: AZAZEL_EVE_PATH is not set, so events go to {default}, "
+                f"but a dev stack feed exists at {candidate}.",
+                file=sys.stderr,
+            )
+            print(
+                "         The dashboard reads the dev feed, so it will NOT react. Fix: "
+                "run `source tools/macdev/env.sh` in this shell, then re-run the injector.",
+                file=sys.stderr,
+            )
+            break
+    return default
+
+
 def _write_booth_input_provenance(scenario: str) -> None:
     """Mark generated EVE as temporary test input for the read-only UI.
 
@@ -277,8 +314,10 @@ def cmd_list(_args: argparse.Namespace) -> int:
 
 def cmd_emit(args: argparse.Namespace) -> int:
     gen = EveGenerator(src_prefix=args.src_prefix, dst_ip=args.dst_ip, rng=random.Random(args.seed))
-    writer = EveWriter(Path(args.eve_path) if args.eve_path else _default_eve_path(), dry_run=args.dry_run)
+    eve_path = _resolve_eve_path(args)
+    writer = EveWriter(eve_path, dry_run=args.dry_run)
     if not args.dry_run:
+        print(f"writing EVE alerts to {eve_path}")
         _write_booth_input_provenance(args.scenario)
     sent = 0
     for event in gen.iter_scenario(args.scenario, args.count):
@@ -294,9 +333,11 @@ def cmd_emit(args: argparse.Namespace) -> int:
 
 def cmd_flow(args: argparse.Namespace) -> int:
     gen = EveGenerator(src_prefix=args.src_prefix, dst_ip=args.dst_ip, rng=random.Random(args.seed))
-    writer = EveWriter(Path(args.eve_path) if args.eve_path else _default_eve_path(), dry_run=args.dry_run)
+    eve_path = _resolve_eve_path(args)
+    writer = EveWriter(eve_path, dry_run=args.dry_run)
     stages = [s.strip() for s in args.stages.split(",") if s.strip()] or list(DEFAULT_FLOW)
     if not args.dry_run:
+        print(f"writing EVE alerts to {eve_path}")
         _write_booth_input_provenance("flow:" + ",".join(stages))
     for index, scenario_id in enumerate(stages):
         print(f"[stage {index + 1}/{len(stages)}] {scenario_id} (count={args.count})")
@@ -312,9 +353,11 @@ def cmd_flow(args: argparse.Namespace) -> int:
 
 def cmd_stream(args: argparse.Namespace) -> int:
     gen = EveGenerator(src_prefix=args.src_prefix, dst_ip=args.dst_ip, rng=random.Random(args.seed))
-    writer = EveWriter(Path(args.eve_path) if args.eve_path else _default_eve_path(), dry_run=args.dry_run)
+    eve_path = _resolve_eve_path(args)
+    writer = EveWriter(eve_path, dry_run=args.dry_run)
     attack_ids = [s for s in _SCENARIOS if s != "benign"]
     if not args.dry_run:
+        print(f"writing EVE alerts to {eve_path}")
         _write_booth_input_provenance("stream")
     interval = 1.0 / max(0.1, args.rate)
     next_attack = time.monotonic() + args.attack_every


### PR DESCRIPTION
## Summary

Two booth-hardening fixes that surfaced during a live rehearsal of the Arsenal demo.

**1. `demo-fast` front-end poll 1500ms → 3000ms.**
The dashboard fires 11 parallel fetches per refresh. At a 1500ms poll — faster than the ~3s demo-fast snapshot cache — refreshes overlap and the single-process dev web server drops the heaviest endpoint (`/api/dashboard/evidence`, which tails 4 log files), showing up as a **LINK OFFLINE / TELEMETRY STALE** chip even though the decision itself (`summary`/`state`) is fine. Matching the poll to the cache at 3000ms keeps the board snappy without the wasted round-trips. `AZAZEL_DASHBOARD_POLL_MS` still overrides.

**2. Injector eve-path footgun guard.**
When `AZAZEL_EVE_PATH` is unset (i.e. `tools/macdev/env.sh` was not sourced in the shell), the injector silently appended to the default `/var/log/suricata/eve.json` — a file the running dev stack never tails — so the dashboard never reacted, with no error. It now:
- prints `writing EVE alerts to <path>` on every `emit` / `flow` / `stream`, and
- warns, with the exact fix (`source tools/macdev/env.sh`), when a dev-stack feed exists but `AZAZEL_EVE_PATH` is unset.

Appliance behavior is unchanged (on an appliance, `/var/log/suricata/eve.json` is the correct path and no dev feed exists, so no warning fires).

Verified: poll resolves to prod 4000 / demo-fast 3000 / override honored; injector prints the path when env is set and warns when it isn't; the exact footgun that cost ~30 min in rehearsal now self-announces.

## Type of change

- [x] fix — bug fix

## Checklist

- [x] `PYTHONPATH=. pytest -q` passes (57 passed on the touched slice; the 4 EPD-PNG failures are pre-existing/environmental — Pillow not installed here — and fail identically on clean `main`)
- [ ] Related documentation updated in this PR
- [x] Deterministic First principle not violated (AI is assist, not primary decision-maker) — display/tooling only, no decision logic
- [x] Raspberry Pi constraints not broken (memory, aarch64 compatibility) — no new deps
- [x] No changes to `installer/`, `systemd/`, `security/` without explicit justification below — none touched

## Notes for reviewers

Both changes are demo/dev-ergonomics only. The injector guard is gated on a dev-state feed existing, so it never fires on an appliance. The poll change only affects the `AZAZEL_DEMO_FAST=1` profile; the production default stays 4000ms.

## Related issues

Closes #


---
_Generated by [Claude Code](https://claude.ai/code/session_01HR5NqcJwsDrwg5QCkTurYm)_