### PR TITLE
feat(web): drive dashboard from SSE snapshot stream (real-time, no click needed)

### DIFF
--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -9,6 +9,8 @@ const I18N = window.AZAZEL_I18N || {};
 const CURRENT_PAGE = document.body?.dataset?.page || 'dashboard';
 
 let dashboardTimer = null;
+let stateStream = null;
+let lastStreamRefreshMs = 0;
 let currentAudience = resolveInitialAudience();
 let latestState = {};
 let latestSummary = {};
@@ -406,11 +408,34 @@ document.addEventListener('DOMContentLoaded', () => {
     // (throttled) tick.
     document.addEventListener('visibilitychange', () => { if (!document.hidden) refreshDashboard(); });
     window.addEventListener('focus', refreshDashboard);
+    // Real-time server push (SSE). The setInterval poll above is throttled hard
+    // by the browser in unfocused/background windows, so during a demo the board
+    // can stall for minutes while the operator drives commands from a terminal.
+    // The server already streams control-plane snapshots at /api/state/stream;
+    // subscribing refreshes the board on each pushed change. SSE delivery is
+    // network-driven, not timer-driven, so it is NOT subject to background-timer
+    // throttling — the board updates without any click or focus. Debounced so a
+    // ~1s push cadence doesn't multiply fetch load on the single dev web worker.
+    // The interval + focus listeners above remain as a fallback if SSE drops.
+    if (AUTH_TOKEN) {
+        try {
+            stateStream = new EventSource('/api/state/stream?token=' + encodeURIComponent(AUTH_TOKEN));
+            stateStream.addEventListener('state', () => {
+                const now = Date.now();
+                if (now - lastStreamRefreshMs < 2000) return;
+                lastStreamRefreshMs = now;
+                refreshDashboard();
+            });
+        } catch (e) { /* SSE unavailable: poll + focus fallback remains */ }
+    }
 });
 
 window.addEventListener('beforeunload', () => {
     if (dashboardTimer) {
         clearInterval(dashboardTimer);
+    }
+    if (stateStream) {
+        try { stateStream.close(); } catch (e) { /* ignore */ }
     }
     if (headerClockTimer) {
         clearInterval(headerClockTimer);


### PR DESCRIPTION
## Summary

The dashboard board updates via `setInterval(refreshDashboard, POLL_INTERVAL_MS)`, which Chromium/Brave throttle hard in **unfocused or backgrounded** windows. During a demo the operator drives the injector from a terminal, so the side-by-side dashboard's poll stalled for up to **~2 minutes** — even though `/api/state` reported `THREAT CRITICAL` within ~2s (verified live). The prior focus-refresh listener only helps if the operator *clicks* the dashboard, which isn't always the flow.

This wires the client to the **already-existing** server push endpoint `/api/state/stream` (SSE, `text/event-stream`, streams control-plane snapshots). SSE delivery is **network-driven, not timer-driven**, so it is not subject to the background-timer throttling — the board now updates on each pushed snapshot change **without any click or focus**.

- Debounced to ~2s so the ~1s push cadence doesn't multiply fetch load on the single dev web worker.
- The interval poll + focus listeners remain as a fallback if the stream drops.
- `EventSource` authenticates via the `?token=` query param (it cannot set request headers); the server's `require_token` already accepts `request.args.get("token")`.

## Type of change

- [x] fix — bug fix <!-- demo-blocking latency; feat-flavored but fixes the stall -->

## Checklist

- [ ] `PYTHONPATH=. pytest -q` passes <!-- front-end JS only; server SSE endpoint pre-existed; `node --check` passes -->
- [x] Related documentation updated in this PR
- [x] Deterministic First principle not violated (AI is assist, not primary decision-maker)
- [x] Raspberry Pi constraints not broken (memory, aarch64 compatibility)
- [x] No changes to `installer/`, `systemd/`, `security/` without explicit justification below

## Notes for reviewers

- Server side is unchanged: `/api/state/stream` (`app.py:5282`) already streams `event: state` snapshots via `watch_snapshots`. This PR only subscribes the client.
- The `EventSource` is closed on `beforeunload`. On the single-process dev server each SSE connection holds one worker thread; with `threaded=True` and one or two dashboards this is fine.
- Fallback path unchanged: if `EventSource` fails to construct or the stream drops, the existing `setInterval` + `visibilitychange`/`focus` listeners still drive refreshes.

## Related issues

Closes #

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR5NqcJwsDrwg5QCkTurYm)_