### PR TITLE
chore(web): rename dashboard 'Booth Focus Mode' link to 'Decision Focus'

### DIFF
--- a/azazel_edge_web/templates/index.html
+++ b/azazel_edge_web/templates/index.html
@@ -24,7 +24,7 @@
                     <button id="audienceTemporary" class="audience-btn active" data-audience="temporary">{{ tr('dashboard.temporary', 'Temporary') }}</button>
                 </div>
                 <div class="topbar-links">
-                    <a class="topbar-link" href="/booth-focus?lang=en">Booth Focus Mode</a>
+                    <a class="topbar-link" href="/booth-focus?lang=en">Decision Focus</a>
                     <a id="askMioLink" class="topbar-link" href="#assistantPanel">{{ tr('dashboard.ask_mio', 'Ask M.I.O.') }}</a>
                     <button id="showGuideBtn" class="topbar-link topbar-link-button" type="button">{{ tr('dashboard.show_guide', 'Show Guide') }}</button>
                     <a id="openMattermostLink" class="topbar-link" href="/ops-comm">{{ tr('dashboard.open_mattermost', 'Open Mattermost') }}</a>


### PR DESCRIPTION
## Summary

The `/booth-focus` page already titles itself **Decision Focus** (`booth_focus.html` `<title>`, header `AZAZEL-EDGE · DECISION FOCUS`), but the entry link on the main dashboard still read **"Booth Focus Mode"**. Rename the link to **"Decision Focus"** so the on-screen label matches the page it opens and drops the booth/exhibition framing — it's the operator's decision-focus view (bounded action + rejected alternatives + audit), reached from the main situation board.

Label-only change. The route (`/booth-focus`), JS, and CSS are unchanged.

## Type of change

- [x] chore — build/CI/config <!-- user-facing label only -->

## Checklist

- [ ] `PYTHONPATH=. pytest -q` passes <!-- template label change only; no Python affected -->
- [x] Related documentation updated in this PR <!-- demo artifacts/script aligned separately to use "Decision Focus" -->
- [x] Deterministic First principle not violated (AI is assist, not primary decision-maker)
- [x] Raspberry Pi constraints not broken (memory, aarch64 compatibility)
- [x] No changes to `installer/`, `systemd/`, `security/` without explicit justification below

## Notes for reviewers

One-line label change in `templates/index.html`. The route stays `/booth-focus` to avoid breaking bookmarks/links; only the visible text changes.

## Related issues

Closes #

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR5NqcJwsDrwg5QCkTurYm)_