### PR TITLE
revert(web): remove SSE dashboard stream (caused ERR_INSUFFICIENT_RESOURCES)

### DIFF
--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -9,8 +9,6 @@ const I18N = window.AZAZEL_I18N || {};
 const CURRENT_PAGE = document.body?.dataset?.page || 'dashboard';
 
 let dashboardTimer = null;
-let stateStream = null;
-let lastStreamRefreshMs = 0;
 let currentAudience = resolveInitialAudience();
 let latestState = {};
 let latestSummary = {};
@@ -408,34 +406,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // (throttled) tick.
     document.addEventListener('visibilitychange', () => { if (!document.hidden) refreshDashboard(); });
     window.addEventListener('focus', refreshDashboard);
-    // Real-time server push (SSE). The setInterval poll above is throttled hard
-    // by the browser in unfocused/background windows, so during a demo the board
-    // can stall for minutes while the operator drives commands from a terminal.
-    // The server already streams control-plane snapshots at /api/state/stream;
-    // subscribing refreshes the board on each pushed change. SSE delivery is
-    // network-driven, not timer-driven, so it is NOT subject to background-timer
-    // throttling — the board updates without any click or focus. Debounced so a
-    // ~1s push cadence doesn't multiply fetch load on the single dev web worker.
-    // The interval + focus listeners above remain as a fallback if SSE drops.
-    if (AUTH_TOKEN) {
-        try {
-            stateStream = new EventSource('/api/state/stream?token=' + encodeURIComponent(AUTH_TOKEN));
-            stateStream.addEventListener('state', () => {
-                const now = Date.now();
-                if (now - lastStreamRefreshMs < 2000) return;
-                lastStreamRefreshMs = now;
-                refreshDashboard();
-            });
-        } catch (e) { /* SSE unavailable: poll + focus fallback remains */ }
-    }
 });
 
 window.addEventListener('beforeunload', () => {
     if (dashboardTimer) {
         clearInterval(dashboardTimer);
-    }
-    if (stateStream) {
-        try { stateStream.close(); } catch (e) { /* ignore */ }
     }
     if (headerClockTimer) {
         clearInterval(headerClockTimer);


### PR DESCRIPTION
## Summary

Revert the SSE dashboard wiring from #330. On the single-process dev web server it broke the dashboard: the long-lived `/api/state/stream` connection combined with the 11-endpoint poll drove the browser to `net::ERR_INSUFFICIENT_RESOURCES` on every `/api/*` request (312 errors observed live). The board froze on its last snapshot and could neither refresh nor reset — `LINK OFFLINE`, `summary/state: Failed to fetch`.

This restores the client to the polling + `focus`/`visibilitychange` refresh from #329, which works. The background-timer throttling that #330 tried to solve is left for a different approach that doesn't hold a connection on the single-process dev server.

Non-draft so it can merge quickly — this unblocks a demo machine.

## Type of change

- [x] fix — bug fix (revert of a regression)

## Checklist

- [ ] `PYTHONPATH=. pytest -q` passes <!-- front-end JS only; `node --check` passes -->
- [x] Related documentation updated in this PR
- [x] Deterministic First principle not violated
- [x] Raspberry Pi constraints not broken
- [x] No changes to `installer/`, `systemd/`, `security/`

## Notes for reviewers

Straight revert of the `app.js` SSE additions from #330 (EventSource subscription, `stateStream`/`lastStreamRefreshMs`, and the `beforeunload` close). The server-side `/api/state/stream` endpoint is left in place (it predates #330 and is unused by the client again). `node --check` passes; a grep confirms no `EventSource`/`state/stream`/`stateStream` remain in the client.

## Related issues

Closes #

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR5NqcJwsDrwg5QCkTurYm)_