### PR TITLE
fix(web): don't flap the LINK chip OFFLINE on a single transient poll failure

### DIFF
--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -846,8 +846,15 @@ async function refreshDashboard() {
 
     if (hardFailures.length > 0) {
         console.error('Dashboard refresh failed:', hardFailures);
-        showToast(tr('dashboard.refresh_failed', 'Dashboard refresh failed: {error}', { error: hardFailures.join(' | ') }), 'error');
         azConnSetState(false);
+        // Tolerate a single transient slow poll before alarming. The single-process
+        // dev web server can briefly starve /api/state or /api/dashboard/summary while
+        // the heavy /api/dashboard/evidence request holds a worker; surfacing a toast
+        // (and OFFLINE chip) on a one-cycle blip makes the booth screen flicker. Only
+        // notify once the failure persists across polls.
+        if (azConnConsecutiveFailures >= 2) {
+            showToast(tr('dashboard.refresh_failed', 'Dashboard refresh failed: {error}', { error: hardFailures.join(' | ') }), 'error');
+        }
         return;
     }
 
@@ -3044,10 +3051,16 @@ function azConnSetState(ok) {
     } else {
         azConnConsecutiveFailures += 1;
         const hadPriorSuccess = lastSuccessfulPollMs !== null;
-        // caution on the first failure after a prior success, escalate to danger if it persists;
-        // straight to danger if we've never had a successful snapshot yet.
-        const tone = hadPriorSuccess && azConnConsecutiveFailures === 1 ? 'status-caution' : 'status-danger';
-        chip.classList.add(tone);
+        // Tolerate a single transient failure after a prior success: keep the last-good
+        // LIVE chip for one blip so a one-cycle slow poll (dev web server briefly starving
+        // /api/state while /api/dashboard/evidence holds a worker) doesn't flap the link
+        // indicator OFFLINE on the booth screen. Escalate to OFFLINE only once the failure
+        // persists (>=2 consecutive), or immediately if we've never had a successful snapshot.
+        if (hadPriorSuccess && azConnConsecutiveFailures < 2) {
+            chip.classList.add('status-safe');
+            return;
+        }
+        chip.classList.add('status-danger');
         valueEl.textContent = tr('dashboard.conn_state.offline', 'OFFLINE');
         // Mirror the tooltip into a visible-on-focus sr-only node: `title` only ever surfaces on
         // mouse hover, which keyboard and touch/kiosk operators can never trigger.


### PR DESCRIPTION
## Summary

On the booth dashboard the top-right **LINK** chip flips to `OFFLINE` (and a "Dashboard refresh failed" toast pops) on the **first** failed refresh cycle. On the single-process dev web server a heavy `/api/dashboard/evidence` request can briefly hold a worker and starve the required `/api/state` / `/api/dashboard/summary` poll for one cycle — so a one-poll blip made the screen flicker `OFFLINE ⇄ LIVE` even though the board data itself was correct and current (observed live: THREAT went `CRITICAL` on injection while the chip flapped).

This already has a partial mitigation server-side (poll capped at 3s under `--demo-fast`, see `app.py:313-316`), but the front-end still alarms on a single blip.

Fix (`static/app.js`, display-only):
- `azConnSetState(false)` now keeps the last-good **LIVE** chip through a single transient failure after a prior success, and only shows `OFFLINE` once the failure persists across **two consecutive** polls (or immediately if no snapshot has ever succeeded).
- The "Dashboard refresh failed" toast is likewise suppressed until `azConnConsecutiveFailures >= 2`.

No change to decision logic, the auth path, or the data path — only how transient poll blips are surfaced. A genuine disconnect still shows `OFFLINE` after ~2 polls (~6s at the default cadence).

Operational note: operators who want to further reduce load on a busy booth machine can raise `AZAZEL_DASHBOARD_POLL_MS` (e.g. `5000`), which overrides the `--demo-fast` 3s cadence.

## Type of change

- [x] fix — bug fix

## Checklist

- [ ] `PYTHONPATH=. pytest -q` passes <!-- front-end JS change only; no Python affected. `node --check` passes. -->
- [x] Related documentation updated in this PR <!-- no repo doc references the link-chip behavior -->
- [x] Deterministic First principle not violated (AI is assist, not primary decision-maker)
- [x] Raspberry Pi constraints not broken (memory, aarch64 compatibility)
- [x] No changes to `installer/`, `systemd/`, `security/` without explicit justification below

## Notes for reviewers

The chip previously used a caution→danger tone escalation but printed `OFFLINE` text on the very first failure. The change gates the whole OFFLINE presentation (and the toast) behind a 2-consecutive-failure threshold, reusing the existing `azConnConsecutiveFailures` counter. On the tolerated blip the chip re-adds `status-safe` (the class list is cleared at the top of `azConnSetState`) so it visibly stays LIVE rather than losing its color.

The new app.js is picked up automatically on the next web restart — `STATIC_ASSET_VERSION` is the process start time, so the `?v=` cache-buster changes on restart.

## Related issues

Closes #

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR5NqcJwsDrwg5QCkTurYm)_