### PR TITLE
fix(demo): align degraded service_health fixtures with the collector vocabulary

### DIFF
--- a/py/azazel_edge/scenario_replay.py
+++ b/py/azazel_edge/scenario_replay.py
@@ -235,7 +235,7 @@ class ScenarioReplayPack:
                     },
                 },
                 'events': [
-                    {'event_id': 'noc-e1', 'source': 'noc_probe', 'kind': 'service_health', 'subject': 'dhcp', 'severity': 75, 'confidence': 0.90, 'attrs': {'service': 'dhcp', 'state': 'degraded'}},
+                    {'event_id': 'noc-e1', 'source': 'noc_probe', 'kind': 'service_health', 'subject': 'dhcp', 'severity': 75, 'confidence': 0.90, 'attrs': {'target': 'dhcp', 'state': 'ON', 'substate': 'degraded', 'result': 'success'}},
                     {'event_id': 'soc-e1', 'source': 'suricata_eve', 'kind': 'alert', 'subject': 'arp-gateway', 'severity': 80, 'confidence': 0.86, 'attrs': {'sid': 9901211, 'attack_type': 'arp spoof', 'category': 'bad-unknown', 'target_port': 0, 'risk_score': 80, 'confidence_raw': 86, 'src_ip': '10.0.0.77', 'dst_ip': '192.168.40.1'}},
                     {'event_id': 'noc-e2', 'source': 'noc_probe', 'kind': 'dhcp_leases', 'subject': 'lease-pool', 'severity': 68, 'confidence': 0.82, 'attrs': {'lease_failures': 15, 'pool_utilization': 95}},
                 ],
@@ -321,7 +321,7 @@ class ScenarioReplayPack:
                     'default_hold_sec': 6,
                 },
                 'events': [
-                    {'event_id': 'sh-h1', 'source': 'noc_probe', 'kind': 'service_health', 'subject': 'internet-uplink', 'severity': 62, 'confidence': 0.85, 'attrs': {'service': 'uplink', 'state': 'degraded'}},
+                    {'event_id': 'sh-h1', 'source': 'noc_probe', 'kind': 'service_health', 'subject': 'internet-uplink', 'severity': 62, 'confidence': 0.85, 'attrs': {'target': 'internet-uplink', 'state': 'ON', 'substate': 'degraded', 'result': 'success'}},
                     {'event_id': 'sh-h2', 'source': 'suricata_eve', 'kind': 'alert', 'subject': '10.0.0.45->192.168.50.50:80/TCP', 'severity': 70, 'confidence': 0.78, 'attrs': {'sid': 220500, 'attack_type': 'suspicious web access', 'category': 'Potentially Bad Traffic', 'target_port': 80, 'risk_score': 70, 'confidence_raw': 78, 'src_ip': '10.0.0.45', 'dst_ip': '192.168.50.50'}},
                 ],
             },


### PR DESCRIPTION
## Summary

Two scenario fixtures in `py/azazel_edge/scenario_replay.py` emitted `service_health` events as `{'service': ..., 'state': 'degraded'}`:

- `evacuation_network_demo` → `noc-e1` (dhcp)
- `shelter_operator_handoff_demo` → `sh-h1` (internet-uplink)

No collector produces that shape. `collect_service_health` (`py/azazel_edge/sensors/noc_monitor.py:237`) emits `{target, unit, state: 'ON'|'OFF', detail, substate, result}` and expresses degradation as `state='ON'` with a non-running `substate` — it never emits `state='degraded'`.

`NocEvaluator._evaluate_availability` matches `str(attrs.get('state')).upper() != 'ON'`, so `'degraded'` fell into the `service_off_penalty` branch and recorded `service_off:<subject>` rather than a degraded-service reason. It also reads `attrs['target']`, which these fixtures never set, so the reason fell back to the subject.

Both fixtures now use the collector's vocabulary. The recorded reason becomes `service_degraded:dhcp` / `service_degraded:internet-uplink` — which is what the booth audit walkthrough reads out.

These scenarios do intend a degraded NOC, so the final status was coincidentally right before; only the explanation was wrong.

## Type of change

- [ ] feat — new feature
- [x] fix — bug fix
- [ ] refactor — no behavior change
- [ ] docs — documentation only
- [ ] test — tests only
- [ ] chore — build/CI/config
- [ ] security — security fix

## Checklist

- [x] `PYTHONPATH=. pytest -q` passes
- [ ] Related documentation updated in this PR
- [x] Deterministic First principle not violated (AI is assist, not primary decision-maker)
- [x] Raspberry Pi constraints not broken (memory, aarch64 compatibility)
- [x] No changes to `installer/`, `systemd/`, `security/` without explicit justification below

Test note: 390 passed / 1 failed, **identical before and after this change**. The failure is `tests/test_fabric_adapters_v1.py::ApiStateStatusViewTests::test_status_view_key_null_when_absent`, caused by `flask` not being installed in the local env — pre-existing and unrelated. 17 web test modules were skipped for the same reason.

## Verification

| Check | Result |
|---|---|
| `bin/azazel-edge-bhusa-freeze-check` output | byte-identical before/after |
| `mixed_correlation_demo` | `action=throttle hash=0ce8c7b59ef2b2ce` — untouched; replay JSON differs only in timestamps/HMAC |
| Selected actions | unchanged (`notify` / `throttle`) |
| Reason | `service_off:*` → `service_degraded:*` |

## Notes for reviewers

Two related issues were found while verifying this. **Neither is fixed here** — both are outside the scope of this change and want a separate decision.

**1. `shelter_baseline_demo` has the same bug and was not previously corrected.** `scenario_replay.py:260` still reads `{'service': 'dns', 'state': 'healthy'}`. Since `'HEALTHY' != 'ON'`, the scenario described as *"normal service health"* currently records `availability: degraded (85) / service_off:dns`. Unlike the two fixed here, this one changes a **status**, not just a reason string — so it was left for an explicit call.

**2. Correcting the reason costs `evacuation_network_demo` its NOC runbook.** The degraded branch is a hardcoded −5, so availability lands at 95 → label `good`, and `_build_incident_summary` drops `good` dimensions entirely (`py/azazel_edge/evaluators/noc.py:708`). For both fixed scenarios:

- `service_degraded:<target>` now appears **only** in `availability.reasons` — it is gone from `incident_summary.supporting_symptoms`
- `noc-e1` / `sh-h1` dropped from the incident evidence chain; confidence 0.74 → 0.6
- suggested runbook downgraded from **Default Route Check** (`path_degradation`, risk 65) to **UI Snapshot Check** (`stable_observe`, risk 20)

The `NOC HEALTH: DEGRADED` headline still holds — overall NOC status is still degraded. The root cause is a third latent bug: `noc-e2` uses `kind: 'dhcp_leases'` (plural) while both the evaluator and the real probe use `'dhcp_lease'` (singular), and `lease_failures` / `pool_utilization` have no scoring path anywhere regardless of the kind name. That event is inert, so the mislabeled `service_off:dhcp` was silently carrying the entire NOC-degradation story for that scenario.

Worth resolving before the booth audit — either give `noc-e2` a kind the evaluator actually scores, or raise the degraded-service penalty so an ON-but-degraded service still registers.

## Related issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)
