### PR TITLE
fix(web): no-store on /api responses so the browser stops replaying stale dashboard state

### DIFF
--- a/azazel_edge_web/app.py
+++ b/azazel_edge_web/app.py
@@ -339,6 +339,14 @@ def _apply_language_headers(response: Response) -> Response:
     lang = _request_lang()
     response.headers["Content-Language"] = lang
     response.set_cookie("azazel_lang", lang, max_age=31536000, samesite="Lax")
+    # Live dashboard data must never be served from the browser cache. Without an
+    # explicit directive, Chromium/Brave heuristically cache these JSON GETs and
+    # replay a stale (e.g. all-green) /api/state for a minute or more — the board
+    # then freezes and the header clock (seeded from state.now_time) jumps
+    # backwards on the stale response. Mark every /api/ response no-store, but
+    # leave endpoints that already set Cache-Control (the SSE streams) untouched.
+    if request.path.startswith("/api/") and "Cache-Control" not in response.headers:
+        response.headers["Cache-Control"] = "no-store"
     return response
 
 

--- a/azazel_edge_web/static/app.js
+++ b/azazel_edge_web/static/app.js
@@ -1023,7 +1023,10 @@ async function fetchAggregatorStatus() {
 
 async function fetchJson(path, options = {}) {
     const headers = Object.assign({}, options.headers || {}, { 'X-Auth-Token': AUTH_TOKEN, 'X-AZAZEL-LANG': CURRENT_LANG });
-    const response = await fetch(path, { ...options, headers });
+    // Never let the browser serve a cached snapshot of live dashboard state:
+    // Brave/Chromium otherwise replay a stale /api/state for minutes, freezing
+    // the board and rewinding the header clock. Force a fresh network fetch.
+    const response = await fetch(path, { cache: 'no-store', ...options, headers });
     const payload = await response.json();
     if (!response.ok || payload.ok === false) {
         throw new Error(payload.error || `Request failed: ${path}`);


### PR DESCRIPTION
## Summary

Diagnosed live: after an injection the board froze on a stale all-green snapshot for ~2 minutes, and the header clock — which is seeded from `state.now_time` (`app.js`) — **jumped backwards**. A clock that rewinds is the tell: the browser was being handed an *older* `/api/state` than it already had, i.e. a cached response.

Root cause: the `/api/` JSON GETs carried **no cache directive**, and `fetchJson` did not disable caching, so Chromium/Brave heuristically cached and replayed an old `/api/state`. Neither window focus nor the poll interval could get past the cache — only cache expiry did (hence the ~2 min, and why side-by-side / click / the focus-refresh didn't help). A `curl` always saw fresh data because curl doesn't cache.

Fix — force fresh live data on both sides:
- **Server:** an `after_request` adds `Cache-Control: no-store` to every `/api/` response that doesn't already set one. The SSE streams (which set `no-cache`) are left untouched; non-API responses are unaffected. Verified in an isolated Flask app: `/api/*` → `no-store`, SSE → `no-cache` preserved, HTML page → unset.
- **Client:** `fetchJson` issues its fetches with `cache: 'no-store'`.

Non-draft to unblock a demo machine. This is the counterpart to the #331 revert — the earlier SSE approach was the wrong lever; the real problem was cache, not the poll transport.

## Type of change

- [x] fix — bug fix

## Checklist

- [ ] `PYTHONPATH=. pytest -q` passes <!-- `python -m py_compile` and `node --check` pass; header logic verified in an isolated Flask test client -->
- [x] Related documentation updated in this PR
- [x] Deterministic First principle not violated
- [x] Raspberry Pi constraints not broken
- [x] No changes to `installer/`, `systemd/`, `security/`

## Notes for reviewers

- `after_request` guards on `"Cache-Control" not in response.headers`, so the two SSE endpoints that already set `no-cache` keep it.
- `cache: 'no-store'` is placed before `...options` in the `fetch` call so a caller can still override it if ever needed.

## Related issues

Closes #

---
_Generated by [Claude Code](https://claude.ai/code/session_01HR5NqcJwsDrwg5QCkTurYm)_